### PR TITLE
crypto: Add Base58 encoding

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/MystenLabs/fastcrypto"
 [dependencies]
 ark-bls12-377 = { version = "0.3.0", features = ["std"] }
 base64ct = { version = "1.5.3", features = ["alloc"] }
+bs58 = "0.4.0"
 ed25519-consensus = { version = "2.0.1", features = ["serde"] }
 eyre = "0.6.8"
 hex = "0.4.3"
@@ -87,6 +88,5 @@ faster-hex = "0.6.1"
 rustc-hex = "2.1.0"
 base64 = "0.13.1"
 radix64 = "0.6.2"
-bs58 = "0.4.0"
 base58 = "0.2.0"
 rust-base58 = "0.0.4"

--- a/fastcrypto/src/tests/encoding_tests.rs
+++ b/fastcrypto/src/tests/encoding_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::encoding::{encode_with_format, Base64, Encoding, Hex};
+use crate::encoding::{encode_with_format, Base58, Base64, Encoding, Hex};
 use proptest::{arbitrary::Arbitrary, prop_assert_eq};
 #[test]
 fn test_hex_roundtrip() {
@@ -59,6 +59,39 @@ fn test_base64_err() {
     assert!(Base64::try_from("SGVsbA====".to_string()).is_err());
 }
 
+#[test]
+fn test_vectors_ietf_base58() {
+    // Test vectors from https://datatracker.ietf.org/doc/html/draft-msporny-base58-03#section-5
+    assert_eq!(Base58::encode("Hello World!"), "2NEpo7TZRRrLZSi2U");
+    assert_eq!(
+        Base58::encode("The quick brown fox jumps over the lazy dog."),
+        "USm3fpXnKG5EUBx2ndxBDMPVciP5hGey2Jh4NDv6gmeo1LkMeiKrLJUUBk6Z"
+    );
+    assert_eq!(
+        Base58::encode(Hex::decode("0x0000287fb4cd").unwrap()),
+        "11233QC4"
+    );
+
+    // Test vectors from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
+    assert_eq!(
+        Base58::encode(Hex::decode("00000000000000000000").unwrap()),
+        "1111111111"
+    );
+    assert_eq!(Base58::encode(Hex::decode("10c8511e").unwrap()), "Rt5zm");
+    assert_eq!(
+        Base58::encode(Hex::decode("ecac89cad93923c02321").unwrap()),
+        "EJDM8drfXA6uyA"
+    );
+    assert_eq!(Base58::encode(Hex::decode("000111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5").unwrap()), "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
+}
+
+#[test]
+fn test_base58_err() {
+    // Test vectors from https://github.com/bitcoin/bitcoin/blob/master/src/test/base58_tests.cpp
+    assert!(Base58::try_from("bad0IOl".to_string()).is_err());
+    assert!(Base58::try_from("invalid\0".to_string()).is_err());
+}
+
 proptest::proptest! {
     #[test]
     fn roundtrip_hex(bytes in <[u8; 20]>::arbitrary()) {
@@ -71,6 +104,13 @@ proptest::proptest! {
     fn roundtrip_base64(bytes in <[u8; 20]>::arbitrary()) {
         let encoded = Base64::from_bytes(&bytes);
         let decoded = encoded.to_vec().unwrap();
+        prop_assert_eq!(bytes, decoded.as_slice());
+    }
+
+    #[test]
+    fn roundtrip_base58(bytes in <[u8; 20]>::arbitrary()) {
+        let encoded = Base58::encode(bytes);
+        let decoded = Base58::decode(&encoded).unwrap();
         prop_assert_eq!(bytes, decoded.as_slice());
     }
 }


### PR DESCRIPTION
from benchmark result, bs58 is the winning encoding scheme

```
Base58 encoding/bs58_encode_MSG_64B_ZERO
                        time:   [141.77 ns 142.22 ns 142.72 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Base58 encoding/base58_encode_MSG_64B_ZERO
                        time:   [157.48 ns 158.25 ns 159.08 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Base58 encoding/rust_base58_encode_MSG_64B_ZERO
                        time:   [287.63 ns 288.30 ns 289.05 ns]
```