### PR TITLE
[ristretto] Derive ops for easy group definitions (PoC)

### DIFF
--- a/fastcrypto-derive/src/lib.rs
+++ b/fastcrypto-derive/src/lib.rs
@@ -9,7 +9,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::DeriveInput;
+use syn::{parse_macro_input, DeriveInput};
 
 /// Derive the `SilentDisplay` trait, which is an implementation of `Display` that does not print the contents of the struct.
 /// This is useful for structs that contain sensitive data, such as private keys.
@@ -29,9 +29,9 @@ pub fn silent_display(source: TokenStream) -> TokenStream {
     gen.into()
 }
 
-#[proc_macro_derive(SilentDebug)]
 /// Derive the `SilentDebug` trait, which is an implementation of `Debug` that does not print the contents of the struct.
 /// This is useful for structs that contain sensitive data, such as private keys.
+#[proc_macro_derive(SilentDebug)]
 pub fn silent_debug(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
@@ -45,4 +45,155 @@ pub fn silent_debug(source: TokenStream) -> TokenStream {
         }
     };
     gen.into()
+}
+
+/// Add<&Self>, Add<Self> for a NewType which inner type has an Add<&Self> for Self
+#[proc_macro_derive(AddSelfRef)]
+pub fn derive_add_self_ref_newtype(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+    let name = &item.ident;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        #[automatically_derived]
+        impl <#impl_generics> ::core::ops::Add<&Self> for #name #ty_generics #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn add(self, other: &Self) -> Self::Output {
+                Self(self.0 + &other.0)
+            }
+        }
+
+        #[automatically_derived]
+        impl #impl_generics ::core::ops::Add<Self> for #name #ty_generics #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn add(self, other: Self) -> Self::Output {
+                Self(self.0 + &other.0)
+            }
+        }
+    )
+    .into()
+}
+
+/// AddAssign<&Self>, AddAssign<Self> for a NewType which inner type has an AddAssign<&Self> for Self
+#[proc_macro_derive(AddAssignSelfRef)]
+pub fn derive_add_assign_self_ref_newtype(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+    let name = &item.ident;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        #[automatically_derived]
+        impl #impl_generics ::core::ops::AddAssign<&Self> for #name #ty_generics #where_clause
+        {
+            #[inline]
+            fn add_assign(&mut self, other: &Self) {
+                self.0 += &other.0
+            }
+        }
+
+        #[automatically_derived]
+        impl #impl_generics ::core::ops::AddAssign<Self> for #name #ty_generics #where_clause
+        {
+            #[inline]
+            fn add_assign(&mut self, other: Self) {
+                self.0 += &other.0
+            }
+        }
+    )
+    .into()
+}
+
+/// Sub<&Self>, Sub<Self> for a NewType which inner type has a Sub<&Self> for Self
+#[proc_macro_derive(SubSelfRef)]
+pub fn derive_sub_self_ref_newtype(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+    let name = &item.ident;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        #[automatically_derived]
+        impl #impl_generics ::core::ops::Sub<&Self> for #name #ty_generics #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn sub(self, other: &Self) -> Self::Output {
+                Self(self.0 - &other.0)
+            }
+        }
+
+        #[automatically_derived]
+        impl #impl_generics ::core::ops::Sub<Self> for #name #ty_generics #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn sub(self, other: Self) -> Self::Output {
+                Self(self.0 - &other.0)
+            }
+        }
+    )
+    .into()
+}
+
+/// SubAssign<&Self>, SubAssign<Self> for a NewType which inner type has a SubAssign<&Self> for Self
+#[proc_macro_derive(SubAssignSelfRef)]
+pub fn derive_sub_assign_self_ref_newtype(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+    let name = &item.ident;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        #[automatically_derived]
+        impl <#impl_generics> ::core::ops::SubAssign<&Self> for #name #ty_generics #where_clause
+        {
+            #[inline]
+            fn sub_assign(&mut self, other: &Self) {
+                self.0 -= &other.0
+            }
+        }
+
+        #[automatically_derived]
+        impl <#impl_generics> ::core::ops::SubAssign<Self> for #name #ty_generics #where_clause
+        {
+            #[inline]
+            fn sub_assign(&mut self, other: Self) {
+                self.0 -= &other.0
+            }
+        }
+    )
+    .into()
+}
+
+/// Neg for a NewType which inner type has an Neg for Self
+#[proc_macro_derive(NegSelf)]
+pub fn derive_neg_self_newtype(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+    let name = &item.ident;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        #[automatically_derived]
+        impl #impl_generics ::core::ops::Neg for #name #ty_generics #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn neg(self) -> Self::Output {
+                Self(- self.0)
+            }
+        }
+    )
+    .into()
 }

--- a/fastcrypto-derive/tests/newtype.rs
+++ b/fastcrypto-derive/tests/newtype.rs
@@ -3,7 +3,7 @@
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use fastcrypto_derive::{
     AddAssignSelfRef, AddSelfRef, MulAssignSelfRef, MulSelfRef, NegSelf, SubAssignSelfRef,
-    SubSelfRef,
+    SubSelfRef, SumSelfRef,
 };
 
 #[derive(
@@ -14,6 +14,7 @@ use fastcrypto_derive::{
     NegSelf,
     MulSelfRef,
     MulAssignSelfRef,
+    SumSelfRef,
 )]
 #[ScalarType = "Bar"]
 struct Foo(i64);
@@ -91,4 +92,13 @@ fn test_mul_assign_self_ref() {
     assert_eq!(foo1.0, 6);
     foo3.mul_assign(foo2);
     assert_eq!(foo3.0, 10);
+}
+
+#[test]
+fn test_sum_self_ref() {
+    let foo1 = Foo(1);
+    let foo2 = Foo(2);
+    let foo3 = Foo(3);
+
+    assert_eq!(vec![foo1, foo2, foo3].iter().sum::<Foo>().0, 6);
 }

--- a/fastcrypto-derive/tests/newtype.rs
+++ b/fastcrypto-derive/tests/newtype.rs
@@ -1,10 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
-use fastcrypto_derive::{AddAssignSelfRef, AddSelfRef, NegSelf, SubAssignSelfRef, SubSelfRef};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use fastcrypto_derive::{
+    AddAssignSelfRef, AddSelfRef, MulAssignSelfRef, MulSelfRef, NegSelf, SubAssignSelfRef,
+    SubSelfRef,
+};
 
-#[derive(AddSelfRef, AddAssignSelfRef, SubSelfRef, SubAssignSelfRef, NegSelf)]
+#[derive(
+    AddSelfRef,
+    AddAssignSelfRef,
+    SubSelfRef,
+    SubAssignSelfRef,
+    NegSelf,
+    MulSelfRef,
+    MulAssignSelfRef,
+)]
+#[ScalarType = "Bar"]
 struct Foo(i64);
+
+struct Bar(i64);
 
 #[test]
 fn test_add_self_ref() {
@@ -55,4 +69,26 @@ fn test_neg_self() {
     let foo1 = Foo(3);
 
     assert_eq!((foo1.neg()).0, -3);
+}
+
+#[test]
+fn test_mul_self_ref() {
+    let foo1 = Foo(1);
+    let foo2 = Bar(2);
+    let foo3 = Foo(3);
+
+    assert_eq!(foo1.mul(&foo2).0, 2);
+    assert_eq!(foo3.mul(foo2).0, 6);
+}
+
+#[test]
+fn test_mul_assign_self_ref() {
+    let mut foo1 = Foo(3);
+    let foo2 = Bar(2);
+    let mut foo3 = Foo(5);
+
+    foo1.mul_assign(&foo2);
+    assert_eq!(foo1.0, 6);
+    foo3.mul_assign(foo2);
+    assert_eq!(foo3.0, 10);
 }

--- a/fastcrypto-derive/tests/newtype.rs
+++ b/fastcrypto-derive/tests/newtype.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+use fastcrypto_derive::{AddAssignSelfRef, AddSelfRef, NegSelf, SubAssignSelfRef, SubSelfRef};
+
+#[derive(AddSelfRef, AddAssignSelfRef, SubSelfRef, SubAssignSelfRef, NegSelf)]
+struct Foo(i64);
+
+#[test]
+fn test_add_self_ref() {
+    let foo1 = Foo(1);
+    let foo2 = Foo(2);
+    let foo3 = Foo(3);
+
+    assert_eq!(foo1.add(&foo2).0, 3);
+    assert_eq!(foo3.add(foo2).0, 5);
+}
+
+#[test]
+fn test_add_assign_self_ref() {
+    let mut foo1 = Foo(1);
+    let foo2 = Foo(2);
+    let mut foo3 = Foo(3);
+
+    foo1.add_assign(&foo2);
+    assert_eq!(foo1.0, 3);
+    foo3.add_assign(foo2);
+    assert_eq!(foo3.0, 5);
+}
+
+#[test]
+fn test_sub_self_ref() {
+    let foo1 = Foo(3);
+    let foo2 = Foo(2);
+    let foo3 = Foo(5);
+
+    assert_eq!(foo1.sub(&foo2).0, 1);
+    assert_eq!(foo3.sub(foo2).0, 3);
+}
+
+#[test]
+fn test_sub_assign_self_ref() {
+    let mut foo1 = Foo(3);
+    let foo2 = Foo(2);
+    let mut foo3 = Foo(5);
+
+    foo1.sub_assign(&foo2);
+    assert_eq!(foo1.0, 1);
+    foo3.sub_assign(foo2);
+    assert_eq!(foo3.0, 3);
+}
+
+#[test]
+fn test_neg_self() {
+    let foo1 = Foo(3);
+
+    assert_eq!((foo1.neg()).0, -3);
+}

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::fmt::Debug;
+use std::iter::Sum;
+
+pub mod ristretto;
+
+/// This section is a PoC EC group trait, loosely inspired by zkcrypto::groups::Group.
+
+/// A helper trait for types with a group operation.
+pub trait GroupOps<Rhs = Self, Output = Self>:
+    Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
+{
+}
+
+impl<T, Rhs, Output> GroupOps<Rhs, Output> for T where
+    T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
+{
+}
+
+/// A helper trait for references with a group operation.
+pub trait GroupOpsOwned<Rhs = Self, Output = Self>: for<'r> GroupOps<&'r Rhs, Output> {}
+impl<T, Rhs, Output> GroupOpsOwned<Rhs, Output> for T where T: for<'r> GroupOps<&'r Rhs, Output> {}
+
+/// A helper trait for types implementing group scalar multiplication.
+pub trait ScalarMul<Rhs, Output = Self>: Mul<Rhs, Output = Output> + MulAssign<Rhs> {}
+
+impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Output> + MulAssign<Rhs>
+{}
+
+/// A helper trait for references implementing group scalar multiplication.
+pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
+impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
+
+pub trait Group:
+    Clone
+    + Copy
+    + Debug
+    + Eq
+    + Sized
+    + Send
+    + Sync
+    + 'static
+    + Sum
+    + for<'a> Sum<&'a Self>
+    + Neg<Output = Self>
+    + GroupOps
+    + GroupOpsOwned
+    + ScalarMul<<Self as Group>::Scalar>
+    + ScalarMulOwned<<Self as Group>::Scalar>
+{
+    /// Scalars modulo the order of this group's scalar field.
+    type Scalar;
+
+    /// Returns the additive identity, also known as the "neutral element".
+    fn identity() -> Self;
+
+    /// Determines if this point is the identity.
+    fn is_identity(&self) -> bool;
+}

--- a/fastcrypto/src/groups/ristretto.rs
+++ b/fastcrypto/src/groups/ristretto.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use curve25519_dalek_ng::scalar::Scalar as ExternalRistrettoScalar;
+use curve25519_dalek_ng::{ristretto::RistrettoPoint as ExternalRistrettoPoint, traits::Identity};
+use fastcrypto_derive::{
+    AddAssignSelfRef, AddSelfRef, MulAssignSelfRef, MulSelfRef, NegSelf, SubAssignSelfRef,
+    SubSelfRef, SumSelfRef,
+};
+
+use super::Group;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    AddSelfRef,
+    AddAssignSelfRef,
+    SubSelfRef,
+    SubAssignSelfRef,
+    NegSelf,
+    MulSelfRef,
+    MulAssignSelfRef,
+    SumSelfRef,
+)]
+#[ScalarType = "RistrettoScalar"]
+struct RistrettoPoint(ExternalRistrettoPoint);
+
+struct RistrettoScalar(ExternalRistrettoScalar);
+
+impl Group for RistrettoPoint {
+    type Scalar = RistrettoScalar;
+
+    fn identity() -> Self {
+        RistrettoPoint(ExternalRistrettoPoint::identity())
+    }
+
+    fn is_identity(&self) -> bool {
+        self == &Self::identity()
+    }
+}

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -66,6 +66,8 @@ pub mod encoding_tests;
 #[path = "tests/mskr_tests.rs"]
 pub mod mskr_tests;
 
+pub mod groups;
+
 // Signing traits
 pub mod traits;
 // Key scheme implementations


### PR DESCRIPTION
This is a PoC for PR #232 which demonstrates two things:
1. how to derive a variety of [arithmetic operators](https://doc.rust-lang.org/std/ops/index.html) when the operands are NewTypes which inner types support those operations. Included are :
```
core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
std::iter::Sum;
```
as implemented on both references and owned instances.
2. how to define a trait using those operations. In particular, we show the "convenience trait" pattern, (here `GroupOps, GroupOpsOwned, ScalarMul, ScalarMulOwned`) and their use in the final trait definition.

(see discussion at https://github.com/MystenLabs/fastcrypto/pull/232#discussion_r1030563246)
