### PR TITLE
Benchmark for batched signature verification with different messages

### DIFF
--- a/fastcrypto/benches/crypto.rs
+++ b/fastcrypto/benches/crypto.rs
@@ -11,7 +11,7 @@ mod signature_benches {
     use fastcrypto::{
         bls12381::{BLS12381AggregateSignature, BLS12381KeyPair, BLS12381Signature},
         ed25519::*,
-        hash::Blake2b,
+        hash::{Blake2b, HashFunction},
         secp256k1::{Secp256k1KeyPair, Secp256k1Signature},
         traits::{AggregateAuthenticator, KeyPair, VerifyingKey},
         Verifier,
@@ -119,6 +119,63 @@ mod signature_benches {
         }
     }
 
+    fn verify_batch_signatures_different_msg<M: measurement::Measurement>(
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        static BATCH_SIZES: [usize; 10] = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192];
+
+        let mut csprng: ThreadRng = thread_rng();
+
+        for size in BATCH_SIZES.iter() {
+            let ed_keypairs: Vec<_> = (0..*size)
+                .map(|_| Ed25519KeyPair::generate(&mut csprng))
+                .collect();
+            let blst_keypairs: Vec<_> = (0..*size)
+                .map(|_| BLS12381KeyPair::generate(&mut csprng))
+                .collect();
+
+            let msgs: Vec<Vec<u8>> = (0..*size)
+                .map(|i| fastcrypto::hash::Sha256::digest(i.to_string().as_bytes()).to_vec())
+                .collect();
+
+            let ed_signatures: Vec<_> = ed_keypairs
+                .iter()
+                .zip(&msgs)
+                .map(|(key, msg)| key.sign(&msg))
+                .collect();
+            let ed_public_keys: Vec<_> =
+                ed_keypairs.iter().map(|key| key.public().clone()).collect();
+            let blst_signatures: Vec<_> = blst_keypairs
+                .iter()
+                .zip(&msgs)
+                .map(|(key, msg)| key.sign(&msg))
+                .collect();
+            let blst_public_keys: Vec<_> = blst_keypairs
+                .iter()
+                .map(|key| key.public().clone())
+                .collect();
+
+            c.bench_with_input(
+                BenchmarkId::new("Ed25519 batch verification different msg", *size),
+                &(&msgs, ed_public_keys, ed_signatures),
+                |b, (msgs, pks, sigs)| {
+                    b.iter(|| {
+                        VerifyingKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs)
+                    });
+                },
+            );
+            c.bench_with_input(
+                BenchmarkId::new("BLS12381 batch verification different msg", *size),
+                &(&msgs, &blst_public_keys, &blst_signatures),
+                |b, (msgs, pks, sigs)| {
+                    b.iter(|| {
+                        VerifyingKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs)
+                    });
+                },
+            );
+        }
+    }
+
     fn key_generation(c: &mut Criterion) {
         let mut csprng: ThreadRng = thread_rng();
         let mut csprng2 = csprng.clone();
@@ -151,6 +208,8 @@ mod signature_benches {
         group.sampling_mode(SamplingMode::Flat);
 
         verify_batch_signatures(&mut group);
+
+        verify_batch_signatures_different_msg(&mut group);
         group.finish();
     }
 }

--- a/fastcrypto/src/bls12381.rs
+++ b/fastcrypto/src/bls12381.rs
@@ -255,6 +255,60 @@ impl VerifyingKey for BLS12381PublicKey {
             Err(eyre!("Verification failed!"))
         }
     }
+
+    fn verify_batch_empty_fail_different_msg<'a, M>(
+        msgs: &[M],
+        pks: &[Self],
+        sigs: &[Self::Sig],
+    ) -> Result<(), eyre::Report>
+    where
+        M: Borrow<[u8]> + 'a,
+    {
+        if sigs.is_empty() {
+            return Err(eyre!(
+                "Critical Error! This behaviour can signal something dangerous, and \
+            that someone may be trying to bypass signature verification through providing empty \
+            batches."
+            ));
+        }
+        if sigs.len() != pks.len() || msgs.len() != pks.len() {
+            return Err(eyre!(
+                "Mismatch between number of messages, signatures and public keys provided"
+            ));
+        }
+        let mut rands: Vec<blst_scalar> = Vec::with_capacity(sigs.len());
+        let mut rng = OsRng;
+
+        for _ in 0..sigs.len() {
+            let mut vals = [0u64; 4];
+            vals[0] = rng.next_u64();
+            while vals[0] == 0 {
+                // Reject zero as it is used for multiplication.
+                vals[0] = rng.next_u64();
+            }
+            let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
+            unsafe {
+                blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
+                rands.push(rand_i.assume_init());
+            }
+        }
+
+        let result = blst::Signature::verify_multiple_aggregate_signatures(
+            &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+            DST,
+            &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
+            false,
+            &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
+            true,
+            &rands,
+            64,
+        );
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(eyre!("Verification failed!"))
+        }
+    }
 }
 
 ///

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -168,7 +168,7 @@ fn verify_batch_missing_public_keys() {
 #[test]
 fn verify_valid_batch_different_msg() {
     let (msgs, pks, sigs) = signature_test_inputs_different_msg();
-    let res = BLS12381PublicKey::verify_batch_empty_fail_different_msg(msgs, &pks, &sigs);
+    let res = BLS12381PublicKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs);
     assert!(res.is_ok(), "{:?}", res);
 }
 

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -172,6 +172,14 @@ fn verify_valid_batch_different_msg() {
     assert!(res.is_ok(), "{:?}", res);
 }
 
+#[test]
+fn verify_invalid_batch_different_msg() {
+    let (msgs, pks, mut sigs) = signature_test_inputs_different_msg();
+    sigs[0] = BLS12381Signature::default();
+    let res = BLS12381PublicKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs);
+    assert!(res.is_err(), "{:?}", res);
+}
+
 fn verify_batch_aggregate_signature_inputs() -> (
     Vec<u8>,
     Vec<u8>,

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -121,6 +121,7 @@ fn signature_test_inputs_different_msg(
 
     (digests, pubkeys, signatures)
 }
+
 #[test]
 fn verify_valid_batch() {
     let (digest, pubkeys, signatures) = signature_test_inputs();

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -249,7 +249,7 @@ fn verify_batch_missing_public_keys() {
 #[test]
 fn verify_valid_batch_different_msg() {
     let (msgs, pks, sigs) = signature_test_inputs_different_msg();
-    let res = Ed25519PublicKey::verify_batch_empty_fail_different_msg(msgs, &pks, &sigs);
+    let res = Ed25519PublicKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs);
     assert!(res.is_ok(), "{:?}", res);
 }
 

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -254,6 +254,14 @@ fn verify_valid_batch_different_msg() {
 }
 
 #[test]
+fn verify_invalid_batch_different_msg() {
+    let (msgs, pks, mut sigs) = signature_test_inputs_different_msg();
+    sigs[0] = Ed25519Signature::default();
+    let res = Ed25519PublicKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs);
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
 fn verify_valid_aggregate_signaature() {
     let (digest, pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = Ed25519AggregateSignature::aggregate(&signatures).unwrap();

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -246,7 +246,7 @@ fn verify_batch_missing_public_keys() {
 #[test]
 fn verify_valid_batch_different_msg() {
     let (msgs, pks, sigs) = signature_test_inputs_different_msg();
-    let res = Secp256k1PublicKey::verify_batch_empty_fail_different_msg(msgs, &pks, &sigs);
+    let res = Secp256k1PublicKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs);
     assert!(res.is_ok(), "{:?}", res);
 }
 

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -251,6 +251,14 @@ fn verify_valid_batch_different_msg() {
 }
 
 #[test]
+fn verify_invalid_batch_different_msg() {
+    let (msgs, pks, mut sigs) = signature_test_inputs_different_msg();
+    sigs[0] = Secp256k1Signature::default();
+    let res = Secp256k1PublicKey::verify_batch_empty_fail_different_msg(&msgs, &pks, &sigs);
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
 fn verify_hashed_failed_if_message_unhashed() {
     // Get a keypair.
     let kp = keys().pop().unwrap();

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -78,20 +78,20 @@ impl<T: ToFromBytes> EncodeDecodeBase64 for T {
 /// to the ones on its associated types for private and signature material.
 ///
 pub trait VerifyingKey:
-Serialize
-+ DeserializeOwned
-+ std::hash::Hash
-+ Display
-+ Eq  // required to make some cached bytes representations explicit
-+ Ord // required to put keys in BTreeMap
-+ Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
-+ ToFromBytes
-+ signature::Verifier<Self::Sig>
-+ for <'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
-+ Send
-+ Sync
-+ 'static
-+ Clone
+    Serialize
+    + DeserializeOwned
+    + std::hash::Hash
+    + Display
+    + Eq  // required to make some cached bytes representations explicit
+    + Ord // required to put keys in BTreeMap
+    + Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
+    + ToFromBytes
+    + signature::Verifier<Self::Sig>
+    + for <'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
+    + Send
+    + Sync
+    + 'static
+    + Clone
 {
     type PrivKey: SigningKey<PubKey = Self>;
     type Sig: Authenticator<PubKey = Self>;

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -87,14 +87,14 @@ Serialize
 + Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
 + ToFromBytes
 + signature::Verifier<Self::Sig>
-+ for<'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
++ for <'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
 + Send
 + Sync
 + 'static
 + Clone
 {
-    type PrivKey: SigningKey<PubKey=Self>;
-    type Sig: Authenticator<PubKey=Self>;
+    type PrivKey: SigningKey<PubKey = Self>;
+    type Sig: Authenticator<PubKey = Self>;
     const LENGTH: usize;
 
     // Expected to be overridden by implementations

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -78,23 +78,23 @@ impl<T: ToFromBytes> EncodeDecodeBase64 for T {
 /// to the ones on its associated types for private and signature material.
 ///
 pub trait VerifyingKey:
-    Serialize
-    + DeserializeOwned
-    + std::hash::Hash
-    + Display
-    + Eq  // required to make some cached bytes representations explicit
-    + Ord // required to put keys in BTreeMap
-    + Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
-    + ToFromBytes
-    + signature::Verifier<Self::Sig>
-    + for <'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
-    + Send
-    + Sync
-    + 'static
-    + Clone
+Serialize
++ DeserializeOwned
++ std::hash::Hash
++ Display
++ Eq  // required to make some cached bytes representations explicit
++ Ord // required to put keys in BTreeMap
++ Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
++ ToFromBytes
++ signature::Verifier<Self::Sig>
++ for<'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
++ Send
++ Sync
++ 'static
++ Clone
 {
-    type PrivKey: SigningKey<PubKey = Self>;
-    type Sig: Authenticator<PubKey = Self>;
+    type PrivKey: SigningKey<PubKey=Self>;
+    type Sig: Authenticator<PubKey=Self>;
     const LENGTH: usize;
 
     // Expected to be overridden by implementations
@@ -108,6 +108,24 @@ pub trait VerifyingKey:
         pks.iter()
             .zip(sigs)
             .try_for_each(|(pk, sig)| pk.verify(msg, sig))
+            .map_err(|_| eyre!("Signature verification failed"))
+    }
+
+    // Expected to be overridden by implementations
+    fn verify_batch_empty_fail_different_msg<'a, M, I>(msgs: I, pks: &[Self], sigs: &[Self::Sig]) -> Result<(), eyre::Report> where
+        M: Borrow<[u8]> + 'a,
+        I: IntoIterator<Item=M>,
+    {
+        if sigs.is_empty() {
+            return Err(eyre!("Critical Error! This behaviour can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
+        }
+        if pks.len() != sigs.len() {
+            return Err(eyre!("Mismatch between number of signatures and public keys provided"));
+        }
+        pks.iter()
+            .zip(sigs)
+            .zip(msgs.into_iter())
+            .try_for_each(|((pk, sig), msg)| pk.verify(msg.borrow(), sig))
             .map_err(|_| eyre!("Signature verification failed"))
     }
 }


### PR DESCRIPTION
Closing #100 
Should be merged after PR #104 and #107 
```
verification_comparison/Ed25519 batch verification/16
                        time:   [330.65 µs 331.70 µs 332.80 µs]
                        change: [-1.7526% -1.1520% -0.5987%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
verification_comparison/BLS12381 batch verification/16
                        time:   [1.5727 ms 1.5814 ms 1.5908 ms]
                        change: [-2.8898% -2.1228% -1.3811%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
verification_comparison/BLS12381 aggregate verification/16
                        time:   [612.54 µs 614.50 µs 616.62 µs]
                        change: [+0.1154% +0.6382% +1.1807%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe
verification_comparison/Ed25519 batch verification/32
                        time:   [636.39 µs 640.60 µs 645.39 µs]
                        change: [+1.1025% +1.8247% +2.6286%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
verification_comparison/BLS12381 batch verification/32
                        time:   [2.3115 ms 2.3283 ms 2.3461 ms]
                        change: [-2.9790% -1.7458% -0.5106%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
verification_comparison/BLS12381 aggregate verification/32
                        time:   [628.84 µs 630.57 µs 632.41 µs]
                        change: [+0.4206% +0.9067% +1.3650%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
verification_comparison/Ed25519 batch verification/64
                        time:   [1.1932 ms 1.1949 ms 1.1968 ms]
                        change: [-2.4024% -2.0398% -1.6680%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
verification_comparison/BLS12381 batch verification/64
                        time:   [4.4454 ms 4.4650 ms 4.4857 ms]
                        change: [-0.8316% -0.1862% +0.4458%] (p = 0.56 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
verification_comparison/BLS12381 aggregate verification/64
                        time:   [671.77 µs 673.12 µs 674.54 µs]
                        change: [+0.5982% +1.0161% +1.4302%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
verification_comparison/Ed25519 batch verification/128
                        time:   [2.3477 ms 2.3522 ms 2.3567 ms]
                        change: [-0.3442% +0.0084% +0.3548%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
verification_comparison/BLS12381 batch verification/128
                        time:   [7.5813 ms 7.6769 ms 7.7949 ms]
                        change: [-6.0316% -2.4742% +0.3169%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
verification_comparison/BLS12381 aggregate verification/128
                        time:   [732.02 µs 733.81 µs 735.75 µs]
                        change: [-0.6994% -0.3803% -0.0434%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
verification_comparison/Ed25519 batch verification/256
                        time:   [4.3097 ms 4.3234 ms 4.3379 ms]
                        change: [-1.2222% -0.4862% +0.1439%] (p = 0.18 > 0.05)
                        No change in performance detected.
verification_comparison/BLS12381 batch verification/256
                        time:   [13.292 ms 13.382 ms 13.490 ms]
                        change: [-6.6038% -4.8893% -3.3735%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
verification_comparison/BLS12381 aggregate verification/256
                        time:   [863.53 µs 864.03 µs 864.56 µs]
                        change: [-0.5791% -0.3517% -0.1479%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
verification_comparison/Ed25519 batch verification/512
                        time:   [8.0154 ms 8.0571 ms 8.1160 ms]
                        change: [+1.1287% +1.6530% +2.3838%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
verification_comparison/BLS12381 batch verification/512
                        time:   [25.647 ms 25.731 ms 25.820 ms]
                        change: [+0.7541% +1.1567% +1.6005%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
verification_comparison/BLS12381 aggregate verification/512
                        time:   [1.1693 ms 1.1719 ms 1.1747 ms]
                        change: [+1.1028% +1.4034% +1.7197%] (p = 0.00 < 0.05)
                        Performance has regressed.
verification_comparison/Ed25519 batch verification/1024
                        time:   [15.033 ms 15.108 ms 15.213 ms]
                        change: [+0.9194% +1.4536% +2.1757%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking verification_comparison/BLS12381 batch verification/1024: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.0s, or reduce sample count to 90.
verification_comparison/BLS12381 batch verification/1024
                        time:   [51.824 ms 52.840 ms 54.090 ms]
                        change: [-0.5670% +2.0831% +4.9766%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
verification_comparison/BLS12381 aggregate verification/1024
                        time:   [1.7470 ms 1.7521 ms 1.7573 ms]
                        change: [+1.0380% +1.4310% +1.8308%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
verification_comparison/Ed25519 batch verification/2048
                        time:   [29.333 ms 29.455 ms 29.618 ms]
                        change: [+0.7682% +1.3092% +1.9833%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 32 outliers among 100 measurements (32.00%)
  17 (17.00%) low mild
  4 (4.00%) high mild
  11 (11.00%) high severe
Benchmarking verification_comparison/BLS12381 batch verification/2048: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.3s, or reduce sample count to 40.
verification_comparison/BLS12381 batch verification/2048
                        time:   [102.68 ms 103.33 ms 104.03 ms]
                        change: [+0.8323% +1.8368% +2.8049%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  9 (9.00%) high mild
  9 (9.00%) high severe
verification_comparison/BLS12381 aggregate verification/2048
                        time:   [2.8741 ms 2.8783 ms 2.8827 ms]
                        change: [+0.1941% +0.4970% +0.8066%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking verification_comparison/Ed25519 batch verification/4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
verification_comparison/Ed25519 batch verification/4096
                        time:   [57.700 ms 57.851 ms 58.003 ms]
                        change: [-0.3027% +0.1629% +0.6345%] (p = 0.49 > 0.05)
                        No change in performance detected.
Benchmarking verification_comparison/BLS12381 batch verification/4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 20.4s, or reduce sample count to 20.
verification_comparison/BLS12381 batch verification/4096
                        time:   [199.57 ms 201.11 ms 203.03 ms]
                        change: [-0.0309% +0.8923% +1.9921%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
verification_comparison/BLS12381 aggregate verification/4096
                        time:   [5.1681 ms 5.1748 ms 5.1821 ms]
                        change: [+1.2517% +1.4939% +1.7409%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe
Benchmarking verification_comparison/Ed25519 batch verification/8192: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 11.5s, or reduce sample count to 40.
verification_comparison/Ed25519 batch verification/8192
                        time:   [113.05 ms 113.65 ms 114.52 ms]
                        change: [-1.0224% -0.3185% +0.3701%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking verification_comparison/BLS12381 batch verification/8192: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 40.2s, or reduce sample count to 10.
verification_comparison/BLS12381 batch verification/8192
                        time:   [400.98 ms 404.71 ms 409.47 ms]
                        change: [+0.5656% +1.5621% +2.8168%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
verification_comparison/BLS12381 aggregate verification/8192
                        time:   [9.7858 ms 9.7983 ms 9.8115 ms]
                        change: [+2.0141% +2.2098% +2.3974%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
verification_comparison/Ed25519 batch verification different msg/16
                        time:   [526.16 µs 526.93 µs 527.76 µs]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe
verification_comparison/BLS12381 batch verification different msg/16
                        time:   [1.5457 ms 1.5489 ms 1.5529 ms]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
verification_comparison/Ed25519 batch verification different msg/32
                        time:   [1.0400 ms 1.0418 ms 1.0436 ms]
verification_comparison/BLS12381 batch verification different msg/32
                        time:   [2.2409 ms 2.2491 ms 2.2580 ms]
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
verification_comparison/Ed25519 batch verification different msg/64
                        time:   [2.0747 ms 2.0776 ms 2.0805 ms]
verification_comparison/BLS12381 batch verification different msg/64
                        time:   [4.3808 ms 4.3927 ms 4.4093 ms]
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe
verification_comparison/Ed25519 batch verification different msg/128
                        time:   [4.1564 ms 4.1646 ms 4.1734 ms]
Found 13 outliers among 100 measurements (13.00%)
  12 (12.00%) high mild
  1 (1.00%) high severe
verification_comparison/BLS12381 batch verification different msg/128
                        time:   [6.8451 ms 6.8604 ms 6.8766 ms]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
verification_comparison/Ed25519 batch verification different msg/256
                        time:   [8.3365 ms 8.3442 ms 8.3529 ms]
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
verification_comparison/BLS12381 batch verification different msg/256
                        time:   [13.127 ms 13.156 ms 13.189 ms]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
verification_comparison/Ed25519 batch verification different msg/512
                        time:   [16.769 ms 16.793 ms 16.823 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
verification_comparison/BLS12381 batch verification different msg/512
                        time:   [25.681 ms 25.807 ms 25.946 ms]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
verification_comparison/Ed25519 batch verification different msg/1024
                        time:   [33.571 ms 33.619 ms 33.669 ms]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking verification_comparison/BLS12381 batch verification different msg/1024: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.0s, or reduce sample count to 90.
Benchmarking verification_comparison/BLS12381 batch verification different msg/1024: Collecting 100 samples in estimated 5.0367 s (100 iterationsverification_comparison/BLS12381 batch verification different msg/1024
                        time:   [49.660 ms 49.732 ms 49.819 ms]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
Benchmarking verification_comparison/Ed25519 batch verification different msg/2048: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.8s, or reduce sample count to 70.
verification_comparison/Ed25519 batch verification different msg/2048
                        time:   [67.232 ms 67.368 ms 67.515 ms]
Found 11 outliers among 100 measurements (11.00%)
  11 (11.00%) high mild
Benchmarking verification_comparison/BLS12381 batch verification different msg/2048: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.9s, or reduce sample count to 50.
Benchmarking verification_comparison/BLS12381 batch verification different msg/2048: Collecting 100 samples in estimated 9.8579 s (100 iterationsverification_comparison/BLS12381 batch verification different msg/2048
                        time:   [100.51 ms 101.11 ms 101.74 ms]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking verification_comparison/Ed25519 batch verification different msg/4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 13.8s, or reduce sample count to 30.
verification_comparison/Ed25519 batch verification different msg/4096
                        time:   [135.48 ms 135.75 ms 136.03 ms]
Benchmarking verification_comparison/BLS12381 batch verification different msg/4096: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 20.9s, or reduce sample count to 20.
Benchmarking verification_comparison/BLS12381 batch verification different msg/4096: Collecting 100 samples in estimated 20.870 s (100 iterationsverification_comparison/BLS12381 batch verification different msg/4096
                        time:   [197.92 ms 198.54 ms 199.22 ms]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
Benchmarking verification_comparison/Ed25519 batch verification different msg/8192: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 27.3s, or reduce sample count to 10.
verification_comparison/Ed25519 batch verification different msg/8192
                        time:   [269.76 ms 270.18 ms 270.61 ms]
Benchmarking verification_comparison/BLS12381 batch verification different msg/8192: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 40.0s, or reduce sample count to 10.
verification_comparison/BLS12381 batch verification different msg/8192
                        time:   [390.95 ms 392.00 ms 393.19 ms]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
```