### PR TITLE
Assume message is hashed in secp256k1_tests::fail_to_verify_if_upper_s

### DIFF
--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -294,7 +294,7 @@ fn fail_to_verify_if_upper_s() {
     let rec_sig = <Secp256k1Signature as ToFromBytes>::from_bytes(&sig_bytes).unwrap();
 
     // Failed to verify with upper S.
-    assert!(pk.verify(&msg, &rec_sig).is_err());
+    assert!(pk.verify_hashed(&msg, &rec_sig).is_err());
 
     // Nomralize S to be less than N/2.
     sig.normalize_s();


### PR DESCRIPTION
Although the test should fail, the assertion would always fail since the message is hashed before it is verified.