### PR TITLE
HEX encoding benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "ed25519-consensus",
  "eyre",
  "fastcrypto-derive",
+ "faster-hex",
  "generic-array",
  "hex",
  "hex-literal",
@@ -1022,6 +1023,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "readonly",
+ "rustc-hex",
  "secp256k1",
  "serde",
  "serde-reflection",
@@ -1067,6 +1069,12 @@ dependencies = [
  "criterion",
  "proptest",
 ]
+
+[[package]]
+name = "faster-hex"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
 name = "fastrand"
@@ -1779,6 +1787,12 @@ dependencies = [
  "hmac",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -58,6 +58,10 @@ fastcrypto-derive = { path = "../fastcrypto-derive", version = "0.1.2" }
 name = "crypto"
 harness = false
 
+[[bench]]
+name = "encoding"
+harness = false
+
 [features]
 default = ["secure"]
 secure = []
@@ -74,3 +78,5 @@ proptest-derive = "0.3.0"
 serde_json = "1.0.87"
 serde-reflection = "0.3.6"
 wycheproof = "0.4.0"
+faster-hex = "0.6.1"
+rustc-hex = "2.1.0"

--- a/fastcrypto/benches/crypto.rs
+++ b/fastcrypto/benches/crypto.rs
@@ -292,6 +292,15 @@ mod signature_benches {
         });
     }
 
+    fn verification_comparison(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("verification_comparison");
+        group.sampling_mode(SamplingMode::Flat);
+
+        verify_batch_signatures(&mut group);
+        verify_batch_signatures_different_msg(&mut group);
+        group.finish();
+    }
+
     criterion_group! {
         name = signature_benches;
         config = Criterion::default();
@@ -300,16 +309,7 @@ mod signature_benches {
            verify,
            verification_comparison,
            aggregate_signatures,
-           key_generation
-    }
-
-    fn verification_comparison(c: &mut Criterion) {
-        let mut group: BenchmarkGroup<_> = c.benchmark_group("verification_comparison");
-        group.sampling_mode(SamplingMode::Flat);
-
-        verify_batch_signatures(&mut group);
-        verify_batch_signatures_different_msg(&mut group);
-        group.finish();
+           key_generation,
     }
 }
 

--- a/fastcrypto/benches/encoding.rs
+++ b/fastcrypto/benches/encoding.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate criterion;
+
+mod encoding_benches {
+    use super::*;
+    use criterion::*;
+    use faster_hex::{
+        hex_decode, hex_decode_fallback, hex_decode_unchecked, hex_encode_fallback, hex_string,
+    };
+    use rustc_hex::{FromHex, ToHex};
+
+    struct TestMessage<'a> {
+        name: &'a str,
+        value: &'a [u8],
+    }
+
+    const TEST_MESSAGES: &[TestMessage] = &[
+        TestMessage {
+            name: "MSG_20B_ZERO",
+            value: &[0u8; 20],
+        },
+        TestMessage {
+            name: "MSG_32B_ZERO",
+            value: &[0u8; 32],
+        },
+        TestMessage {
+            name: "MSG_20B_RANDOM",
+            value: b"this is a random msg",
+        },
+        TestMessage {
+            name: "MSG_32B_RANDOM",
+            value: b"this is a random msg: (32B long)",
+        },
+    ];
+
+    // TODO: atm we compare against hex encoding crates only, please add base64, bech32, base58 and
+    //  base58check.
+    fn encode(c: &mut Criterion) {
+        for test_message in TEST_MESSAGES {
+            c.bench_function(
+                &("rustc_hex_encode_".to_owned() + test_message.name),
+                move |b| {
+                    b.iter(|| {
+                        let ret: String = test_message.value.to_hex();
+                        black_box(ret);
+                    })
+                },
+            );
+
+            c.bench_function(&("hex_encode_".to_owned() + test_message.name), move |b| {
+                b.iter(|| {
+                    let ret = hex::encode(test_message.value);
+                    black_box(ret);
+                })
+            });
+
+            c.bench_function(
+                &("faster_hex_encode_".to_owned() + test_message.name),
+                move |b| {
+                    b.iter(|| {
+                        let ret = hex_string(test_message.value);
+                        black_box(ret);
+                    })
+                },
+            );
+
+            c.bench_function(
+                &("faster_hex_encode_fallback_".to_owned() + test_message.name),
+                move |b| {
+                    b.iter(|| {
+                        let bytes = test_message.value;
+                        let mut buffer = vec![0; bytes.len() * 2];
+                        hex_encode_fallback(bytes, &mut buffer);
+                    })
+                },
+            );
+        }
+    }
+
+    // TODO: atm we compare against hex decoding crates only, please add base64, bech32, base58 and
+    //  base58check.
+    fn decode(c: &mut Criterion) {
+        for test_message in TEST_MESSAGES {
+            c.bench_function(
+                &("rustc_hex_decode_".to_owned() + test_message.name),
+                move |b| {
+                    let hex: String = test_message.value.to_hex();
+                    b.iter(|| {
+                        let ret: Vec<u8> = hex.from_hex().unwrap();
+                        black_box(ret);
+                    })
+                },
+            );
+
+            c.bench_function(&("hex_decode_".to_owned() + test_message.name), move |b| {
+                let hex: String = test_message.value.to_hex();
+                b.iter(|| {
+                    let ret: Vec<u8> = hex::decode(&hex).unwrap();
+                    black_box(ret);
+                })
+            });
+
+            c.bench_function(
+                &("faster_hex_decode_".to_owned() + test_message.name),
+                move |b| {
+                    let hex: String = test_message.value.to_hex();
+                    let len = test_message.value.len();
+                    b.iter(|| {
+                        let mut dst = vec![0; len];
+                        dst.resize(len, 0);
+                        hex_decode(hex.as_bytes(), &mut dst).unwrap();
+                    })
+                },
+            );
+
+            c.bench_function(
+                &("faster_hex_decode_unchecked_".to_owned() + test_message.name),
+                move |b| {
+                    let hex: String = test_message.value.to_hex();
+                    let len = test_message.value.len();
+                    b.iter(|| {
+                        let mut dst = vec![0; len];
+                        dst.resize(len, 0);
+                        hex_decode_unchecked(hex.as_bytes(), &mut dst);
+                    })
+                },
+            );
+
+            c.bench_function(
+                &("faster_hex_decode_fallback_".to_owned() + test_message.name),
+                move |b| {
+                    let hex: String = test_message.value.to_hex();
+                    let len = test_message.value.len();
+                    b.iter(|| {
+                        let mut dst = vec![0; len];
+                        dst.resize(len, 0);
+                        hex_decode_fallback(hex.as_bytes(), &mut dst);
+                    })
+                },
+            );
+        }
+    }
+
+    criterion_group! {
+        name = encoding_benches;
+        config = Criterion::default();
+        targets =
+            encode,
+            decode,
+    }
+}
+
+criterion_main!(encoding_benches::encoding_benches,);


### PR DESCRIPTION
- Atm we only focus on 20 and 32 byte messages (required for encoding Sui txs, addresses and object IDs)
- Expect Followup PRs for other encoding schemes (base64, base58, base58check, bech32).

ref issue: https://github.com/MystenLabs/fastcrypto/issues/166

Interestingly, 
**faster_hex_encode is 2x faster Vs rustc_hex_encode 
                              and 3x faster Vs hex_encode**
                              
**faster_hex_decode is 3x faster Vs rustc_hex_decode 
                                 and 4x faster Vs hex_decode**

Benchmark Results on Macbook Pro, M1 MAX CPU
```
    Finished bench [optimized] target(s) in 0.49s
     Running benches/encoding.rs (target/release/deps/encoding-2f5adcd41bb7fb7d)
Benchmarking rustc_hex_encode_MSG_20B_ZERO: Collecting 100 samples in estimated rustc_hex_encode_MSG_20B_ZERO
                        time:   [68.508 ns 68.632 ns 68.757 ns]
                        change: [-0.9817% -0.7883% -0.5821%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking hex_encode_MSG_20B_ZERO: Collecting 100 samples in estimated 5.0004hex_encode_MSG_20B_ZERO 
                        time:   [107.24 ns 107.35 ns 107.47 ns]
                        change: [-0.8059% -0.6251% -0.4690%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) high mild
  9 (9.00%) high severe

Benchmarking faster_hex_encode_MSG_20B_ZERO: Collecting 100 samples in estimatedfaster_hex_encode_MSG_20B_ZERO
                        time:   [38.020 ns 38.054 ns 38.097 ns]
                        change: [-0.9029% -0.4851% -0.1262%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking faster_hex_encode_fallback_MSG_20B_ZERO: Collecting 100 samples in faster_hex_encode_fallback_MSG_20B_ZERO
                        time:   [36.612 ns 36.693 ns 36.794 ns]
                        change: [-0.1522% +0.1456% +0.4442%] (p = 0.35 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

Benchmarking rustc_hex_encode_MSG_32B_ZERO: Collecting 100 samples in estimated rustc_hex_encode_MSG_32B_ZERO
                        time:   [97.957 ns 98.085 ns 98.242 ns]
                        change: [-0.4502% -0.0483% +0.3047%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

Benchmarking hex_encode_MSG_32B_ZERO: Collecting 100 samples in estimated 5.0002hex_encode_MSG_32B_ZERO 
                        time:   [151.99 ns 152.15 ns 152.36 ns]
                        change: [-0.2781% -0.0990% +0.0639%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Benchmarking faster_hex_encode_MSG_32B_ZERO: Collecting 100 samples in estimatedfaster_hex_encode_MSG_32B_ZERO
                        time:   [42.012 ns 42.084 ns 42.170 ns]
                        change: [-0.2687% -0.0286% +0.1885%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

Benchmarking faster_hex_encode_fallback_MSG_32B_ZERO: Collecting 100 samples in faster_hex_encode_fallback_MSG_32B_ZERO
                        time:   [41.306 ns 41.376 ns 41.456 ns]
                        change: [-0.4513% -0.1435% +0.2042%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe

Benchmarking rustc_hex_encode_MSG_20B_RANDOM: Collecting 100 samples in estimaterustc_hex_encode_MSG_20B_RANDOM
                        time:   [68.186 ns 68.238 ns 68.298 ns]
                        change: [-0.1582% +0.0041% +0.1545%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

Benchmarking hex_encode_MSG_20B_RANDOM: Collecting 100 samples in estimated 5.00hex_encode_MSG_20B_RANDOM
                        time:   [107.21 ns 107.32 ns 107.46 ns]
                        change: [-2.0571% -1.8432% -1.6282%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

Benchmarking faster_hex_encode_MSG_20B_RANDOM: Collecting 100 samples in estimatfaster_hex_encode_MSG_20B_RANDOM
                        time:   [37.920 ns 37.988 ns 38.073 ns]
                        change: [-2.0715% -1.8432% -1.6152%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

Benchmarking faster_hex_encode_fallback_MSG_20B_RANDOM: Collecting 100 samples ifaster_hex_encode_fallback_MSG_20B_RANDOM
                        time:   [36.586 ns 36.629 ns 36.675 ns]
                        change: [-1.9616% -1.6053% -1.2829%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking rustc_hex_encode_MSG_32B_RANDOM: Collecting 100 samples in estimaterustc_hex_encode_MSG_32B_RANDOM
                        time:   [98.145 ns 98.449 ns 98.853 ns]
                        change: [-0.5973% -0.2168% +0.1657%] (p = 0.29 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) high mild
  11 (11.00%) high severe

Benchmarking hex_encode_MSG_32B_RANDOM: Collecting 100 samples in estimated 5.00hex_encode_MSG_32B_RANDOM
                        time:   [152.14 ns 152.35 ns 152.60 ns]
                        change: [-0.6751% -0.5244% -0.3662%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking faster_hex_encode_MSG_32B_RANDOM: Collecting 100 samples in estimatfaster_hex_encode_MSG_32B_RANDOM
                        time:   [41.959 ns 42.002 ns 42.055 ns]
                        change: [-0.8442% -0.6092% -0.3909%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking faster_hex_encode_fallback_MSG_32B_RANDOM: Collecting 100 samples ifaster_hex_encode_fallback_MSG_32B_RANDOM
                        time:   [41.281 ns 41.331 ns 41.390 ns]
                        change: [-0.0443% +0.1315% +0.3076%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

Benchmarking rustc_hex_decode_MSG_20B_ZERO: Collecting 100 samples in estimated rustc_hex_decode_MSG_20B_ZERO
                        time:   [146.28 ns 146.53 ns 146.87 ns]
                        change: [-0.4563% -0.1676% +0.0789%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

Benchmarking hex_decode_MSG_20B_ZERO: Collecting 100 samples in estimated 5.0005hex_decode_MSG_20B_ZERO 
                        time:   [207.72 ns 209.00 ns 210.30 ns]
                        change: [-1.2123% -0.5673% +0.0911%] (p = 0.10 > 0.05)
                        No change in performance detected.

Benchmarking faster_hex_decode_MSG_20B_ZERO: Collecting 100 samples in estimated faster_hex_decode_MSG_20B_ZERO
                        time:   [47.491 ns 47.579 ns 47.679 ns]
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

Benchmarking faster_hex_decode_unchecked_MSG_20B_ZERO: Collecting 100 samples in faster_hex_decode_uncheckedMSG_20B_ZERO
                        time:   [34.437 ns 34.478 ns 34.521 ns]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

Benchmarking faster_hex_decode_fallback_MSG_20B_ZERO: Collecting 100 samples in faster_hex_decode_fallbackMSG_20B_ZERO
                        time:   [34.409 ns 34.462 ns 34.531 ns]
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

Benchmarking rustc_hex_decode_MSG_32B_ZERO: Collecting 100 samples in estimated rustc_hex_decode_MSG_32B_ZERO
                        time:   [213.49 ns 213.81 ns 214.25 ns]
Found 26 outliers among 100 measurements (26.00%)
  17 (17.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe

Benchmarking hex_decode_MSG_32B_ZERO: Collecting 100 samples in estimated 5.0004hex_decode_MSG_32B_ZERO 
                        time:   [307.29 ns 308.45 ns 309.53 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking faster_hex_decode_MSG_32B_ZERO: Collecting 100 samples in estimatedfaster_hex_decode_MSG_32B_ZERO
                        time:   [63.495 ns 63.710 ns 64.096 ns]
Found 34 outliers among 100 measurements (34.00%)
  14 (14.00%) low severe
  3 (3.00%) low mild
  8 (8.00%) high mild
  9 (9.00%) high severe

Benchmarking faster_hex_decode_unchecked_MSG_32B_ZERO: Collecting 100 samples in faster_hex_decode_uncheckedMSG_32B_ZERO
                        time:   [42.115 ns 42.582 ns 43.321 ns]
Found 16 outliers among 100 measurements (16.00%)
  9 (9.00%) high mild
  7 (7.00%) high severe

Benchmarking faster_hex_decode_fallback_MSG_32B_ZERO: Collecting 100 samples in efaster_hex_decode_fallbackMSG_32B_ZERO
                        time:   [42.028 ns 42.194 ns 42.402 ns]
Found 16 outliers among 100 measurements (16.00%)
  9 (9.00%) high mild
  7 (7.00%) high severe

Benchmarking rustc_hex_decode_MSG_20B_RANDOM: Collecting 100 samples in estimaterustc_hex_decode_MSG_20B_RANDOM
                        time:   [146.39 ns 146.61 ns 146.89 ns]
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

Benchmarking hex_decode_MSG_20B_RANDOM: Collecting 100 samples in estimated 5.00hex_decode_MSG_20B_RANDOM
                        time:   [186.58 ns 187.07 ns 187.60 ns]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Benchmarking faster_hex_decode_MSG_20B_RANDOM: Collecting 100 samples in estimatfaster_hex_decode_MSG_20B_RANDOM
                        time:   [47.247 ns 47.312 ns 47.393 ns]
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

Benchmarking faster_hex_decode_unchecked_MSG_20B_RANDOM: Collecting 100 samples ifaster_hex_decode_uncheckedMSG_20B_RANDOM
                        time:   [34.092 ns 34.126 ns 34.166 ns]
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

Benchmarking faster_hex_decode_fallbackMSG_20B_RANDOM: Collecting 100 samples infaster_hex_decode_fallback_MSG_20B_RANDOM
                        time:   [34.160 ns 34.202 ns 34.250 ns]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

Benchmarking rustc_hex_decode_MSG_32B_RANDOM: Collecting 100 samples in estimaterustc_hex_decode_MSG_32B_RANDOM
                        time:   [192.29 ns 192.48 ns 192.70 ns]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe

Benchmarking hex_decode_MSG_32B_RANDOM: Collecting 100 samples in estimated 5.00hex_decode_MSG_32B_RANDOM
                        time:   [258.47 ns 258.95 ns 259.46 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking faster_hex_decode_MSG_32B_RANDOM: Collecting 100 samples in estimatfaster_hex_decode_MSG_32B_RANDOM
                        time:   [62.531 ns 62.613 ns 62.707 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking faster_hex_decode_unchecked_MSG_32B_RANDOM: Collecting 100 samples ifaster_hex_decode_uncheckedMSG_32B_RANDOM
                        time:   [40.919 ns 40.982 ns 41.059 ns]
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) high mild
  10 (10.00%) high severe

Benchmarking faster_hex_decode_fallback_MSG_32B_RANDOM: Collecting 100 samples infaster_hex_decode_fallbackMSG_32B_RANDOM
                        time:   [41.282 ns 41.390 ns 41.522 ns]
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe
```