### PR TITLE
Add benchmarking workflow to CI

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -19,7 +19,7 @@ name: Benchmarking
        - name: Install criterion
          run: cargo install cargo-criterion
        - name: Run benchmarks
-         run: cargo criterion Verify/ --message-format=json > ${{ github.sha }}.json
+         run: cargo criterion --message-format=json > ${{ github.sha }}.json
        - name: Deploy latest benchmark report
          uses: peaceiris/actions-gh-pages@v3
          with:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 
- jobs:
+jobs:
    benchmark:
      name: Continuous benchmarking
      runs-on: ubuntu-ghcloud

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,0 +1,36 @@
+name: Benchmarking
+  on:
+    workflow_dispatch:
+    release:
+      types: [published]
+
+ jobs:
+   benchmark:
+     name: Continuous benchmarking
+     runs-on: ubuntu-ghcloud
+     steps:
+       - uses: actions/checkout@v3
+       - name: Get old benchmarks
+         uses: actions/checkout@v3
+         with:
+           ref: gh-pages
+           path: gh-pages
+       - run: mkdir -p target; cp -r gh-pages/benchmarks/criterion target;
+       - name: Install criterion
+         run: cargo install cargo-criterion
+       - name: Run benchmarks
+         run: cargo criterion Verify/ --message-format=json > ${{ github.sha }}.json
+       - name: Deploy latest benchmark report
+         uses: peaceiris/actions-gh-pages@v3
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: ./target/criterion
+           destination_dir: benchmarks/criterion
+       - name: Move benchmark json to history
+         run: mkdir history; cp ${{ github.sha }}.json history/
+       - name: Deploy benchmark history
+         uses: peaceiris/actions-gh-pages@v3
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: history/
+           destination_dir: benchmarks/history

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,8 +1,8 @@
 name: Benchmarking
-  on:
-    workflow_dispatch:
-    release:
-      types: [published]
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
 
  jobs:
    benchmark:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
+          destination_dir: docs


### PR DESCRIPTION
Closing #181. PR #209 should be merged first.

This PR adds benchmarking to the CI.
- Running all benchmarks takes ~1 hour, so we only do it on publish, but it may also be triggered manually.
- We use cargo criterion to run benchmarks and generate reports:
    - In order to keep history of benchmarks, we first checkout the old reports from gh-pages
    - Then we use cargo criterion to run all benchmarks with the most recent version of fastcrypto and generate reports,
    - The new reports (including history) are pushed to gh-pages. See https://mystenlabs.github.io/fastcrypto/benchmarks/criterion/reports/ for an incomplete report (not all benchmarks have been run yet), and https://mystenlabs.github.io/fastcrypto/benchmarks/criterion/reports/Verify/Ed25519/history.html for an example of how the history of a benchmark is shown.
    - The results are stored as a JSON-file and stored under benchmarks/history with the latest commit hash as the filename. This allows analysis of historic data and comparison of versions using various analysis tools.

This restructures the gh-pages such that documentation is put under "docs" and benchmarks under "benchmarks".