### PR TITLE
Fix bug in test_sk_zeroization_on_drop for BLS12377

### DIFF
--- a/fastcrypto/src/tests/bls12377_tests.rs
+++ b/fastcrypto/src/tests/bls12377_tests.rs
@@ -433,10 +433,15 @@ fn test_sk_zeroization_on_drop() {
         bytes_ptr = &sk.as_ref()[0] as *const u8;
 
         // Assert the exact location in SecretKey is stored as private key bytes.
-        let privkey_bytes =
-            unsafe { std::slice::from_raw_parts(ptr.add(41), CELO_BLS_PRIVATE_KEY_LENGTH) };
-        assert_eq!(privkey_bytes, &sk_bytes[..]);
-
+        unsafe {
+            for (i, &byte) in sk_bytes
+                .iter()
+                .enumerate()
+                .take(CELO_BLS_PRIVATE_KEY_LENGTH)
+            {
+                assert_eq!(*ptr.add(i + 41), byte);
+            }
+        }
         // Assert that this is equal to sk_bytes before deletion.
         let sk_memory: &[u8] =
             unsafe { std::slice::from_raw_parts(bytes_ptr, CELO_BLS_PRIVATE_KEY_LENGTH) };

--- a/fastcrypto/src/tests/bls12377_tests.rs
+++ b/fastcrypto/src/tests/bls12377_tests.rs
@@ -433,25 +433,20 @@ fn test_sk_zeroization_on_drop() {
         bytes_ptr = &sk.as_ref()[0] as *const u8;
 
         // Assert the exact location in SecretKey is stored as private key bytes.
-        unsafe {
-            let bytes: Vec<u8> = (0..CELO_BLS_PRIVATE_KEY_LENGTH)
-                .map(|i| *ptr.add(i + 41))
-                .collect();
-            assert_eq!(bytes, sk_bytes);
-        }
+        let privkey_bytes =
+            unsafe { std::slice::from_raw_parts(ptr.add(41), CELO_BLS_PRIVATE_KEY_LENGTH) };
+        assert_eq!(privkey_bytes, &sk_bytes[..]);
+
+        // Assert that this is equal to sk_bytes before deletion.
         let sk_memory: &[u8] =
             unsafe { std::slice::from_raw_parts(bytes_ptr, CELO_BLS_PRIVATE_KEY_LENGTH) };
-        // Assert that this is equal to sk_bytes before deletion.
         assert_eq!(sk_memory, &sk_bytes[..]);
     }
 
     // Assert the exact position in SecretKey is no longer private key bytes.
-    unsafe {
-        let bytes: Vec<u8> = (0..CELO_BLS_PRIVATE_KEY_LENGTH)
-            .map(|i| *ptr.add(i + 41))
-            .collect();
-        assert_ne!(bytes, sk_bytes);
-    }
+    let privkey_bytes =
+        unsafe { std::slice::from_raw_parts(ptr.add(41), CELO_BLS_PRIVATE_KEY_LENGTH) };
+    assert_ne!(privkey_bytes, &sk_bytes[..]);
 
     // Check that self.bytes is reset to OnceCell default.
     let sk_memory: &[u8] =

--- a/fastcrypto/src/tests/bls12377_tests.rs
+++ b/fastcrypto/src/tests/bls12377_tests.rs
@@ -442,9 +442,9 @@ fn test_sk_zeroization_on_drop() {
                 assert_eq!(*ptr.add(i + 41), byte);
             }
         }
-        // Assert that this is equal to sk_bytes before deletion.
         let sk_memory: &[u8] =
             unsafe { std::slice::from_raw_parts(bytes_ptr, CELO_BLS_PRIVATE_KEY_LENGTH) };
+        // Assert that this is equal to sk_bytes before deletion.
         assert_eq!(sk_memory, &sk_bytes[..]);
     }
 

--- a/fastcrypto/src/tests/bls12377_tests.rs
+++ b/fastcrypto/src/tests/bls12377_tests.rs
@@ -434,13 +434,10 @@ fn test_sk_zeroization_on_drop() {
 
         // Assert the exact location in SecretKey is stored as private key bytes.
         unsafe {
-            for (i, &byte) in sk_bytes
-                .iter()
-                .enumerate()
-                .take(CELO_BLS_PRIVATE_KEY_LENGTH)
-            {
-                assert_eq!(*ptr.add(i + 41), byte);
-            }
+            let bytes: Vec<u8> = (0..CELO_BLS_PRIVATE_KEY_LENGTH)
+                .map(|i| *ptr.add(i + 41))
+                .collect();
+            assert_eq!(bytes, sk_bytes);
         }
         let sk_memory: &[u8] =
             unsafe { std::slice::from_raw_parts(bytes_ptr, CELO_BLS_PRIVATE_KEY_LENGTH) };
@@ -450,13 +447,10 @@ fn test_sk_zeroization_on_drop() {
 
     // Assert the exact position in SecretKey is no longer private key bytes.
     unsafe {
-        for (i, &byte) in sk_bytes
-            .iter()
-            .enumerate()
-            .take(CELO_BLS_PRIVATE_KEY_LENGTH)
-        {
-            assert_ne!(*ptr.add(i + 41), byte);
-        }
+        let bytes: Vec<u8> = (0..CELO_BLS_PRIVATE_KEY_LENGTH)
+            .map(|i| *ptr.add(i + 41))
+            .collect();
+        assert_ne!(bytes, sk_bytes);
     }
 
     // Check that self.bytes is reset to OnceCell default.


### PR DESCRIPTION
The test_sk_zeroization_on_drop test for BLS12377 fails sometimes because one of the bytes from the secret key not changing before [this check](https://github.com/MystenLabs/fastcrypto/blob/b35b63a15761d38513b7e0bc55e378fcdacf8923/fastcrypto/src/tests/bls12377_tests.rs#L458) will cause the test to fail. We instead check that not _all_ the bytes are still equal.