### PR TITLE
feat: Add a blst-based Groth16 verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-crypto-primitives"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,7 +934,9 @@ dependencies = [
 name = "fastcrypto-proving"
 version = "0.1.0"
 dependencies = [
+ "ark-bls12-377",
  "ark-bls12-381",
+ "ark-bn254",
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff",

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -14,16 +14,16 @@ harness = false
 
 [dependencies]
 ark-bls12-381 = "0.3.0"
+ark-ec = "0.3.0"
 ark-ff = "0.3.0"
+ark-groth16 = "0.3.0"
+ark-relations = "0.3.0"
 ark-serialize = "0.3.0"
 blst = "0.3.10"
 byte-slice-cast = "1.2.1"
 
 [dev-dependencies]
 ark-crypto-primitives = "0.3.0"
-ark-ec = "0.3.0"
-ark-groth16 = "0.3.0"
-ark-relations = "0.3.0"
 ark-std = "0.3.0"
 criterion = "0.4.0"
 proptest = "1.0.0"

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -15,7 +15,7 @@ harness = false
 [dependencies]
 ark-bls12-381 = "0.3.0"
 ark-ec = "0.3.0"
-ark-ff = "0.3.0"
+ark-ff = { version = "0.3.0", features = ["asm"]}
 ark-groth16 = "0.3.0"
 ark-relations = "0.3.0"
 ark-serialize = "0.3.0"

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -23,6 +23,8 @@ blst = "0.3.10"
 byte-slice-cast = "1.2.1"
 
 [dev-dependencies]
+ark-bls12-377 = "0.3.0"
+ark-bn254 = "0.3.0"
 ark-crypto-primitives = "0.3.0"
 ark-std = "0.3.0"
 criterion = "0.4.0"

--- a/fastcrypto-zkp/benches/conversions.rs
+++ b/fastcrypto-zkp/benches/conversions.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use ark_bls12_381::{Fq, Fq2, Fr as BlsFr};
+use ark_bls12_381::{Fq12, G2Affine as BlsG2Affine};
+use ark_bls12_381::{Fq6, G1Affine as BlsG1Affine};
+use ark_ec::{AffineCurve, ProjectiveCurve};
+use ark_ff::{PrimeField, UniformRand};
+use criterion::{criterion_group, Criterion};
+use criterion::{measurement::Measurement, BenchmarkGroup};
+use fastcrypto_proving::conversions::{
+    bls_fq12_to_blst_fp12, bls_fq2_to_blst_fp2, bls_fq6_to_blst_fp6, bls_fq_to_blst_fp,
+    bls_fr_to_blst_fr, bls_g1_affine_to_blst_g1_affine, bls_g2_affine_to_blst_g2_affine,
+    blst_fp12_to_bls_fq12, blst_fp2_to_bls_fq2, blst_fp6_to_bls_fq6, blst_fp_to_bls_fq,
+    blst_fr_to_bls_fr, blst_g1_affine_to_bls_g1_affine, blst_g2_affine_to_bls_g2_affine,
+};
+
+fn convert_from_arkworks<M: Measurement>(grp: &mut BenchmarkGroup<M>) {
+    let mut rng = ark_std::test_rng();
+    let element = BlsFr::rand(&mut rng);
+    grp.bench_with_input("BlsFr -> blst_fr", &element, |b, element| {
+        b.iter(|| bls_fr_to_blst_fr(element));
+    });
+
+    let element = Fq::rand(&mut rng);
+    grp.bench_with_input("Fq -> blst_fp", &element, |b, element| {
+        b.iter(|| bls_fq_to_blst_fp(element));
+    });
+
+    let element = Fq2::rand(&mut rng);
+    grp.bench_with_input("Fq2 -> blst_fp2", &element, |b, element| {
+        b.iter(|| bls_fq2_to_blst_fp2(element));
+    });
+
+    let element = Fq6::rand(&mut rng);
+    grp.bench_with_input("Fq6 -> blst_fp6", &element, |b, element| {
+        b.iter(|| bls_fq6_to_blst_fp6(element));
+    });
+
+    let element = Fq12::rand(&mut rng);
+    grp.bench_with_input("Fq12 -> blst_fp12", &element, |b, element| {
+        b.iter(|| bls_fq12_to_blst_fp12(element));
+    });
+
+    let scalar = BlsFr::rand(&mut rng);
+    let element = BlsG1Affine::prime_subgroup_generator()
+        .mul(scalar.into_repr())
+        .into_affine();
+    grp.bench_with_input("G1Affine -> blst_p1_affine", &element, |b, element| {
+        b.iter(|| bls_g1_affine_to_blst_g1_affine(element));
+    });
+
+    let scalar = BlsFr::rand(&mut rng);
+    let element = BlsG2Affine::prime_subgroup_generator()
+        .mul(scalar.into_repr())
+        .into_affine();
+    grp.bench_with_input("G2Affine -> blst_p2_affine", &element, |b, element| {
+        b.iter(|| bls_g2_affine_to_blst_g2_affine(element));
+    });
+}
+
+fn convert_from_blst<M: Measurement>(grp: &mut BenchmarkGroup<M>) {
+    let mut rng = ark_std::test_rng();
+    let bls = BlsFr::rand(&mut rng);
+    let element = bls_fr_to_blst_fr(&bls);
+    grp.bench_with_input("blst_fr -> BlsFr", &element, |b, element| {
+        b.iter(|| blst_fr_to_bls_fr(element));
+    });
+
+    let bls = Fq::rand(&mut rng);
+    let element = bls_fq_to_blst_fp(&bls);
+    grp.bench_with_input("blst_fp -> Fp", &element, |b, element| {
+        b.iter(|| blst_fp_to_bls_fq(element));
+    });
+
+    let bls = Fq2::rand(&mut rng);
+    let element = bls_fq2_to_blst_fp2(&bls);
+    grp.bench_with_input("blst_fp2 -> Fq2", &element, |b, element| {
+        b.iter(|| blst_fp2_to_bls_fq2(element));
+    });
+
+    let bls = Fq6::rand(&mut rng);
+    let element = bls_fq6_to_blst_fp6(&bls);
+    grp.bench_with_input("blst_fp6 -> Fq6", &element, |b, element| {
+        b.iter(|| blst_fp6_to_bls_fq6(element));
+    });
+
+    let bls = Fq12::rand(&mut rng);
+    let element = bls_fq12_to_blst_fp12(&bls);
+    grp.bench_with_input("blst_fp12 -> Fq12", &element, |b, element| {
+        b.iter(|| blst_fp12_to_bls_fq12(element));
+    });
+
+    let scalar = BlsFr::rand(&mut rng);
+    let bls = BlsG1Affine::prime_subgroup_generator()
+        .mul(scalar.into_repr())
+        .into_affine();
+    let element = bls_g1_affine_to_blst_g1_affine(&bls);
+    grp.bench_with_input("blst_p1_affine -> G1Affine", &element, |b, element| {
+        b.iter(|| blst_g1_affine_to_bls_g1_affine(element));
+    });
+
+    let scalar = BlsFr::rand(&mut rng);
+    let bls = BlsG2Affine::prime_subgroup_generator()
+        .mul(scalar.into_repr())
+        .into_affine();
+    let element = bls_g2_affine_to_blst_g2_affine(&bls);
+    grp.bench_with_input("blst_p2_affine -> G2Affine", &element, |b, element| {
+        b.iter(|| blst_g2_affine_to_bls_g2_affine(element));
+    });
+}
+
+fn to_from_arkworks(c: &mut Criterion) {
+    let mut group: BenchmarkGroup<_> = c.benchmark_group("Conversions Arkworks -> Blst");
+    convert_from_arkworks(&mut group);
+    group.finish();
+    let mut group: BenchmarkGroup<_> = c.benchmark_group("Conversions Blst -> Arkworks");
+    convert_from_blst(&mut group);
+    group.finish();
+}
+
+criterion_group! {
+    name = conversion_benches;
+    config = Criterion::default();
+    targets =
+       to_from_arkworks,
+}

--- a/fastcrypto-zkp/benches/proving.rs
+++ b/fastcrypto-zkp/benches/proving.rs
@@ -5,50 +5,12 @@ use ark_crypto_primitives::SNARK;
 use ark_ec::PairingEngine;
 use ark_ff::{PrimeField, UniformRand};
 use ark_groth16::Groth16;
-use ark_relations::{
-    lc,
-    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
-};
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
     Criterion, SamplingMode,
 };
+use fastcrypto_proving::dummy_circuit::DummyCircuit;
 use std::ops::Mul;
-
-#[derive(Copy, Clone)]
-struct DummyCircuit<F: PrimeField> {
-    pub a: Option<F>,
-    pub b: Option<F>,
-    pub num_variables: usize,
-    pub num_constraints: usize,
-}
-
-impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
-    // We'll be proving a relationship involving the product c of a & b
-    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
-        let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
-        let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
-        let c = cs.new_input_variable(|| {
-            let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
-            let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
-
-            Ok(a * b)
-        })?;
-
-        // a, b, c are above, let's define the rest.
-        for _ in 0..(self.num_variables - 3) {
-            let _ = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
-        }
-
-        for _ in 0..self.num_constraints - 1 {
-            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
-        }
-
-        cs.enforce_constraint(lc!(), lc!(), lc!())?;
-
-        Ok(())
-    }
-}
 
 fn bench_prove<F: PrimeField, E: PairingEngine<Fr = F>, M: Measurement>(
     grp: &mut BenchmarkGroup<M>,

--- a/fastcrypto-zkp/benches/proving.rs
+++ b/fastcrypto-zkp/benches/proving.rs
@@ -15,6 +15,9 @@ use criterion::{
 use fastcrypto_proving::dummy_circuit::DummyCircuit;
 use std::ops::Mul;
 
+#[path = "./conversions.rs"]
+mod conversions;
+
 fn bench_prove<F: PrimeField, E: PairingEngine<Fr = F>, M: Measurement>(
     grp: &mut BenchmarkGroup<M>,
 ) {
@@ -170,4 +173,4 @@ criterion_group! {
        prove,
 }
 
-criterion_main!(proving_benches,);
+criterion_main!(conversions::conversion_benches, proving_benches,);

--- a/fastcrypto-zkp/src/conversions.rs
+++ b/fastcrypto-zkp/src/conversions.rs
@@ -41,16 +41,16 @@ pub fn bls_fr_to_blst_fr(fe: &BlsFr) -> blst_fr {
     out
 }
 
-pub fn blst_fr_to_bls_fr(fe: blst_fr) -> BlsFr {
+pub fn blst_fr_to_bls_fr(fe: &blst_fr) -> BlsFr {
     let mut out = [0u64; 4];
-    unsafe { blst_uint64_from_fr(out.as_mut_ptr(), &fe) };
+    unsafe { blst_uint64_from_fr(out.as_mut_ptr(), fe) };
     let bytes = out.as_byte_slice();
 
     BlsFr::from_le_bytes_mod_order(bytes)
 }
 
 // Base Field conversions
-pub fn bls_fq_to_blst_fp(f: Fq) -> blst_fp {
+pub fn bls_fq_to_blst_fp(f: &Fq) -> blst_fp {
     let mut fp_bytes_le = [0u8; G1_UNCOMPRESSED_SIZE / 2];
     f.serialize_uncompressed(&mut fp_bytes_le[..])
         .expect("fp size correct");
@@ -62,15 +62,15 @@ pub fn bls_fq_to_blst_fp(f: Fq) -> blst_fp {
     blst_fp
 }
 
-pub fn blst_fp_to_bls_fq(f: blst_fp) -> Fq {
+pub fn blst_fp_to_bls_fq(f: &blst_fp) -> Fq {
     let mut out = [0u64; 6];
-    unsafe { blst_uint64_from_fp(out.as_mut_ptr(), &f) };
+    unsafe { blst_uint64_from_fp(out.as_mut_ptr(), f) };
     let bytes = out.as_byte_slice();
     <Fq as FromBytes>::read(bytes).unwrap()
 }
 
 // QFE conversions
-pub fn bls_fq2_to_blst_fp2(f: Fq2) -> blst_fp2 {
+pub fn bls_fq2_to_blst_fp2(f: &Fq2) -> blst_fp2 {
     let mut fp_bytes_le = [0u8; G2_UNCOMPRESSED_SIZE / 2];
     f.serialize_uncompressed(&mut fp_bytes_le[..])
         .expect("fp size correct");
@@ -91,37 +91,37 @@ pub fn bls_fq2_to_blst_fp2(f: Fq2) -> blst_fp2 {
     }
 }
 
-pub fn blst_fp2_to_bls_fq2(f: blst_fp2) -> Fq2 {
+pub fn blst_fp2_to_bls_fq2(f: &blst_fp2) -> Fq2 {
     let [fp1, fp2] = f.fp;
-    let bls_fp1 = blst_fp_to_bls_fq(fp1);
-    let bls_fp2 = blst_fp_to_bls_fq(fp2);
+    let bls_fp1 = blst_fp_to_bls_fq(&fp1);
+    let bls_fp2 = blst_fp_to_bls_fq(&fp2);
     Fq2::new(bls_fp1, bls_fp2)
 }
 
 // Target Field conversions
-pub fn bls_fq6_to_blst_fp6(f: Fq6) -> blst_fp6 {
-    let c0 = bls_fq2_to_blst_fp2(f.c0);
-    let c1 = bls_fq2_to_blst_fp2(f.c1);
-    let c2 = bls_fq2_to_blst_fp2(f.c2);
+pub fn bls_fq6_to_blst_fp6(f: &Fq6) -> blst_fp6 {
+    let c0 = bls_fq2_to_blst_fp2(&f.c0);
+    let c1 = bls_fq2_to_blst_fp2(&f.c1);
+    let c2 = bls_fq2_to_blst_fp2(&f.c2);
     blst_fp6 { fp2: [c0, c1, c2] }
 }
 
-pub fn blst_fp6_to_bls_fq6(f: blst_fp6) -> Fq6 {
-    let c0 = blst_fp2_to_bls_fq2(f.fp2[0]);
-    let c1 = blst_fp2_to_bls_fq2(f.fp2[1]);
-    let c2 = blst_fp2_to_bls_fq2(f.fp2[2]);
+pub fn blst_fp6_to_bls_fq6(f: &blst_fp6) -> Fq6 {
+    let c0 = blst_fp2_to_bls_fq2(&f.fp2[0]);
+    let c1 = blst_fp2_to_bls_fq2(&f.fp2[1]);
+    let c2 = blst_fp2_to_bls_fq2(&f.fp2[2]);
     Fq6::new(c0, c1, c2)
 }
 
-pub fn bls_fq12_to_blst_fp12(f: Fq12) -> blst_fp12 {
-    let c0 = bls_fq6_to_blst_fp6(f.c0);
-    let c1 = bls_fq6_to_blst_fp6(f.c1);
+pub fn bls_fq12_to_blst_fp12(f: &Fq12) -> blst_fp12 {
+    let c0 = bls_fq6_to_blst_fp6(&f.c0);
+    let c1 = bls_fq6_to_blst_fp6(&f.c1);
     blst_fp12 { fp6: [c0, c1] }
 }
 
-pub fn blst_fp12_to_bls_fq12(f: blst_fp12) -> Fq12 {
-    let c0 = blst_fp6_to_bls_fq6(f.fp6[0]);
-    let c1 = blst_fp6_to_bls_fq6(f.fp6[1]);
+pub fn blst_fp12_to_bls_fq12(f: &blst_fp12) -> Fq12 {
+    let c0 = blst_fp6_to_bls_fq6(&f.fp6[0]);
+    let c1 = blst_fp6_to_bls_fq6(&f.fp6[1]);
     Fq12::new(c0, c1)
 }
 
@@ -130,8 +130,8 @@ pub fn blst_fp12_to_bls_fq12(f: blst_fp12) -> Fq12 {
 pub fn bls_g1_affine_to_blst_g1_affine(pt: &BlsG1Affine) -> blst_p1_affine {
     debug_assert_eq!(pt.uncompressed_size(), G1_UNCOMPRESSED_SIZE);
     let tmp_p1 = blst_p1_affine {
-        x: bls_fq_to_blst_fp(pt.x),
-        y: bls_fq_to_blst_fp(pt.y),
+        x: bls_fq_to_blst_fp(&pt.x),
+        y: bls_fq_to_blst_fp(&pt.y),
     };
     // See https://github.com/arkworks-rs/curves/issues/14 for why the double serialize
     // we're in fact applying correct masks that arkworks does not use. This may be solved alternatively using
@@ -146,10 +146,10 @@ pub fn bls_g1_affine_to_blst_g1_affine(pt: &BlsG1Affine) -> blst_p1_affine {
     g1
 }
 
-pub fn blst_g1_affine_to_bls_g1_affine(pt: blst_p1_affine) -> BlsG1Affine {
+pub fn blst_g1_affine_to_bls_g1_affine(pt: &blst_p1_affine) -> BlsG1Affine {
     let mut out = [0u8; G1_UNCOMPRESSED_SIZE];
     unsafe {
-        blst_p1_affine_serialize(out.as_mut_ptr(), &pt);
+        blst_p1_affine_serialize(out.as_mut_ptr(), pt);
     }
     let infinity = out[0] & (1 << 6) != 0;
     BlsG1Affine::new(
@@ -162,8 +162,8 @@ pub fn blst_g1_affine_to_bls_g1_affine(pt: blst_p1_affine) -> BlsG1Affine {
 pub fn bls_g2_affine_to_blst_g2_affine(pt: &BlsG2Affine) -> blst_p2_affine {
     debug_assert_eq!(pt.uncompressed_size(), G2_UNCOMPRESSED_SIZE);
     let tmp_p2 = blst_p2_affine {
-        x: bls_fq2_to_blst_fp2(pt.x),
-        y: bls_fq2_to_blst_fp2(pt.y),
+        x: bls_fq2_to_blst_fp2(&pt.x),
+        y: bls_fq2_to_blst_fp2(&pt.y),
     };
     // See https://github.com/arkworks-rs/curves/issues/14 for why the double serialize
     // we're in fact applying correct masks that arkworks does not use. This may be solved alternatively using
@@ -178,14 +178,14 @@ pub fn bls_g2_affine_to_blst_g2_affine(pt: &BlsG2Affine) -> blst_p2_affine {
     g2
 }
 
-pub fn blst_g2_affine_to_bls_g2_affine(pt: blst_p2_affine) -> BlsG2Affine {
-    let ptx = blst_fp2_to_bls_fq2(pt.x);
-    let pty = blst_fp2_to_bls_fq2(pt.y);
+pub fn blst_g2_affine_to_bls_g2_affine(pt: &blst_p2_affine) -> BlsG2Affine {
+    let ptx = blst_fp2_to_bls_fq2(&pt.x);
+    let pty = blst_fp2_to_bls_fq2(&pt.y);
 
     // TODO: surely there's a better way to do this?
     let mut out = [0u8; G2_UNCOMPRESSED_SIZE];
     unsafe {
-        blst_p2_affine_serialize(out.as_mut_ptr(), &pt);
+        blst_p2_affine_serialize(out.as_mut_ptr(), pt);
     }
     let infinity = out[0] & (1 << 6) != 0;
     BlsG2Affine::new(ptx, pty, infinity)
@@ -227,13 +227,13 @@ pub(crate) mod tests {
         #[test]
         fn roundtrip_bls_fr(b in arb_bls_fr()) {
             let blst_variant = bls_fr_to_blst_fr(&b);
-            let roundtrip = blst_fr_to_bls_fr(blst_variant);
+            let roundtrip = blst_fr_to_bls_fr(&blst_variant);
             prop_assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_fr(b in arb_blst_fr()) {
-            let bls_variant = blst_fr_to_bls_fr(b);
+            let bls_variant = blst_fr_to_bls_fr(&b);
             let roundtrip = bls_fr_to_blst_fr(&bls_variant);
             prop_assert_eq!(b, roundtrip);
         }
@@ -262,15 +262,15 @@ pub(crate) mod tests {
     proptest! {
         #[test]
         fn roundtrip_bls_fq(b in arb_bls_fq()) {
-            let blst_variant = bls_fq_to_blst_fp(b);
-            let roundtrip = blst_fp_to_bls_fq(blst_variant);
+            let blst_variant = bls_fq_to_blst_fp(&b);
+            let roundtrip = blst_fp_to_bls_fq(&blst_variant);
             prop_assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_fp(b in arb_blst_fp()) {
-            let bls_variant = blst_fp_to_bls_fq(b);
-            let roundtrip = bls_fq_to_blst_fp(bls_variant);
+            let bls_variant = blst_fp_to_bls_fq(&b);
+            let roundtrip = bls_fq_to_blst_fp(&bls_variant);
             prop_assert_eq!(b, roundtrip);
         }
     }
@@ -287,15 +287,15 @@ pub(crate) mod tests {
     proptest! {
         #[test]
         fn roundtrip_bls_fq2(b in arb_bls_fq2()) {
-            let blst_variant = bls_fq2_to_blst_fp2(b);
-            let roundtrip = blst_fp2_to_bls_fq2(blst_variant);
+            let blst_variant = bls_fq2_to_blst_fp2(&b);
+            let roundtrip = blst_fp2_to_bls_fq2(&blst_variant);
             prop_assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_fp2(b in arb_blst_fp2()) {
-            let bls_variant = blst_fp2_to_bls_fq2(b);
-            let roundtrip = bls_fq2_to_blst_fp2(bls_variant);
+            let bls_variant = blst_fp2_to_bls_fq2(&b);
+            let roundtrip = bls_fq2_to_blst_fp2(&bls_variant);
             prop_assert_eq!(b, roundtrip);
         }
     }
@@ -316,15 +316,15 @@ pub(crate) mod tests {
     proptest! {
         #[test]
         fn roundtrip_bls_fq6(b in arb_bls_fq6()){
-            let blst_variant = bls_fq6_to_blst_fp6(b);
-            let roundtrip = blst_fp6_to_bls_fq6(blst_variant);
+            let blst_variant = bls_fq6_to_blst_fp6(&b);
+            let roundtrip = blst_fp6_to_bls_fq6(&blst_variant);
             prop_assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_fp6(b in arb_blst_fp6()){
-            let bls_variant = blst_fp6_to_bls_fq6(b);
-            let roundtrip = bls_fq6_to_blst_fp6(bls_variant);
+            let bls_variant = blst_fp6_to_bls_fq6(&b);
+            let roundtrip = bls_fq6_to_blst_fp6(&bls_variant);
             prop_assert_eq!(b, roundtrip);
         }
     }
@@ -340,15 +340,15 @@ pub(crate) mod tests {
     proptest! {
         #[test]
         fn roundtrip_bls_fq12(b in arb_bls_fq12()) {
-            let blst_variant = bls_fq12_to_blst_fp12(b);
-            let roundtrip = blst_fp12_to_bls_fq12(blst_variant);
+            let blst_variant = bls_fq12_to_blst_fp12(&b);
+            let roundtrip = blst_fp12_to_bls_fq12(&blst_variant);
             prop_assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_fp12(b in arb_blst_fp12()) {
-            let bls_variant = blst_fp12_to_bls_fq12(b);
-            let roundtrip = bls_fq12_to_blst_fp12(bls_variant);
+            let bls_variant = blst_fp12_to_bls_fq12(&b);
+            let roundtrip = bls_fq12_to_blst_fp12(&bls_variant);
             prop_assert_eq!(b, roundtrip);
         }
     }
@@ -394,13 +394,13 @@ pub(crate) mod tests {
         #[test]
         fn roundtrip_bls_g1_affine(b in arb_bls_g1_affine()) {
             let blst_variant = bls_g1_affine_to_blst_g1_affine(&b);
-            let roundtrip = blst_g1_affine_to_bls_g1_affine(blst_variant);
+            let roundtrip = blst_g1_affine_to_bls_g1_affine(&blst_variant);
             assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_g1_affine(b in arb_blst_g1_affine()) {
-            let bls_variant = blst_g1_affine_to_bls_g1_affine(b);
+            let bls_variant = blst_g1_affine_to_bls_g1_affine(&b);
             let roundtrip = bls_g1_affine_to_blst_g1_affine(&bls_variant);
             assert_eq!(b, roundtrip);
         }
@@ -446,13 +446,13 @@ pub(crate) mod tests {
         #[test]
         fn roundtrip_bls_g2_affine(b in arb_bls_g2_affine()) {
             let blst_variant = bls_g2_affine_to_blst_g2_affine(&b);
-            let roundtrip = blst_g2_affine_to_bls_g2_affine(blst_variant);
+            let roundtrip = blst_g2_affine_to_bls_g2_affine(&blst_variant);
             assert_eq!(b, roundtrip);
         }
 
         #[test]
         fn roundtrip_blst_g2_affine(b in arb_blst_g2_affine()) {
-            let bls_variant = blst_g2_affine_to_bls_g2_affine(b);
+            let bls_variant = blst_g2_affine_to_bls_g2_affine(&b);
             let roundtrip = bls_g2_affine_to_blst_g2_affine(&bls_variant);
             assert_eq!(b, roundtrip);
         }

--- a/fastcrypto-zkp/src/dummy_circuit.rs
+++ b/fastcrypto-zkp/src/dummy_circuit.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use ark_ff::PrimeField;
+use ark_relations::{
+    lc,
+    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+};
+
+#[derive(Copy, Clone)]
+pub struct DummyCircuit<F: PrimeField> {
+    pub a: Option<F>,
+    pub b: Option<F>,
+    pub num_variables: usize,
+    pub num_constraints: usize,
+}
+
+impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
+    // We'll be proving a relationship involving the product c of a & b
+    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
+        let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
+        let c = cs.new_input_variable(|| {
+            let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+            let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+
+            Ok(a * b)
+        })?;
+
+        // a, b, c are above, let's define the rest.
+        for _ in 0..(self.num_variables - 3) {
+            let _ = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        }
+
+        for _ in 0..self.num_constraints - 1 {
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        }
+
+        cs.enforce_constraint(lc!(), lc!(), lc!())?;
+
+        Ok(())
+    }
+}

--- a/fastcrypto-zkp/src/lib.rs
+++ b/fastcrypto-zkp/src/lib.rs
@@ -1,3 +1,4 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 pub mod conversions;
+pub mod verifier;

--- a/fastcrypto-zkp/src/lib.rs
+++ b/fastcrypto-zkp/src/lib.rs
@@ -1,4 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+// Conversions between arkworks <-> blst
 pub mod conversions;
+
+// dummy circuit used for tests and benchmarks
+pub mod dummy_circuit;
+
+// Groth16 SNARK verifier
 pub mod verifier;

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -15,10 +15,6 @@ use ark_crypto_primitives::SNARK;
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, PrimeField, UniformRand};
 use ark_groth16::{Groth16, PreparedVerifyingKey};
-use ark_relations::{
-    lc,
-    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
-};
 
 use crate::{
     conversions::{
@@ -26,49 +22,14 @@ use crate::{
         bls_g2_affine_to_blst_g2_affine, blst_fp12_to_bls_fq12,
         tests::{arb_bls_fr, arb_bls_g1_affine, arb_blst_g1_affine, arb_blst_g2_affine},
     },
+    dummy_circuit::DummyCircuit,
     verifier::{
         g1_linear_combination, multipairing_with_processed_vk, process_vk_special,
         verify_with_processed_vk, Proof, VerifyingKey,
     },
 };
 
-// This duplicates the proving DummyCircuit, which is a bit hard to share.
-#[derive(Copy, Clone)]
-struct DummyCircuit<F: PrimeField> {
-    pub a: Option<F>,
-    pub b: Option<F>,
-    pub num_variables: usize,
-    pub num_constraints: usize,
-}
-
-impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
-    // We'll be proving a relationship involving the product c of a & b
-    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
-        let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
-        let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
-        let c = cs.new_input_variable(|| {
-            let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
-            let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
-
-            Ok(a * b)
-        })?;
-
-        // a, b, c are above, let's define the rest.
-        for _ in 0..(self.num_variables - 3) {
-            let _ = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
-        }
-
-        for _ in 0..self.num_constraints - 1 {
-            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
-        }
-
-        cs.enforce_constraint(lc!(), lc!(), lc!())?;
-
-        Ok(())
-    }
-}
-
-// This emulates the process_vk function of the arkworks verifier, but using blst to compute the term 
+// This emulates the process_vk function of the arkworks verifier, but using blst to compute the term
 // alpha_g1_beta_g2. See [`test_prepare_vk`].
 fn ark_process_vk(vk: &VerifyingKey<Bls12_381>) -> PreparedVerifyingKey<Bls12_381> {
     let g1_alpha = bls_g1_affine_to_blst_g1_affine(&vk.alpha_g1);
@@ -91,7 +52,7 @@ fn ark_process_vk(vk: &VerifyingKey<Bls12_381>) -> PreparedVerifyingKey<Bls12_38
 }
 
 // This commputes the result of the multi-pairing involved in the Groth16 verification, using arkworks.
-// See [`test_multipairing_with_processed_vk`] 
+// See [`test_multipairing_with_processed_vk`]
 pub fn ark_multipairing_with_prepared_vk(
     pvk: &PreparedVerifyingKey<Bls12_381>,
     proof: &Proof<Bls12_381>,

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use blst::{
+    blst_final_exp, blst_fp12, blst_fp12_mul, blst_fr, blst_miller_loop, blst_p1, blst_p1_affine,
+    blst_p1_to_affine, Pairing,
+};
+use proptest::{collection, prelude::*};
+use std::{
+    iter,
+    ops::{AddAssign, Mul, Neg},
+};
+
+use ark_bls12_381::{Bls12_381, Fq12, Fr};
+use ark_crypto_primitives::SNARK;
+use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
+use ark_ff::{One, PrimeField, UniformRand};
+use ark_groth16::{Groth16, PreparedVerifyingKey};
+use ark_relations::{
+    lc,
+    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+};
+
+use crate::{
+    conversions::{
+        bls_fq12_to_blst_fp12, bls_fr_to_blst_fr, bls_g1_affine_to_blst_g1_affine,
+        bls_g2_affine_to_blst_g2_affine, blst_fp12_to_bls_fq12,
+        tests::{arb_bls_fr, arb_bls_g1_affine, arb_blst_g1_affine, arb_blst_g2_affine},
+    },
+    verifier::{
+        g1_linear_combination, multipairing_with_processed_vk, process_vk_special,
+        verify_with_processed_vk, Proof, VerifyingKey,
+    },
+};
+
+// This duplicates the proving DummyCircuit, which is a bit hard to share.
+#[derive(Copy, Clone)]
+struct DummyCircuit<F: PrimeField> {
+    pub a: Option<F>,
+    pub b: Option<F>,
+    pub num_variables: usize,
+    pub num_constraints: usize,
+}
+
+impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
+    // We'll be proving a relationship involving the product c of a & b
+    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
+        let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
+        let c = cs.new_input_variable(|| {
+            let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+            let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+
+            Ok(a * b)
+        })?;
+
+        // a, b, c are above, let's define the rest.
+        for _ in 0..(self.num_variables - 3) {
+            let _ = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        }
+
+        for _ in 0..self.num_constraints - 1 {
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        }
+
+        cs.enforce_constraint(lc!(), lc!(), lc!())?;
+
+        Ok(())
+    }
+}
+
+// This emulates the process_vk function of the arkworks verifier, but using blst to compute the term 
+// alpha_g1_beta_g2. See [`test_prepare_vk`].
+fn ark_process_vk(vk: &VerifyingKey<Bls12_381>) -> PreparedVerifyingKey<Bls12_381> {
+    let g1_alpha = bls_g1_affine_to_blst_g1_affine(&vk.alpha_g1);
+    let g2_beta = bls_g2_affine_to_blst_g2_affine(&vk.beta_g2);
+    let blst_alpha_g1_beta_g2 = {
+        let mut tmp = blst_fp12::default();
+        unsafe { blst_miller_loop(&mut tmp, &g2_beta, &g1_alpha) };
+
+        let mut out = blst_fp12::default();
+        unsafe { blst_final_exp(&mut out, &tmp) };
+        out
+    };
+    let alpha_g1_beta_g2 = blst_fp12_to_bls_fq12(blst_alpha_g1_beta_g2);
+    PreparedVerifyingKey {
+        vk: vk.clone(),
+        alpha_g1_beta_g2,
+        gamma_g2_neg_pc: vk.gamma_g2.neg().into(),
+        delta_g2_neg_pc: vk.delta_g2.neg().into(),
+    }
+}
+
+// This commputes the result of the multi-pairing involved in the Groth16 verification, using arkworks.
+// See [`test_multipairing_with_processed_vk`] 
+pub fn ark_multipairing_with_prepared_vk(
+    pvk: &PreparedVerifyingKey<Bls12_381>,
+    proof: &Proof<Bls12_381>,
+    public_inputs: &[Fr],
+) -> Fq12 {
+    let mut g_ic = pvk.vk.gamma_abc_g1[0].into_projective();
+    for (i, b) in public_inputs.iter().zip(pvk.vk.gamma_abc_g1.iter().skip(1)) {
+        g_ic.add_assign(&b.mul(i.into_repr()));
+    }
+
+    let qap = Bls12_381::miller_loop(
+        [
+            (proof.a.into(), proof.b.into()),
+            (g_ic.into_affine().into(), pvk.gamma_g2_neg_pc.clone()),
+            (proof.c.into(), pvk.delta_g2_neg_pc.clone()),
+        ]
+        .iter(),
+    );
+
+    Bls12_381::final_exponentiation(&qap).unwrap()
+}
+
+const LEN: usize = 10;
+
+proptest! {
+    // This technical test is necessary because blst does not expose
+    // the miller_loop_n operation, and forces us to abuse the signature-oriented pairing engine
+    // that it does expose. Here we show the use of the pairing engine is equivalent to iterated
+    // use of one-off pairings.
+    #[test]
+    fn test_blst_miller_loops(
+        a_s in collection::vec(arb_blst_g1_affine(), LEN..=LEN),
+        b_s in collection::vec(arb_blst_g2_affine(), LEN..=LEN)
+
+    ) {
+        let pairing_engine_result = {
+            let dst = [0u8; 3];
+            let mut pairing_blst = Pairing::new(false, &dst);
+            for (b, a) in b_s.iter().zip(a_s.iter()) {
+                pairing_blst.raw_aggregate(b, a);
+            }
+            pairing_blst.as_fp12() // this implies pairing_blst.commit()
+        };
+
+        let mut res = blst_fp12::default();
+        let mut loop0 = blst_fp12::default();
+
+        for i in 0..LEN {
+            unsafe {
+                blst_miller_loop(&mut loop0, b_s[i..].as_ptr(), a_s[i..].as_ptr());
+                blst_fp12_mul(&mut res, &res, &loop0);
+                loop0 = blst_fp12::default();
+            }
+        }
+
+        prop_assert_eq!(res, pairing_engine_result);
+    }
+
+}
+
+#[test]
+fn test_prepare_vk() {
+    const PUBLIC_SIZE: usize = 128;
+    let rng = &mut ark_std::test_rng();
+    let c = DummyCircuit::<Fr> {
+        a: Some(<Fr>::rand(rng)),
+        b: Some(<Fr>::rand(rng)),
+        num_variables: PUBLIC_SIZE,
+        num_constraints: 65536,
+    };
+
+    let (_pk, vk) = Groth16::<Bls12_381>::circuit_specific_setup(c, rng).unwrap();
+
+    let ark_pvk = Groth16::<Bls12_381>::process_vk(&vk).unwrap();
+    let blst_pvk = ark_process_vk(&vk);
+    assert_eq!(ark_pvk.alpha_g1_beta_g2, blst_pvk.alpha_g1_beta_g2);
+}
+
+proptest! {
+    #[test]
+    fn test_g1_linear_combination(
+        frs in collection::vec(arb_bls_fr(), LEN-1..=LEN-1),
+        a_s in collection::vec(arb_bls_g1_affine(), LEN..=LEN),
+    ) {
+
+        let pts: Vec<blst_p1_affine> = a_s
+            .iter()
+            .map(bls_g1_affine_to_blst_g1_affine)
+            .collect();
+        // TODO: find a more direct way to grab this constant
+        let one = bls_fr_to_blst_fr(&Fr::one());
+        let ss: Vec<blst_fr> = iter::once(one)
+            .chain(frs.iter().map(bls_fr_to_blst_fr))
+            .collect();
+        let mut blst_res = blst_p1::default();
+        g1_linear_combination(&mut blst_res, &pts, &ss[..], ss.len());
+        let mut blst_res_affine = blst_p1_affine::default();
+        unsafe { blst_p1_to_affine(&mut blst_res_affine, &blst_res) };
+
+        let mut g_ic = a_s[0].into_projective();
+        for (i, b) in frs.iter().zip(a_s.iter().skip(1)) {
+            g_ic.add_assign(&b.mul(i.into_repr()));
+        }
+
+        // TODO: convert this so we can make a projective comparison
+        prop_assert_eq!(blst_res_affine, bls_g1_affine_to_blst_g1_affine(&g_ic.into_affine()));
+
+    }
+}
+
+#[test]
+fn test_verify_with_processed_vk() {
+    const PUBLIC_SIZE: usize = 128;
+    let rng = &mut ark_std::test_rng();
+    let c = DummyCircuit::<Fr> {
+        a: Some(<Fr>::rand(rng)),
+        b: Some(<Fr>::rand(rng)),
+        num_variables: PUBLIC_SIZE,
+        num_constraints: 65536,
+    };
+
+    let (pk, vk) = Groth16::<Bls12_381>::circuit_specific_setup(c, rng).unwrap();
+    let proof = Groth16::<Bls12_381>::prove(&pk, c, rng).unwrap();
+    let v = c.a.unwrap().mul(c.b.unwrap());
+
+    let blst_pvk = process_vk_special(&vk);
+
+    assert!(verify_with_processed_vk(&blst_pvk, &[v], &proof).unwrap());
+}
+
+#[test]
+fn test_multipairing_with_processed_vk() {
+    const PUBLIC_SIZE: usize = 128;
+    let rng = &mut ark_std::test_rng();
+    let c = DummyCircuit::<Fr> {
+        a: Some(<Fr>::rand(rng)),
+        b: Some(<Fr>::rand(rng)),
+        num_variables: PUBLIC_SIZE,
+        num_constraints: 65536,
+    };
+
+    let (pk, vk) = Groth16::<Bls12_381>::circuit_specific_setup(c, rng).unwrap();
+    let proof = Groth16::<Bls12_381>::prove(&pk, c, rng).unwrap();
+    let v = c.a.unwrap().mul(c.b.unwrap());
+
+    let ark_pvk = Groth16::<Bls12_381>::process_vk(&vk).unwrap();
+    let blst_pvk = process_vk_special(&vk);
+
+    let ark_fe = ark_multipairing_with_prepared_vk(&ark_pvk, &proof, &[v]);
+    let blst_fe = multipairing_with_processed_vk(&blst_pvk, &[v], &proof);
+
+    assert_eq!(bls_fq12_to_blst_fp12(ark_fe), blst_fe);
+}

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -25,9 +25,16 @@ use crate::{
     dummy_circuit::DummyCircuit,
     verifier::{
         g1_linear_combination, multipairing_with_processed_vk, process_vk_special,
-        verify_with_processed_vk, Proof, VerifyingKey,
+        verify_with_processed_vk, Proof, VerifyingKey, BLST_FR_ONE,
     },
 };
+
+#[test]
+fn fr_one_test() {
+    let bls_one = Fr::one();
+    let blst_one = bls_fr_to_blst_fr(&bls_one);
+    assert_eq!(blst_one, BLST_FR_ONE);
+}
 
 // This emulates the process_vk function of the arkworks verifier, but using blst to compute the term
 // alpha_g1_beta_g2. See [`test_prepare_vk`].
@@ -142,8 +149,7 @@ proptest! {
             .iter()
             .map(bls_g1_affine_to_blst_g1_affine)
             .collect();
-        // TODO: find a more direct way to grab this constant
-        let one = bls_fr_to_blst_fr(&Fr::one());
+        let one = BLST_FR_ONE;
         let ss: Vec<blst_fr> = iter::once(one)
             .chain(frs.iter().map(bls_fr_to_blst_fr))
             .collect();

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -42,7 +42,7 @@ fn ark_process_vk(vk: &VerifyingKey<Bls12_381>) -> PreparedVerifyingKey<Bls12_38
         unsafe { blst_final_exp(&mut out, &tmp) };
         out
     };
-    let alpha_g1_beta_g2 = blst_fp12_to_bls_fq12(blst_alpha_g1_beta_g2);
+    let alpha_g1_beta_g2 = blst_fp12_to_bls_fq12(&blst_alpha_g1_beta_g2);
     PreparedVerifyingKey {
         vk: vk.clone(),
         alpha_g1_beta_g2,
@@ -204,5 +204,5 @@ fn test_multipairing_with_processed_vk() {
     let ark_fe = ark_multipairing_with_prepared_vk(&ark_pvk, &proof, &[v]);
     let blst_fe = multipairing_with_processed_vk(&blst_pvk, &[v], &proof);
 
-    assert_eq!(bls_fq12_to_blst_fp12(ark_fe), blst_fe);
+    assert_eq!(bls_fq12_to_blst_fp12(&ark_fe), blst_fe);
 }

--- a/fastcrypto-zkp/src/verifier.rs
+++ b/fastcrypto-zkp/src/verifier.rs
@@ -1,0 +1,239 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use std::{iter, ops::Neg, ptr};
+
+use ark_bls12_381::{Bls12_381, Fr as BlsFr};
+use ark_ec::PairingEngine;
+use ark_ff::One;
+pub use ark_groth16::{Proof, VerifyingKey};
+use ark_relations::r1cs::SynthesisError;
+
+use blst::{
+    blst_final_exp, blst_fp, blst_fp12, blst_fr, blst_miller_loop, blst_p1, blst_p1_add_or_double,
+    blst_p1_affine, blst_p1_from_affine, blst_p1_mult, blst_p1_to_affine, blst_p1s_mult_pippenger,
+    blst_p1s_mult_pippenger_scratch_sizeof, blst_scalar, blst_scalar_from_fr, limb_t, Pairing,
+};
+
+use crate::conversions::{
+    bls_fq12_to_blst_fp12, bls_fr_to_blst_fr, bls_g1_affine_to_blst_g1_affine,
+    bls_g2_affine_to_blst_g2_affine, blst_fp12_to_bls_fq12,
+};
+
+#[cfg(test)]
+#[path = "unit_tests/verifier_tests.rs"]
+mod verifier_tests;
+
+/// This is a helper function to store a pre-processed version of the verifying key.
+/// This is roughly homologous to [`ark_groth16::PreparedVerifyingKey`].
+/// Note that contrary to Arkworks, we don't store a "prepared" version of the gamma_g2_neg_pc,
+/// delta_g2_neg_pc fields, because we can't use them with blst's pairing engine.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpecialPreparedVerifyingKey<E: PairingEngine> {
+    /// The unprepared verification key.
+    pub vk: VerifyingKey<E>,
+    /// The element `e(alpha * G, beta * H)` in `E::GT`.
+    pub alpha_g1_beta_g2: E::Fqk,
+    /// The element `- gamma * H` in `E::G2`, for use in pairings.
+    pub gamma_g2_neg_pc: E::G2Affine,
+    /// The element `- delta * H` in `E::G2`, for use in pairings.
+    pub delta_g2_neg_pc: E::G2Affine,
+}
+
+/// Takes an input Verifier key `vk` and returns a `SpecialPreparedVerifyingKey`. This is roughly homologous to
+/// [`ark_groth16::PreparedVerifyingKey::process_vk`].
+///
+/// TODO: we are storing a superfluous copy of the vk, we could do with just vk.gamma_abc_g1.
+pub fn process_vk_special(vk: &VerifyingKey<Bls12_381>) -> SpecialPreparedVerifyingKey<Bls12_381> {
+    let g1_alpha = bls_g1_affine_to_blst_g1_affine(&vk.alpha_g1);
+    let g2_beta = bls_g2_affine_to_blst_g2_affine(&vk.beta_g2);
+    let blst_alpha_g1_beta_g2 = {
+        let mut tmp = blst_fp12::default();
+        unsafe { blst_miller_loop(&mut tmp, &g2_beta, &g1_alpha) };
+
+        let mut out = blst_fp12::default();
+        unsafe { blst_final_exp(&mut out, &tmp) };
+        out
+    };
+    let alpha_g1_beta_g2 = blst_fp12_to_bls_fq12(blst_alpha_g1_beta_g2);
+    SpecialPreparedVerifyingKey {
+        vk: vk.clone(),
+        alpha_g1_beta_g2,
+        gamma_g2_neg_pc: vk.gamma_g2.neg(),
+        delta_g2_neg_pc: vk.delta_g2.neg(),
+    }
+}
+
+/// This helper constant makes it easier to use compute the linear combination involved in the pairing inputs.
+const G1_IDENTITY: blst_p1 = blst_p1 {
+    x: blst_fp { l: [0; 6] },
+    y: blst_fp { l: [0; 6] },
+    z: blst_fp { l: [0; 6] },
+};
+
+/// Returns the log base 2 of b in O(lg(N)) time.
+pub fn log_2_byte(b: u8) -> usize {
+    let mut r = if b > 0xF { 1 } else { 0 } << 2;
+    let mut b = b >> r;
+    let shift = if b > 0x3 { 1 } else { 0 } << 1;
+    b >>= shift + 1;
+    r |= shift | b;
+    r.into()
+}
+
+/// Returns a single scalar multiplication of `pt` by `b`.
+fn mul(pt: &blst_p1, b: &blst_fr) -> blst_p1 {
+    let mut scalar: blst_scalar = blst_scalar::default();
+    unsafe {
+        blst_scalar_from_fr(&mut scalar, b);
+    }
+
+    // Count the number of bytes to be multiplied.
+    let mut i = scalar.b.len();
+    while i != 0 && scalar.b[i - 1] == 0 {
+        i -= 1;
+    }
+
+    let mut result = blst_p1::default();
+    if i == 0 {
+        return G1_IDENTITY;
+    } else if i == 1 && scalar.b[0] == 1 {
+        return *pt;
+    } else {
+        // Count the number of bits to be multiplied.
+        unsafe {
+            blst_p1_mult(
+                &mut result,
+                pt,
+                &(scalar.b[0]),
+                8 * i - 7 + log_2_byte(scalar.b[i - 1]),
+            );
+        }
+    }
+    result
+}
+
+/// Facade for the blst_p1_add_or_double function.
+fn add_or_dbl(a: &blst_p1, b: &blst_p1) -> blst_p1 {
+    let mut ret = blst_p1::default();
+    unsafe {
+        blst_p1_add_or_double(&mut ret, a, b);
+    }
+    ret
+}
+
+/// Computes the [\sum p_i * b_i, p_i in p_affine, b_i in coeffs] in G1.
+fn g1_linear_combination(
+    out: &mut blst_p1,
+    p_affine: &[blst_p1_affine],
+    coeffs: &[blst_fr],
+    len: usize,
+) {
+    if len < 8 {
+        // Direct approach
+        let mut tmp;
+        *out = G1_IDENTITY;
+        for i in 0..len {
+            let mut p = blst_p1::default();
+            unsafe { blst_p1_from_affine(&mut p, &p_affine[i]) };
+
+            tmp = mul(&p, &coeffs[i]);
+            *out = add_or_dbl(out, &tmp);
+        }
+    } else {
+        let mut scratch: Vec<u8>;
+        unsafe {
+            scratch = vec![0u8; blst_p1s_mult_pippenger_scratch_sizeof(len) as usize];
+        }
+
+        let mut scalars = vec![blst_scalar::default(); len];
+
+        for i in 0..len {
+            let mut scalar: blst_scalar = blst_scalar::default();
+            unsafe {
+                blst_scalar_from_fr(&mut scalar, &coeffs[i]);
+            }
+            scalars[i] = scalar
+        }
+
+        let scalars_arg: [*const blst_scalar; 2] = [scalars.as_ptr(), ptr::null()];
+        let points_arg: [*const blst_p1_affine; 2] = [p_affine.as_ptr(), ptr::null()];
+        unsafe {
+            blst_p1s_mult_pippenger(
+                out,
+                points_arg.as_ptr(),
+                len,
+                scalars_arg.as_ptr() as *const *const u8,
+                256,
+                scratch.as_mut_ptr() as *mut limb_t,
+            );
+        }
+    }
+}
+
+/// Returns the result of the multi-pairing involved in the verification equation. This will then be compared to the pre-computed term
+/// pvk.alpha_g1_beta_g2 to check the validity of the proof.
+///
+/// The textbook Groth16 equation is (in additive notation):
+/// e(A, B) = e(g * alpha, h * beta) + e(g * f, h * gamma) + e(C, h * delta)
+/// where f is the linear combination of the a_i points in the verifying key with the input scalars
+///
+/// Due to the pre-processing of e(g * alpha, h * beta), and using the pairing inverse, we instead compute:
+/// e)A, B) + e(g * f, h * - gamma) + e(C, h * - delta).
+///
+/// Eventually, we will compare this value to  e(g * alpha, h * beta)
+///
+fn multipairing_with_processed_vk(
+    pvk: &SpecialPreparedVerifyingKey<Bls12_381>,
+    x: &[BlsFr],
+    proof: &Proof<Bls12_381>,
+) -> blst_fp12 {
+    // Linear combination: note that the arkworks interface assumes the 1st scalar is an implicit 1
+    let pts: Vec<blst_p1_affine> = pvk
+        .vk
+        .gamma_abc_g1
+        .iter()
+        .map(bls_g1_affine_to_blst_g1_affine)
+        .collect();
+    // TODO: find a more direct way to grab this
+    let one = bls_fr_to_blst_fr(&BlsFr::one());
+    let ss: Vec<blst_fr> = iter::once(one)
+        .chain(x.iter().map(bls_fr_to_blst_fr))
+        .collect();
+    let mut out = blst_p1::default();
+    g1_linear_combination(&mut out, &pts, &ss[..], ss.len());
+
+    let blst_proof_a = bls_g1_affine_to_blst_g1_affine(&proof.a);
+    let blst_proof_b = bls_g2_affine_to_blst_g2_affine(&proof.b);
+
+    let mut blst_proof_1_g1 = blst_p1_affine::default();
+    unsafe { blst_p1_to_affine(&mut blst_proof_1_g1, &out) };
+    let blst_proof_1_g2 = bls_g2_affine_to_blst_g2_affine(&pvk.gamma_g2_neg_pc);
+
+    let blst_proof_2_g1 = bls_g1_affine_to_blst_g1_affine(&proof.c);
+    let blst_proof_2_g2 = bls_g2_affine_to_blst_g2_affine(&pvk.delta_g2_neg_pc);
+
+    let dst = [0u8; 3];
+    let mut pairing_blst = Pairing::new(false, &dst);
+    pairing_blst.raw_aggregate(&blst_proof_b, &blst_proof_a);
+    pairing_blst.raw_aggregate(&blst_proof_1_g2, &blst_proof_1_g1);
+    pairing_blst.raw_aggregate(&blst_proof_2_g2, &blst_proof_2_g1);
+    pairing_blst.as_fp12().final_exp()
+}
+
+/// Returns the validity of the Groth16 proof passed as argument. The format of the inputs is assumed to be in arkworks format.
+/// See [`multipairing_with_processed_vk`] for the actual pairing computation details.
+/// TODO: due to arkworks incompatibilities in BLS12-381 point (de) serialization, we should probably implement a custom (de)serialization
+/// for those formats, see https://github.com/arkworks-rs/algebra/issues/257
+pub fn verify_with_processed_vk(
+    pvk: &SpecialPreparedVerifyingKey<Bls12_381>,
+    x: &[BlsFr],
+    proof: &Proof<Bls12_381>,
+) -> Result<bool, SynthesisError> {
+    // Note the "+1" : this API implies the first scalar coefficient is 1 and not sent
+    if (x.len() + 1) != pvk.vk.gamma_abc_g1.len() {
+        return Err(SynthesisError::MalformedVerifyingKey);
+    }
+
+    let res = multipairing_with_processed_vk(pvk, x, proof);
+    Ok(res == bls_fq12_to_blst_fp12(pvk.alpha_g1_beta_g2))
+}

--- a/fastcrypto-zkp/src/verifier.rs
+++ b/fastcrypto-zkp/src/verifier.rs
@@ -3,7 +3,6 @@
 use std::{iter, ops::Neg, ptr};
 
 use ark_bls12_381::{Bls12_381, Fr as BlsFr, G2Affine};
-use ark_ff::One;
 pub use ark_groth16::{Proof, VerifyingKey};
 use ark_relations::r1cs::SynthesisError;
 
@@ -167,6 +166,16 @@ fn g1_linear_combination(
     }
 }
 
+/// This represents the multiplicative unit scalar, see fr_one_test
+pub(crate) const BLST_FR_ONE: blst_fr = blst_fr {
+    l: [
+        8589934590,
+        6378425256633387010,
+        11064306276430008309,
+        1739710354780652911,
+    ],
+};
+
 /// Returns the result of the multi-pairing involved in the verification equation. This will then be compared to the pre-computed term
 /// pvk.alpha_g1_beta_g2 to check the validity of the proof.
 ///
@@ -192,7 +201,7 @@ fn multipairing_with_processed_vk(
         .map(bls_g1_affine_to_blst_g1_affine)
         .collect();
     // TODO: find a more direct way to grab this
-    let one = bls_fr_to_blst_fr(&BlsFr::one());
+    let one = BLST_FR_ONE;
     let ss: Vec<blst_fr> = iter::once(one)
         .chain(x.iter().map(bls_fr_to_blst_fr))
         .collect();


### PR DESCRIPTION
This PR sits on top of #110 which should be merged before it.
Adds a pure-blst Groth16 verifier. Approx verification time ~1/2 that of Arkworks.

Detailed bench output at https://gist.github.com/de4e15a3c20cb5251dbe1fc8ecef190d