### PR TITLE
Code hygiene fixes

### DIFF
--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -58,9 +58,9 @@ pub struct BLS12381PrivateKey {
     pub bytes: OnceCell<[u8; BLS_PRIVATE_KEY_LENGTH]>,
 }
 
-// There is a strong requirement for this specific impl. in Fab benchmarks
+// There is a strong requirement for this specific impl. in Fab benchmarks.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "type")] // necessary so as not to deser under a != type
+#[serde(tag = "type")] // necessary so as not to deserialize under a != type.
 pub struct BLS12381KeyPair {
     name: BLS12381PublicKey,
     secret: BLS12381PrivateKey,
@@ -139,7 +139,7 @@ impl Display for BLS12381PublicKey {
     }
 }
 
-// There is a strong requirement for this specific impl. in Fab benchmarks
+// There is a strong requirement for this specific impl. in Fab benchmarks.
 impl Serialize for BLS12381PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -149,7 +149,7 @@ impl Serialize for BLS12381PublicKey {
     }
 }
 
-// There is a strong requirement for this specific impl. in Fab benchmarks
+// There is a strong requirement for this specific impl. in Fab benchmarks.
 impl<'de> Deserialize<'de> for BLS12381PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -198,7 +198,11 @@ impl VerifyingKey for BLS12381PublicKey {
     ) -> Result<(), eyre::Report> {
         let num_sigs = sigs.len();
         if sigs.is_empty() {
-            return Err(eyre!("Critical Error! This behavious can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
+            return Err(eyre!(
+                "Critical Error! This behaviour can signal something dangerous, and \
+            that someone may be trying to bypass signature verification through providing empty \
+            batches."
+            ));
         }
         if sigs.len() != pks.len() {
             return Err(eyre!(
@@ -208,7 +212,7 @@ impl VerifyingKey for BLS12381PublicKey {
         let mut rands: Vec<blst_scalar> = Vec::with_capacity(num_sigs);
         let mut rng = OsRng;
 
-        for _i in 0..num_sigs {
+        for _ in 0..num_sigs {
             let mut vals = [0u64; 4];
             vals[0] = rng.next_u64();
             while vals[0] == 0 {
@@ -384,15 +388,15 @@ impl From<BLS12381PrivateKey> for BLS12381KeyPair {
 }
 
 impl EncodeDecodeBase64 for BLS12381KeyPair {
-    fn decode_base64(value: &str) -> Result<Self, eyre::Report> {
-        keypair_decode_base64(value)
-    }
-
     fn encode_base64(&self) -> String {
         let mut bytes: Vec<u8> = Vec::new();
         bytes.extend_from_slice(self.secret.as_ref());
         bytes.extend_from_slice(self.name.as_ref());
         base64ct::Base64::encode_string(&bytes[..])
+    }
+
+    fn decode_base64(value: &str) -> Result<Self, eyre::Report> {
+        keypair_decode_base64(value)
     }
 }
 
@@ -401,20 +405,20 @@ impl KeyPair for BLS12381KeyPair {
     type PrivKey = BLS12381PrivateKey;
     type Sig = BLS12381Signature;
 
-    #[cfg(feature = "copy_key")]
-    fn copy(&self) -> Self {
-        BLS12381KeyPair {
-            name: self.name.clone(),
-            secret: BLS12381PrivateKey::from_bytes(self.secret.as_ref()).unwrap(),
-        }
-    }
-
     fn public(&'_ self) -> &'_ Self::PubKey {
         &self.name
     }
 
     fn private(self) -> Self::PrivKey {
         BLS12381PrivateKey::from_bytes(self.secret.as_ref()).unwrap()
+    }
+
+    #[cfg(feature = "copy_key")]
+    fn copy(&self) -> Self {
+        BLS12381KeyPair {
+            name: self.name.clone(),
+            secret: BLS12381PrivateKey::from_bytes(self.secret.as_ref()).unwrap(),
+        }
     }
 
     fn generate<R: rand::CryptoRng + rand::RngCore>(rng: &mut R) -> Self {
@@ -490,9 +494,9 @@ impl Default for BLS12381AggregateSignature {
 }
 
 impl AggregateAuthenticator for BLS12381AggregateSignature {
-    type PrivKey = BLS12381PrivateKey;
-    type PubKey = BLS12381PublicKey;
     type Sig = BLS12381Signature;
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
 
     /// Parse a key from its byte representation
     fn aggregate(signatures: Vec<Self::Sig>) -> Result<Self, signature::Error> {

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -396,8 +396,8 @@ impl Display for Ed25519AggregateSignature {
 
 impl AggregateAuthenticator for Ed25519AggregateSignature {
     type Sig = Ed25519Signature;
-    type PrivKey = Ed25519PrivateKey;
     type PubKey = Ed25519PublicKey;
+    type PrivKey = Ed25519PrivateKey;
 
     /// Parse a key from its byte representation
     fn aggregate(signatures: Vec<Self::Sig>) -> Result<Self, signature::Error> {
@@ -469,15 +469,15 @@ impl From<Ed25519PrivateKey> for Ed25519KeyPair {
 }
 
 impl EncodeDecodeBase64 for Ed25519KeyPair {
-    fn decode_base64(value: &str) -> Result<Self, eyre::Report> {
-        keypair_decode_base64(value)
-    }
-
     fn encode_base64(&self) -> String {
         let mut bytes: Vec<u8> = Vec::new();
         bytes.extend_from_slice(self.secret.as_ref());
         bytes.extend_from_slice(self.name.as_ref());
         base64ct::Base64::encode_string(&bytes[..])
+    }
+
+    fn decode_base64(value: &str) -> Result<Self, eyre::Report> {
+        keypair_decode_base64(value)
     }
 }
 

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -54,7 +54,7 @@ pub fn hkdf_generate_from_ikm<'a, H: OutputSizeUser, K: KeyPair>(
     info: Option<&'a [u8]>, // Optional domain
 ) -> Result<K, signature::Error>
 where
-    // This is a tad tedious, because of hkdf's use of a sealed trait. But mostly harmless.
+    // This is a tad tedious, because of HKDF's use of a sealed trait. But mostly harmless.
     H: CoreProxy + OutputSizeUser,
     H::Core: HashMarker
         + UpdateCore
@@ -68,8 +68,8 @@ where
     let info = info.unwrap_or(&DEFAULT_DOMAIN);
     let hk = hkdf::Hkdf::<H, Hmac<H>>::new(Some(salt), ikm);
 
-    // we need the HKDF to be able to expand precisely to the byte length of a Private key for the chosen KeyPair parameter.
-    // This check is a tad over constraining (check Hkdf impl for a more relaxed variant) but is always correct.
+    // We need the HKDF to be able to expand precisely to the byte length of a Private key for the chosen KeyPair parameter.
+    // This check is a tad over constraining (check HKDF impl for a more relaxed variant) but is always correct.
     if H::OutputSize::USIZE != K::PrivKey::LENGTH {
         return Err(signature::Error::from_source(hkdf::InvalidLength));
     }

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -338,15 +338,15 @@ pub struct Secp256k1KeyPair {
 }
 
 impl EncodeDecodeBase64 for Secp256k1KeyPair {
-    fn decode_base64(value: &str) -> Result<Self, eyre::Report> {
-        keypair_decode_base64(value)
-    }
-
     fn encode_base64(&self) -> String {
         let mut bytes: Vec<u8> = Vec::new();
         bytes.extend_from_slice(self.secret.as_ref());
         bytes.extend_from_slice(self.name.as_ref());
         base64ct::Base64::encode_string(&bytes[..])
+    }
+
+    fn decode_base64(value: &str) -> Result<Self, eyre::Report> {
+        keypair_decode_base64(value)
     }
 }
 
@@ -363,6 +363,14 @@ impl KeyPair for Secp256k1KeyPair {
         Secp256k1PrivateKey::from_bytes(self.secret.as_ref()).unwrap()
     }
 
+    #[cfg(feature = "copy_key")]
+    fn copy(&self) -> Self {
+        Secp256k1KeyPair {
+            name: self.name.clone(),
+            secret: Secp256k1PrivateKey::from_bytes(self.secret.as_ref()).unwrap(),
+        }
+    }
+
     fn generate<R: rand::CryptoRng + rand::RngCore>(rng: &mut R) -> Self {
         let (privkey, pubkey) = SECP256K1.generate_keypair(rng);
 
@@ -375,14 +383,6 @@ impl KeyPair for Secp256k1KeyPair {
                 privkey,
                 bytes: OnceCell::new(),
             },
-        }
-    }
-
-    #[cfg(feature = "copy_key")]
-    fn copy(&self) -> Self {
-        Secp256k1KeyPair {
-            name: self.name.clone(),
-            secret: Secp256k1PrivateKey::from_bytes(self.secret.as_ref()).unwrap(),
         }
     }
 }

--- a/src/tests/bls12381_tests.rs
+++ b/src/tests/bls12381_tests.rs
@@ -205,7 +205,7 @@ fn verify_batch_missing_parameters_length_mismatch() {
     let (digest1, digest2, pubkeys1, pubkeys2, aggregated_signature1, aggregated_signature2) =
         verify_batch_aggregate_signature_inputs();
 
-    // Fewer pubkeys than signatures
+    // Fewer PubKeys than signatures
     assert!(BLS12381AggregateSignature::batch_verify(
         &[&aggregated_signature1, &aggregated_signature2],
         vec![pubkeys1.iter()],
@@ -239,7 +239,7 @@ fn verify_batch_missing_keys_in_batch() {
     let (digest1, digest2, pubkeys1, pubkeys2, aggregated_signature1, aggregated_signature2) =
         verify_batch_aggregate_signature_inputs();
 
-    // Pubkeys missing at the end
+    // PubKeys missing at the end
     assert!(BLS12381AggregateSignature::batch_verify(
         &[&aggregated_signature1, &aggregated_signature2],
         vec![pubkeys1.iter(), pubkeys2[1..].iter()],
@@ -247,7 +247,7 @@ fn verify_batch_missing_keys_in_batch() {
     )
     .is_err());
 
-    // Pubkeys missing at the start
+    // PubKeys missing at the start
     assert!(BLS12381AggregateSignature::batch_verify(
         &[&aggregated_signature1, &aggregated_signature2],
         vec![pubkeys1.iter(), pubkeys2[..pubkeys2.len() - 1].iter()],
@@ -427,7 +427,7 @@ fn test_sk_zeroization_on_drop() {
     // Check that self.privkey is zeroized
     unsafe {
         for i in 0..BLS12381PrivateKey::LENGTH {
-            assert!(*ptr.add(i) == 0);
+            assert_eq!(*ptr.add(i), 0);
         }
     }
 

--- a/src/tests/secp256k1_tests.rs
+++ b/src/tests/secp256k1_tests.rs
@@ -296,9 +296,9 @@ fn test_sk_zeroization_on_drop() {
     // Check that self.privkey is set to ONE_KEY (workaround to all zero SecretKey considered as invalid)
     unsafe {
         for i in 0..constants::SECRET_KEY_SIZE - 1 {
-            assert!(*ptr.add(i) == 0);
+            assert_eq!(*ptr.add(i), 0);
         }
-        assert!(*ptr.add(constants::SECRET_KEY_SIZE - 1) == 1);
+        assert_eq!(*ptr.add(constants::SECRET_KEY_SIZE - 1), 1);
     }
 
     // Check that self.bytes is zeroized
@@ -318,7 +318,7 @@ proptest::proptest! {
         let message: &[u8] = b"hello world!";
         let hashed_msg = rust_secp256k1::Message::from_slice(<sha3::Keccak256 as sha3::digest::Digest>::digest(message).as_slice()).unwrap();
 
-        // contruct private key with bytes and signs message
+        // construct private key with bytes and signs message
         let priv_key = <Secp256k1PrivateKey as ToFromBytes>::from_bytes(&r).unwrap();
         let key_pair = Secp256k1KeyPair::from(priv_key);
         let key_pair_copied = key_pair.copy();
@@ -337,7 +337,7 @@ proptest::proptest! {
         }
         let malleated_signature: Secp256k1Signature = <Secp256k1Signature as signature::Signature>::from_bytes(&flipped_bytes).unwrap();
 
-        // malleated signature with opposite sign fails to verify
+        // malleable(altered) signature with opposite sign fails to verify
         assert!(key_pair.public().verify(message, &malleated_signature).is_err());
 
         // use k256 to construct private key with the same bytes and signs the same message
@@ -383,7 +383,7 @@ fn wycheproof_test() {
             let bytes = match Signature::from_der(&test.sig) {
                 Ok(s) => s.serialize_compact(),
                 Err(_) => {
-                    assert!(test.result == wycheproof::TestResult::Invalid);
+                    assert_eq!(test.result, wycheproof::TestResult::Invalid);
                     continue;
                 }
             };


### PR DESCRIPTION
- It's a good hygiene (+ for consistency and readability purposes) that inherited functions are implemented in the same order with the trait definitions.
- various other fixes