### PR TITLE
crypto: fix serde to use encode_with_format

### DIFF
--- a/fastcrypto/src/encoding.rs
+++ b/fastcrypto/src/encoding.rs
@@ -84,7 +84,7 @@ impl Hex {
     }
     /// Encodes bytes as a hex string.
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        Self(Self::encode(bytes))
+        Self(encode_with_format(bytes))
     }
 }
 
@@ -148,7 +148,7 @@ where
     where
         S: Serializer,
     {
-        Self::encode(value).serialize(serializer)
+        encode_with_format(value).serialize(serializer)
     }
 }
 

--- a/fastcrypto/src/tests/encoding_tests.rs
+++ b/fastcrypto/src/tests/encoding_tests.rs
@@ -24,6 +24,20 @@ fn test_hex_encode_format() {
 }
 
 #[test]
+fn test_serde() {
+    let bytes = &[1];
+    let encoded = Hex::from_bytes(bytes);
+
+    let encoded_str = serde_json::to_string(&encoded).unwrap();
+    let decoded: Hex = serde_json::from_str(&encoded_str).unwrap();
+    assert_eq!("\"0x01\"", encoded_str);
+    assert_eq!(
+        decoded.to_vec().as_ref().unwrap(),
+        encoded.to_vec().as_ref().unwrap()
+    );
+}
+
+#[test]
 fn test_rfc4648_base64() {
     // Test vectors from https://www.rfc-editor.org/rfc/rfc4648
     assert_eq!(Base64::encode(""), "");


### PR DESCRIPTION
sui relies on serde in fastcrypto to include 0x in many cases.