### PR TITLE
Add AllowedRng trait

### DIFF
--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use eyre::eyre;
 
+use rand::rngs::{StdRng, ThreadRng};
 use rand::{CryptoRng, RngCore};
 use serde::{de::DeserializeOwned, Serialize};
 pub use signature::Signer;
@@ -11,7 +12,6 @@ use std::{
     fmt::{Debug, Display},
     str::FromStr,
 };
-use rand::rngs::{StdRng, ThreadRng};
 
 use crate::{
     encoding::{Base64, Encoding},
@@ -299,4 +299,3 @@ pub trait AllowedRng: CryptoRng + RngCore {}
 // TODO: Deprecate StdRng (expect for tests) and use thread_rng() everywhere.
 impl AllowedRng for StdRng {}
 impl AllowedRng for ThreadRng {}
-

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -292,10 +292,13 @@ pub trait FromUniformBytes<const LENGTH: usize>: ToFromBytes {
     }
 }
 
-// Whitelist of the RNG our APIs accept (see https://rust-random.github.io/book/guide-rngs.html for
+// Whitelist the RNG our APIs accept (see https://rust-random.github.io/book/guide-rngs.html for
 // others).
 pub trait AllowedRng: CryptoRng + RngCore {}
-// The next two use ChaCha12 (see https://github.com/rust-random/rand/issues/932).
+
+// StdRng uses ChaCha12 (see https://github.com/rust-random/rand/issues/932).
+// It should be seeded with OsRng (e.g., StdRng::from_rng(OsRng)).
 // TODO: Deprecate StdRng (expect for tests) and use thread_rng() everywhere.
 impl AllowedRng for StdRng {}
+// thread_rng() uses OsRng for the seed, and ChaCha12 as the PRG function.
 impl AllowedRng for ThreadRng {}


### PR DESCRIPTION
We should be more restrictive with the RNG we work with. This adds a trait for that. 
(Updating the existing APIs will be done in a follow up PR).

The default for StdRng and ThreadRng is ChaCha12 (https://github.com/rust-random/rand/issues/932)

Ideally our callers should use something like StdRng::from_rng(rand::rngs::OsRng) or just thread_rng, but for now we don't restrict that.