### PR TITLE
fix: improve the workflow of publish to not launch cargo-semver-checks pointlessly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ env:
 jobs:
   publish:
     name: Publish to crates.io
-    continue-on-error: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,11 +42,6 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v1
-        with:
-          crate-name: ${{ matrix.package }}
-          version-tag-prefix: ${{ matrix.package }}-v
       - id: check
         run: |
           set +e
@@ -62,6 +56,13 @@ jobs:
             # Unexpected outcome, indicates a bug.
             exit "$EXIT_CODE"
           fi
+      - name: Check semver
+        # Only run the semver script if the version changed, otherwise it errors out
+        if: steps.check.outputs.is_new_version == 'yes'
+        uses: obi1kenobi/cargo-semver-checks-action@v1
+        with:
+          crate-name: ${{ matrix.package }}
+          version-tag-prefix: ${{ matrix.package }}-v
       - name: Tag the version
         if: steps.check.outputs.is_new_version == 'yes'
         run: |


### PR DESCRIPTION
Ports https://github.com/MystenLabs/mysten-infra/pull/167/commits/bb60482c63c1c69c79f219529b04c8d9e40ff85a to fastcrypto