### PR TITLE
Let digest type impl debug

### DIFF
--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -96,7 +96,7 @@ pub trait HashFunction<const DIGEST_LENGTH: usize>: Default {
 /// This trait is implemented by all messages that can be hashed.
 pub trait Hash<const DIGEST_LEN: usize> {
     /// The type of the digest when this is hashed.
-    type TypedDigest: Into<Digest<DIGEST_LEN>> + Eq + std::hash::Hash + Copy;
+    type TypedDigest: Into<Digest<DIGEST_LEN>> + Eq + std::hash::Hash + Copy + fmt::Debug;
 
     fn digest(&self) -> Self::TypedDigest;
 }


### PR DESCRIPTION
Compiling Sui with cargo 1.66.0-nightly gives an error when deriving an implementation for Debug for a struct who uses the `Hash` trait to restrict some generic traits. In order to fix this, we restrict the Debug trait for the `TypedDigest`type.

Note that it works with the stable cargo 1.64.0, so it's possible to build using that.