### PR TITLE
bump fastcrypto-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sha2 = "0.10.6"
 sha3 = "0.10.5"
 thiserror = "1.0.36"
 
-fastcrypto-derive = { path = "./fastcrypto-derive", version = "0.1.0" }
+fastcrypto-derive = { path = "./fastcrypto-derive", version = "0.1.2" }
 
 [[bench]]
 name = "crypto"

--- a/fastcrypto-derive/Cargo.toml
+++ b/fastcrypto-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastcrypto-derive"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]


### PR DESCRIPTION
fastcrypto-derive version publish is currently manual, since we do not expect tons of changes here.