### PR TITLE
use cargo nightly in publish.yml and bump major version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastcrypto"
-version = "1.0.0"
+version = "2.0.0"
 license = "Apache-2.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"


### PR DESCRIPTION
need to use cargo nightly to get around the rustdoc format error

```
cargo semver-checks check-release                                                                                                                                                                                                                                
    Updating index
     Parsing fastcrypto v1.0.0 (current)
     Parsing fastcrypto 1.0.0 (baseline)
Error: rustdoc format v15 for file /Users/joy/mysten/fastcrypto/target/semver-checks/registry-fastcrypto-1_0_0/target/semver-checks/target/doc/fastcrypto.json is not supported
```

need to bump major version due to: 
```
cargo +nightly semver-checks check-release

    Updating index
     Parsing fastcrypto v1.1.0 (current)
     Parsing fastcrypto 1.0.0 (baseline)
    Checking fastcrypto v1.0.0 -> v1.1.0 (minor change)
   Completed [   0.115s] 18 checks; 16 passed, 2 failed, 0 skipped

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.12.0/src/queries/function_missing.ron

Failed in:
  function fastcrypto::blake2b_256, previously in file /Users/joy/.cargo/registry/src/github.com-1ecc6299db9ec823/fastcrypto-1.0.0/src/lib.rs:72

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.12.0/src/queries/struct_missing.ron

Failed in:
  struct fastcrypto::Digest, previously in file /Users/joy/.cargo/registry/src/github.com-1ecc6299db9ec823/fastcrypto-1.0.0/src/lib.rs:82
       Final [   0.123s] semver requires new major version: 2 major and 0 minor checks failed
```