### PR TITLE
Add aggregate BLS verfication to benchmarks

### DIFF
--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -111,11 +111,7 @@ mod ed25519_benches {
             );
             c.bench_with_input(
                 BenchmarkId::new("BLS12381 aggregate verification", *size),
-                &(
-                    msg,
-                    blst_public_keys,
-                    blst_aggregate_signature,
-                ),
+                &(msg, blst_public_keys, blst_aggregate_signature),
                 |b, (msg, pk, sig)| {
                     b.iter(|| sig.verify(pk, msg));
                 },

--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -96,7 +96,7 @@ mod ed25519_benches {
                 BenchmarkId::new("BLS12381 aggregate verification", *size),
                 &(msg.clone(), blst_public_keys.clone(), aggregate_signature),
                 |b, i| {
-                    b.iter(|| i.2.verify(&i.1, &i.0[..]));
+                    b.iter(|| i.2.verify(&i.1, &i.0));
                 },
             );
 

--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -112,12 +112,12 @@ mod ed25519_benches {
             c.bench_with_input(
                 BenchmarkId::new("BLS12381 aggregate verification", *size),
                 &(
-                    msg.clone(),
-                    blst_public_keys.clone(),
+                    msg,
+                    blst_public_keys,
                     blst_aggregate_signature,
                 ),
                 |b, (msg, pk, sig)| {
-                    b.iter(|| sig.verify(&pk, &msg));
+                    b.iter(|| sig.verify(pk, msg));
                 },
             );
         }

--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -87,8 +87,9 @@ mod ed25519_benches {
             let blst_public_keys: Vec<_> = blst_keypairs
                 .iter()
                 .map(|key| key.public().clone())
-                .collect();            
-            let blst_aggregate_signature = BLS12381AggregateSignature::aggregate(blst_signatures.clone()).unwrap();
+                .collect();
+            let blst_aggregate_signature =
+                BLS12381AggregateSignature::aggregate(blst_signatures.clone()).unwrap();
 
             c.bench_with_input(
                 BenchmarkId::new("Ed25519 batch verification", *size),
@@ -99,14 +100,22 @@ mod ed25519_benches {
             );
             c.bench_with_input(
                 BenchmarkId::new("BLS12381 batch verification", *size),
-                &(msg.clone(), blst_public_keys.clone(), blst_signatures.clone()),
+                &(
+                    msg.clone(),
+                    blst_public_keys.clone(),
+                    blst_signatures.clone(),
+                ),
                 |b, i| {
                     b.iter(|| VerifyingKey::verify_batch_empty_fail(&i.0, &i.1[..], &i.2[..]));
                 },
             );
             c.bench_with_input(
                 BenchmarkId::new("BLS12381 aggregate verification", *size),
-                &(msg.clone(), blst_public_keys.clone(), blst_aggregate_signature),
+                &(
+                    msg.clone(),
+                    blst_public_keys.clone(),
+                    blst_aggregate_signature,
+                ),
                 |b, (msg, pk, sig)| {
                     b.iter(|| sig.verify(&pk, &msg));
                 },


### PR DESCRIPTION
Closing #82 

Attached are the output of a benchmark and a plot of aggregate verification of BLS signatures vs batched verification of Ed25519 signatures.
 [benchmark.txt](https://github.com/MystenLabs/fastcrypto/files/9703761/benchmark.txt)
![ED25519 batch vs BLS aggregate](https://user-images.githubusercontent.com/6288307/193764440-651b517b-b821-4a10-b11b-51e67aec6df7.png)
