### PR TITLE
[zkp] Test infinity throughout our test suite as well

### DIFF
--- a/fastcrypto-zkp/src/conversions.rs
+++ b/fastcrypto-zkp/src/conversions.rs
@@ -489,11 +489,15 @@ pub(crate) mod tests {
 
     // QFE roundtrips
     fn arb_bls_fq2() -> impl Strategy<Value = Fq2> {
-        (arb_bls_fq(), arb_bls_fq()).prop_map(|(fp1, fp2)| Fq2::new(fp1, fp2))
+        (arb_bls_fq(), arb_bls_fq())
+            .prop_map(|(fp1, fp2)| Fq2::new(fp1, fp2))
+            .no_shrink()
     }
 
     fn arb_blst_fp2() -> impl Strategy<Value = blst_fp2> {
-        (arb_blst_fp(), arb_blst_fp()).prop_map(|(fp1, fp2)| blst_fp2 { fp: [fp1, fp2] })
+        (arb_blst_fp(), arb_blst_fp())
+            .prop_map(|(fp1, fp2)| blst_fp2 { fp: [fp1, fp2] })
+            .no_shrink()
     }
 
     proptest! {
@@ -517,12 +521,15 @@ pub(crate) mod tests {
     fn arb_bls_fq6() -> impl Strategy<Value = Fq6> {
         (arb_bls_fq2(), arb_bls_fq2(), arb_bls_fq2())
             .prop_map(|(f_c0, f_c1, f_c2)| Fq6::new(f_c0, f_c1, f_c2))
+            .no_shrink()
     }
 
     fn arb_blst_fp6() -> impl Strategy<Value = blst_fp6> {
-        (arb_blst_fp2(), arb_blst_fp2(), arb_blst_fp2()).prop_map(|(f_c0, f_c1, f_c2)| blst_fp6 {
-            fp2: [f_c0, f_c1, f_c2],
-        })
+        (arb_blst_fp2(), arb_blst_fp2(), arb_blst_fp2())
+            .prop_map(|(f_c0, f_c1, f_c2)| blst_fp6 {
+                fp2: [f_c0, f_c1, f_c2],
+            })
+            .no_shrink()
     }
 
     proptest! {
@@ -542,11 +549,15 @@ pub(crate) mod tests {
     }
 
     fn arb_bls_fq12() -> impl Strategy<Value = Fq12> {
-        (arb_bls_fq6(), arb_bls_fq6()).prop_map(|(f_c0, f_c1)| Fq12::new(f_c0, f_c1))
+        (arb_bls_fq6(), arb_bls_fq6())
+            .prop_map(|(f_c0, f_c1)| Fq12::new(f_c0, f_c1))
+            .no_shrink()
     }
 
     fn arb_blst_fp12() -> impl Strategy<Value = blst_fp12> {
-        (arb_blst_fp6(), arb_blst_fp6()).prop_map(|(f_c0, f_c1)| blst_fp12 { fp6: [f_c0, f_c1] })
+        (arb_blst_fp6(), arb_blst_fp6())
+            .prop_map(|(f_c0, f_c1)| blst_fp12 { fp6: [f_c0, f_c1] })
+            .no_shrink()
     }
 
     proptest! {

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -85,10 +85,11 @@ pub fn ark_multipairing_with_prepared_vk(
 const LEN: usize = 10;
 
 proptest! {
-    // This technical test is necessary because blst does not expose
-    // the miller_loop_n operation, and forces us to abuse the signature-oriented pairing engine
+    // This technical test is necessary because blst does not expose a generic multi-miller
+    // loop  operation, and forces us to abuse the signature-oriented pairing engine
     // that it does expose. Here we show the use of the pairing engine is equivalent to iterated
     // use of one-off pairings.
+    // see https://github.com/supranational/blst/issues/136
     #[test]
     fn test_blst_miller_loops(
         a_s in collection::vec(arb_blst_g1_affine().prop_filter("values must be non-infinity", |v| unsafe{!blst_p1_affine_is_inf(v)}), LEN..=LEN),

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use blst::{
     blst_final_exp, blst_fp12, blst_fp12_mul, blst_fr, blst_miller_loop, blst_p1, blst_p1_affine,
-    blst_p1_to_affine, Pairing,
+    blst_p1_affine_is_inf, blst_p1_to_affine, blst_p2_affine_is_inf, Pairing,
 };
 use proptest::{collection, prelude::*};
 use std::{
@@ -91,9 +91,8 @@ proptest! {
     // use of one-off pairings.
     #[test]
     fn test_blst_miller_loops(
-        a_s in collection::vec(arb_blst_g1_affine(), LEN..=LEN),
-        b_s in collection::vec(arb_blst_g2_affine(), LEN..=LEN)
-
+        a_s in collection::vec(arb_blst_g1_affine().prop_filter("values must be non-infinity", |v| unsafe{!blst_p1_affine_is_inf(v)}), LEN..=LEN),
+        b_s in collection::vec(arb_blst_g2_affine().prop_filter("values must be non-infinity", |v| unsafe{!blst_p2_affine_is_inf(v)}), LEN..=LEN)
     ) {
         let pairing_engine_result = {
             let dst = [0u8; 3];


### PR DESCRIPTION
As it turns out, Arkworks also has a non-standard representation of the infinity point. This integrates the infinity point in all randomly-generated tests, and corrects the discrepancies.