### PR TITLE
chore: Small Warts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
+      # make sure benches don't bit-rot
+      - name: build benches
+        run: cargo build --benches --all-features
       - name: cargo test
         run: |
           cargo nextest run --all-features

--- a/deny.toml
+++ b/deny.toml
@@ -66,7 +66,7 @@ ignore = [
 [licenses]
 # The lint level for crates which do not have a detectable license
 unlicensed = "deny"
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
@@ -80,7 +80,7 @@ allow = [
     "Unicode-DFS-2016",
     #"Apache-2.0 WITH LLVM-exception",
 ]
-# List of explictly disallowed licenses
+# List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -58,7 +58,7 @@ fn ark_process_vk(vk: &VerifyingKey<Bls12_381>) -> PreparedVerifyingKey<Bls12_38
     }
 }
 
-// This commputes the result of the multi-pairing involved in the Groth16 verification, using arkworks.
+// This computes the result of the multi-pairing involved in the Groth16 verification, using arkworks.
 // See [`test_multipairing_with_processed_vk`]
 pub fn ark_multipairing_with_prepared_vk(
     pvk: &PreparedVerifyingKey<Bls12_381>,

--- a/fastcrypto-zkp/src/verifier.rs
+++ b/fastcrypto-zkp/src/verifier.rs
@@ -200,7 +200,6 @@ fn multipairing_with_processed_vk(
         .iter()
         .map(bls_g1_affine_to_blst_g1_affine)
         .collect();
-    // TODO: find a more direct way to grab this
     let one = BLST_FR_ONE;
     let ss: Vec<blst_fr> = iter::once(one)
         .chain(x.iter().map(bls_fr_to_blst_fr))

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -90,7 +90,7 @@ impl VerifyingKey for Ed25519PublicKey {
         sigs: &[Self::Sig],
     ) -> Result<(), eyre::Report> {
         if sigs.is_empty() {
-            return Err(eyre!("Critical Error! This behavious can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
+            return Err(eyre!("Critical Error! This behaviour can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
         }
         if sigs.len() != pks.len() {
             return Err(eyre!(

--- a/fastcrypto/src/tests/aes_tests.rs
+++ b/fastcrypto/src/tests/aes_tests.rs
@@ -182,7 +182,7 @@ fn wycheproof_test() {
                 (_, _) => panic!(), // Unhandled error
             };
 
-            // Test returns Ok if succesful and Err if it fails
+            // Test returns Ok if successful and Err if it fails
             assert_eq!(result.is_err(), test.result.must_fail());
         }
     }

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -380,8 +380,8 @@ fn test_hkdf_generate_from_ikm() {
 fn test_public_key_bytes_conversion() {
     let kp = keys().pop().unwrap();
     let pk_bytes: BLS12381PublicKeyBytes = kp.public().into();
-    let rebuilded_pk: BLS12381PublicKey = pk_bytes.try_into().unwrap();
-    assert_eq!(kp.public().as_bytes(), rebuilded_pk.as_bytes());
+    let rebuilt_pk: BLS12381PublicKey = pk_bytes.try_into().unwrap();
+    assert_eq!(kp.public().as_bytes(), rebuilt_pk.as_bytes());
 }
 
 #[tokio::test]

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -471,8 +471,8 @@ fn test_hkdf_generate_from_ikm() {
 fn test_public_key_bytes_conversion() {
     let kp = keys().pop().unwrap();
     let pk_bytes: Ed25519PublicKeyBytes = kp.public().into();
-    let rebuilded_pk: Ed25519PublicKey = pk_bytes.try_into().unwrap();
-    assert_eq!(kp.public().as_bytes(), rebuilded_pk.as_bytes());
+    let rebuilt_pk: Ed25519PublicKey = pk_bytes.try_into().unwrap();
+    assert_eq!(kp.public().as_bytes(), rebuilt_pk.as_bytes());
 }
 
 #[test]

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     traits::{EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
-
+#[cfg(feature = "copy_key")]
 use proptest::arbitrary::Arbitrary;
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -68,8 +68,8 @@ fn import_export_public_key() {
 fn test_public_key_bytes_conversion() {
     let kp = keys().pop().unwrap();
     let pk_bytes: Secp256k1PublicKeyBytes = kp.public().into();
-    let rebuilded_pk: Secp256k1PublicKey = pk_bytes.try_into().unwrap();
-    assert_eq!(kp.public().as_bytes(), rebuilded_pk.as_bytes());
+    let rebuilt_pk: Secp256k1PublicKey = pk_bytes.try_into().unwrap();
+    assert_eq!(kp.public().as_bytes(), rebuilt_pk.as_bytes());
 }
 
 #[test]

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -100,7 +100,7 @@ pub trait VerifyingKey:
     // Expected to be overridden by implementations
     fn verify_batch_empty_fail(msg: &[u8], pks: &[Self], sigs: &[Self::Sig]) -> Result<(), eyre::Report> {
         if sigs.is_empty() {
-            return Err(eyre!("Critical Error! This behavious can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
+            return Err(eyre!("Critical Error! This behaviour can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
         }
         if pks.len() != sigs.len() {
             return Err(eyre!("Mismatch between number of signatures and public keys provided"));

--- a/fastcrypto/src/unsecure/mod.rs
+++ b/fastcrypto/src/unsecure/mod.rs
@@ -9,7 +9,7 @@
 /// Warning: All schemes in this file are completely unsafe to use in production.
 pub mod hash;
 
-/// This module contains an implementation of a negligible-cost (apart from some ocassional pk copying) trivial
+/// This module contains an implementation of a negligible-cost (apart from some occasional pk copying) trivial
 /// cryptographic signature scheme. The purpose of this library is to allow seamless benchmarking of systems
 /// without taking into account the cost of cryptographic primitives - and hence providing a theoretical maximal
 /// throughput that a system could achieve if the cost of crypto is optimized away.

--- a/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
+++ b/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
@@ -336,8 +336,8 @@ fn test_hkdf_generate_from_ikm() {
 fn test_public_key_bytes_conversion() {
     let kp = keys().pop().unwrap();
     let pk_bytes: UnsecurePublicKeyBytes = kp.public().into();
-    let rebuilded_pk: UnsecurePublicKey = pk_bytes.try_into().unwrap();
-    assert_eq!(kp.public().as_bytes(), rebuilded_pk.as_bytes());
+    let rebuilt_pk: UnsecurePublicKey = pk_bytes.try_into().unwrap();
+    assert_eq!(kp.public().as_bytes(), rebuilt_pk.as_bytes());
 }
 
 #[test]


### PR DESCRIPTION
- remove the irritating warning on the unused import of `proptest::arbitrary`
- compile the benches (but don't run them) in CI,
- remove superfluous comment, fix typos.