### PR TITLE
Add missing dependency for unsecure signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,7 @@ dependencies = [
  "schemars",
  "secp256k1",
  "serde",
+ "serde-big-array",
  "serde-reflection",
  "serde_bytes",
  "serde_json",
@@ -2014,6 +2015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -21,6 +21,7 @@ rust_secp256k1 = { version = "0.24.0", package = "secp256k1", features = ["recov
 serde = { version = "1.0.147", features = ["derive"] }
 serde_bytes = "0.11.7"
 serde_with = "2.0.1"
+serde-big-array = { version = "0.4.1", optional = true }
 signature = { version = "1.6.4", features = ["rand-preview"] }
 tokio = { version = "1.21.1", features = ["sync", "rt", "macros"] }
 zeroize = "1.5.7"
@@ -67,7 +68,7 @@ harness = false
 default = ["secure", "threads-bls_12_377"]
 secure = []
 copy_key = []
-unsecure_schemes = ["dep:twox-hash"]
+unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]
 no-threads-blst = ["blst/no-threads"]
 threads-bls_12_377 = ["celo-bls/parallel", "ark-ec/parallel", "ark-ff/parallel", "ark-std/parallel"]
 


### PR DESCRIPTION
The unsecure signature scheme needs the serde-big-arrays crate, but this was accidentally not added to Cargo.toml in PR #173 