### PR TITLE
Remove generic traits from external dependencies in hmac

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_bytes = "0.11.7"
 serde_with = "2.0.1"
 signature = { version = "1.6.4", features = ["rand-preview"] }
-tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
+tokio = { version = "1.21.1", features = ["sync", "rt", "macros"] }
 zeroize = "1.5.7"
 bulletproofs = "4.0.0"
 curve25519-dalek-ng = "4.1.1"

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_bytes = "0.11.7"
 serde_with = "2.0.1"
 signature = { version = "1.6.4", features = ["rand-preview"] }
-tokio = { version = "1.21.1", features = ["sync", "rt", "macros"] }
+tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
 zeroize = "1.5.7"
 bulletproofs = "4.0.0"
 curve25519-dalek-ng = "4.1.1"

--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base64ct::{Base64, Encoding};
+use digest::OutputSizeUser;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::fmt;
@@ -103,6 +104,20 @@ pub trait Hash<const DIGEST_LEN: usize> {
 /// This wraps a `digest::Digest` as a `fastcrypto::hash::HashFunction`.
 #[derive(Default)]
 pub struct HashFunctionWrapper<Variant: digest::Digest + 'static, const DIGEST_LEN: usize>(Variant);
+
+/// This allows us to use the hash functions defined here and use them in place of their
+/// internal functions from the digest crate.
+pub trait ReverseWrapper {
+    type Variant: digest::Digest + 'static + digest::core_api::CoreProxy + OutputSizeUser;
+}
+
+impl<
+        Variant: digest::Digest + 'static + digest::core_api::CoreProxy + OutputSizeUser,
+        const DIGEST_LEN: usize,
+    > ReverseWrapper for HashFunctionWrapper<Variant, DIGEST_LEN>
+{
+    type Variant = Variant;
+}
 
 impl<Variant: digest::Digest + 'static + Default, const DIGEST_LEN: usize> HashFunction<DIGEST_LEN>
     for HashFunctionWrapper<Variant, DIGEST_LEN>

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         BLS12381AggregateSignature, BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey,
         BLS12381PublicKeyBytes, BLS12381Signature,
     },
-    hash::{HashFunction, Sha256},
+    hash::{HashFunction, Sha256, Sha3_256},
     hmac::hkdf_generate_from_ikm,
     traits::{
         AggregateAuthenticator, EncodeDecodeBase64, KeyPair, SigningKey, ToFromBytes, VerifyingKey,
@@ -14,7 +14,6 @@ use crate::{
 };
 use base64ct::Encoding;
 use rand::{rngs::StdRng, SeedableRng as _};
-use sha3::Sha3_256;
 use signature::{Signer, Verifier};
 
 pub fn keys() -> Vec<BLS12381KeyPair> {

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -8,7 +8,7 @@ use crate::{
         Ed25519AggregateSignature, Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey,
         Ed25519PublicKeyBytes, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
     },
-    hash::{HashFunction, Sha256},
+    hash::{HashFunction, Sha256, Sha3_256},
     hmac::hkdf_generate_from_ikm,
     traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
@@ -16,7 +16,6 @@ use base64ct::Encoding;
 use ed25519_consensus::VerificationKey;
 use rand::{rngs::StdRng, SeedableRng as _};
 use serde_reflection::{Samples, Tracer, TracerConfig};
-use sha3::Sha3_256;
 use signature::{Signer, Verifier};
 use wycheproof::{eddsa::TestSet, TestResult};
 

--- a/fastcrypto/src/tests/hmac_tests.rs
+++ b/fastcrypto/src/tests/hmac_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::FastCryptoError;
+use crate::hash::{Sha3_256, Keccak256};
 use crate::hmac::{hkdf, hmac, HkdfIkm, HmacKey};
 use crate::traits::{FromUniformBytes, ToFromBytes};
 use digest::{
@@ -14,7 +15,6 @@ use digest::{
 };
 use hkdf::hmac::Hmac;
 use rand::{rngs::StdRng, SeedableRng};
-use sha3::{Keccak256, Sha3_256};
 
 fn hkdf_wrapper<H>(salt: Option<&[u8]>) -> Vec<u8>
 where


### PR DESCRIPTION
The hkdf_generate_from_ikm function takes the used hash function as a generic, but is currently using hash functions from the digest crate instead of from fastcrypto. This PR fixes that and will enable us to remove dependencies on external hash functions from sui.