### PR TITLE
[small] Readable impl Debug for public keys

### DIFF
--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -44,7 +44,7 @@ pub const DST: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
 ///
 
 #[readonly::make]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 pub struct BLS12381PublicKey {
     pub pubkey: blst::PublicKey,
     pub bytes: OnceCell<[u8; BLS_PUBLIC_KEY_LENGTH]>,
@@ -135,6 +135,12 @@ impl Ord for BLS12381PublicKey {
 }
 
 impl Display for BLS12381PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", Base64::encode_string(self.as_ref()))
+    }
+}
+
+impl Debug for BLS12381PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", Base64::encode_string(self.as_ref()))
     }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -39,7 +39,7 @@ const RAW_FIELD_NAME: &str = "raw";
 /// Define Structs
 ///
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Ed25519PublicKey(pub ed25519_consensus::VerificationKey);
 
 pub type Ed25519PublicKeyBytes = PublicKeyBytes<Ed25519PublicKey, { Ed25519PublicKey::LENGTH }>;
@@ -140,6 +140,12 @@ impl Default for Ed25519PublicKey {
 impl Display for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", Base64::encode_string(self.0.as_bytes()))
+    }
+}
+
+impl Debug for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Base64::encode_string(self.as_ref()))
     }
 }
 


### PR DESCRIPTION
This diff makes readable Debug implementations for public keys. We often use `#[instrument]` that by default uses Debug implementation. Default debug implementation is extremely verbose and impossible to reason about in logs, this diff just prints base64 encoded string instead.