### PR TITLE
Reduce benchmark sample size

### DIFF
--- a/fastcrypto/benches/crypto.rs
+++ b/fastcrypto/benches/crypto.rs
@@ -368,7 +368,7 @@ mod signature_benches {
 
     criterion_group! {
         name = signature_benches;
-        config = Criterion::default();
+        config = Criterion::default().sample_size(20);
         targets =
            sign,
            verify,


### PR DESCRIPTION
This PR reduces the sample size from 100 to 20 per benchmark. This is done to reduce the time spent when running the benchmark action.