### PR TITLE
[crypto] batch verification references

### DIFF
--- a/src/tests/bls12381_tests.rs
+++ b/src/tests/bls12381_tests.rs
@@ -193,8 +193,8 @@ fn verify_batch_aggregate_signature() {
         verify_batch_aggregate_signature_inputs();
 
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_ok());
@@ -207,28 +207,28 @@ fn verify_batch_missing_parameters_length_mismatch() {
 
     // Fewer pubkeys than signatures
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
 
     // Fewer messages than signatures
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..]]
     )
     .is_err());
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
@@ -241,16 +241,36 @@ fn verify_batch_missing_keys_in_batch() {
 
     // Pubkeys missing at the end
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[1..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[1..].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
 
     // Pubkeys missing at the start
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..pubkeys2.len() - 1]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[..pubkeys2.len() - 1].iter()],
+        &[&digest1[..], &digest2[..]]
+    )
+    .is_err());
+
+    // add an extra signature to both aggregated_signature that batch_verify takes in
+    let mut signatures1_with_extra = aggregated_signature1;
+    let kp = &keys()[0];
+    let sig = kp.sign(&digest1);
+    let res = signatures1_with_extra.add_signature(sig);
+    assert!(res.is_ok());
+
+    let mut signatures2_with_extra = aggregated_signature2;
+    let kp = &keys()[0];
+    let sig2 = kp.sign(&digest1);
+    let res = signatures2_with_extra.add_signature(sig2);
+    assert!(res.is_ok());
+
+    assert!(BLS12381AggregateSignature::batch_verify(
+        &[&signatures1_with_extra, &signatures2_with_extra],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());

--- a/src/tests/ed25519_tests.rs
+++ b/src/tests/ed25519_tests.rs
@@ -302,8 +302,8 @@ fn verify_batch_aggregate_signature() {
         verify_batch_aggregate_signature_inputs();
 
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_ok());
@@ -316,28 +316,28 @@ fn verify_batch_missing_parameters_length_mismatch() {
 
     // Fewer pubkeys than signatures
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
 
     // Fewer messages than signatures
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..]]
     )
     .is_err());
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
@@ -350,16 +350,16 @@ fn verify_batch_missing_keys_in_batch() {
 
     // Pubkeys missing at the end
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[1..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[1..].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
 
     // Pubkeys missing at the start
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..pubkeys2.len() - 1]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[..pubkeys2.len() - 1].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
@@ -378,11 +378,8 @@ fn verify_batch_missing_keys_in_batch() {
     assert!(res.is_ok());
 
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[
-            signatures1_with_extra.clone(),
-            signatures2_with_extra.clone()
-        ],
-        &[&pubkeys1[..]],
+        &[&signatures1_with_extra, &signatures2_with_extra],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -187,9 +187,9 @@ pub trait AggregateAuthenticator:
         message: &[u8],
     ) -> Result<(), Error>;
 
-    fn batch_verify(
-        sigs: &[Self],
-        pks: &[&[Self::PubKey]],
+    fn batch_verify<'a>(
+        sigs: &[&Self],
+        pks: Vec<impl ExactSizeIterator<Item = &'a Self::PubKey>>,
         messages: &[&[u8]],
     ) -> Result<(), Error>;
 }


### PR DESCRIPTION
Currently, we do a deep-copy for every PublicKey we pass into the batch_verification() function. This isn't great for performance - especially as we are switching to blst where the PublicKeys are not stored in an uncompressed form.