### PR TITLE
Fix default impl of pubkey

### DIFF
--- a/fastcrypto/src/secp256k1.rs
+++ b/fastcrypto/src/secp256k1.rs
@@ -27,6 +27,8 @@ use crate::{
     },
 };
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::AffinePoint;
 use once_cell::sync::{Lazy, OnceCell};
 use rust_secp256k1::{
     constants,
@@ -176,7 +178,10 @@ impl ToFromBytes for Secp256k1PublicKey {
 
 impl Default for Secp256k1PublicKey {
     fn default() -> Self {
-        Secp256k1PublicKey::from_bytes(&[0u8; constants::PUBLIC_KEY_SIZE]).unwrap()
+        // Return the generator
+        Secp256k1PublicKey::from_uncompressed(
+            AffinePoint::GENERATOR.to_encoded_point(false).as_bytes(),
+        )
     }
 }
 

--- a/fastcrypto/src/secp256k1.rs
+++ b/fastcrypto/src/secp256k1.rs
@@ -27,8 +27,6 @@ use crate::{
     },
 };
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
-use k256::elliptic_curve::sec1::ToEncodedPoint;
-use k256::AffinePoint;
 use once_cell::sync::{Lazy, OnceCell};
 use rust_secp256k1::{
     constants,
@@ -178,10 +176,11 @@ impl ToFromBytes for Secp256k1PublicKey {
 
 impl Default for Secp256k1PublicKey {
     fn default() -> Self {
-        // Return the generator
-        Secp256k1PublicKey::from_uncompressed(
-            AffinePoint::GENERATOR.to_encoded_point(false).as_bytes(),
-        )
+        // Return the generator for k256 (https://www.secg.org/sec2-v2.pdf)
+        Secp256k1PublicKey {
+            pubkey: PublicKey::from_slice(hex::decode("0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8").unwrap().as_slice()).unwrap(),
+            bytes: OnceCell::new(),
+        }
     }
 }
 

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -484,3 +484,9 @@ fn dont_display_secrets() {
         );
     });
 }
+
+#[test]
+fn test_default_values() {
+    let _default_pubkey = Secp256k1PublicKey::default();
+    let _default_signature = Secp256k1Signature::default();
+}


### PR DESCRIPTION
Having public keys implement the Default trait is necessary (see https://github.com/MystenLabs/sui/issues/5186), but not ideal. However, we should at least implement it such that it doesn't panic which I've done in this PR.