### PR TITLE
feat: write & use a macro for serialization to/from base64

### DIFF
--- a/fastcrypto/src/bls12377.rs
+++ b/fastcrypto/src/bls12377.rs
@@ -25,6 +25,7 @@ use crate::{
     encoding::{Base64, Encoding},
     pubkey_bytes::PublicKeyBytes,
     serde_helpers::keypair_decode_base64,
+    serialize_deserialize_from_encode_decode_base64,
     traits::{AggregateAuthenticator, AllowedRng, EncodeDecodeBase64, ToFromBytes},
 };
 use ::ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -37,7 +38,7 @@ use ark_ff::{
 use celo_bls::{hash_to_curve::try_and_increment, HashToCurve, PublicKey};
 use eyre::eyre;
 use once_cell::sync::OnceCell;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use signature::{Signer, Verifier};
 
@@ -312,26 +313,7 @@ impl Display for BLS12377PublicKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for BLS12377PublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for BLS12377PublicKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(BLS12377PublicKey);
 
 impl Verifier<BLS12377Signature> for BLS12377PublicKey {
     fn verify(&self, msg: &[u8], signature: &BLS12377Signature) -> Result<(), signature::Error> {
@@ -410,26 +392,7 @@ impl ToFromBytes for BLS12377PrivateKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for BLS12377PrivateKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for BLS12377PrivateKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(BLS12377PrivateKey);
 
 impl SigningKey for BLS12377PrivateKey {
     type PubKey = BLS12377PublicKey;

--- a/fastcrypto/src/bls12381.rs
+++ b/fastcrypto/src/bls12381.rs
@@ -21,8 +21,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::encoding::Encoding;
-use ::blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
+use blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
 
 use once_cell::sync::OnceCell;
 use zeroize::Zeroize;
@@ -30,14 +29,11 @@ use zeroize::Zeroize;
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 
 use crate::{
-    encoding::Base64, error::FastCryptoError, pubkey_bytes::PublicKeyBytes,
-    serde_helpers::keypair_decode_base64,
+    encoding::Base64, encoding::Encoding, error::FastCryptoError, pubkey_bytes::PublicKeyBytes,
+    serde_helpers::keypair_decode_base64, serialize_deserialize_from_encode_decode_base64,
 };
 use eyre::eyre;
-use serde::{
-    de::{self},
-    Deserialize, Serialize,
-};
+use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use signature::{Signature, Signer, Verifier};
@@ -177,26 +173,7 @@ impl Debug for BLS12381PublicKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks.
-impl Serialize for BLS12381PublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks.
-impl<'de> Deserialize<'de> for BLS12381PublicKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(BLS12381PublicKey);
 
 impl Verifier<BLS12381Signature> for BLS12381PublicKey {
     fn verify(&self, msg: &[u8], signature: &BLS12381Signature) -> Result<(), signature::Error> {
@@ -420,26 +397,7 @@ impl ToFromBytes for BLS12381PrivateKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for BLS12381PrivateKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for BLS12381PrivateKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(BLS12381PrivateKey);
 
 impl SigningKey for BLS12381PrivateKey {
     type PubKey = BLS12381PublicKey;

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -14,7 +14,7 @@
 //! assert!(kp.public().verify(message, &signature).is_ok());
 //! ```
 
-use crate::{encoding::Encoding, traits};
+use crate::{encoding::Encoding, serialize_deserialize_from_encode_decode_base64, traits};
 use ed25519_consensus::{batch, VerificationKeyBytes};
 use eyre::eyre;
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
@@ -226,27 +226,7 @@ impl Ord for Ed25519PublicKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for Ed25519PublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let str = self.encode_base64();
-        serializer.serialize_newtype_struct("Ed25519PublicKey", &str)
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for Ed25519PublicKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(Ed25519PublicKey);
 
 ///
 /// Implement SigningKey
@@ -267,27 +247,7 @@ impl ToFromBytes for Ed25519PrivateKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for Ed25519PrivateKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let str = self.encode_base64();
-        serializer.serialize_newtype_struct("Ed25519PublicKey", &str)
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for Ed25519PrivateKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(Ed25519PrivateKey);
 
 ///
 /// Implement Authenticator

--- a/fastcrypto/src/secp256k1.rs
+++ b/fastcrypto/src/secp256k1.rs
@@ -20,6 +20,7 @@ use crate::{
     error::FastCryptoError,
     pubkey_bytes::PublicKeyBytes,
     serde_helpers::keypair_decode_base64,
+    serialize_deserialize_from_encode_decode_base64,
     traits::{
         AllowedRng, Authenticator, EncodeDecodeBase64, KeyPair, SigningKey, ToFromBytes,
         VerifyingKey,
@@ -186,25 +187,7 @@ impl Display for Secp256k1PublicKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for Secp256k1PublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-impl<'de> Deserialize<'de> for Secp256k1PublicKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(Secp256k1PublicKey);
 
 impl<'a> From<&'a Secp256k1PrivateKey> for Secp256k1PublicKey {
     fn from(secret: &'a Secp256k1PrivateKey) -> Self {
@@ -234,26 +217,7 @@ impl ToFromBytes for Secp256k1PrivateKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for Secp256k1PrivateKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for Secp256k1PrivateKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(Secp256k1PrivateKey);
 
 impl AsRef<[u8]> for Secp256k1PrivateKey {
     fn as_ref(&self) -> &[u8] {

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -75,6 +75,27 @@ impl<T: ToFromBytes> EncodeDecodeBase64 for T {
     }
 }
 
+/// A macro that derives a `Serialize` and `Deserialize` impl for a type that
+/// implements `EncodeDecodeBase64`.
+#[macro_export]
+macro_rules! serialize_deserialize_from_encode_decode_base64 {
+    ($type:ty) => {
+        impl ::serde::Serialize for $type {
+            fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(&self.encode_base64())
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for $type {
+            fn deserialize<D: ::serde::Deserializer<'de>>(
+                deserializer: D,
+            ) -> Result<Self, D::Error> {
+                let s = <String as ::serde::Deserialize>::deserialize(deserializer)?;
+                Self::decode_base64(&s).map_err(::serde::de::Error::custom)
+            }
+        }
+    };
+}
 /// Trait impl'd by public keys in asymmetric cryptography.
 ///
 /// The trait bounds are implemented so as to be symmetric and equivalent

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -148,26 +148,7 @@ impl Display for UnsecurePublicKey {
 }
 
 // There is a strong requirement for this specific impl. in Fab benchmarks
-impl Serialize for UnsecurePublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-impl<'de> Deserialize<'de> for UnsecurePublicKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(UnsecurePublicKey);
 
 impl Verifier<UnsecureSignature> for UnsecurePublicKey {
     fn verify(&self, msg: &[u8], signature: &UnsecureSignature) -> Result<(), signature::Error> {
@@ -282,25 +263,7 @@ impl ToFromBytes for UnsecurePrivateKey {
     }
 }
 
-impl Serialize for UnsecurePrivateKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.encode_base64())
-    }
-}
-
-impl<'de> Deserialize<'de> for UnsecurePrivateKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
-        let value = Self::decode_base64(&s).map_err(|e| de::Error::custom(e.to_string()))?;
-        Ok(value)
-    }
-}
+serialize_deserialize_from_encode_decode_base64!(UnsecurePrivateKey);
 
 impl SigningKey for UnsecurePrivateKey {
     type PubKey = UnsecurePublicKey;


### PR DESCRIPTION
We repeatedly use the exact same serialization to/from base64, based on the `EncodeDecodeBase64` trait. This simplifies the pattern, and makes it usable from other crates (e.g. Sui).