### PR TITLE
[zkp] Add Groth16 hash preimage example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,8 @@ checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-nonnative-field",
+ "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
  "ark-snark",
@@ -112,6 +114,7 @@ dependencies = [
  "derivative",
  "digest 0.9.0",
  "rayon",
+ "tracing",
 ]
 
 [[package]]
@@ -187,6 +190,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-nonnative-field"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440ad4569974910adbeb84422b7e622b79e08d27142afd113785b7fcfb446186"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-std",
+ "derivative",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +219,22 @@ dependencies = [
  "derivative",
  "hashbrown 0.11.2",
  "rayon",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e8fdacb1931f238a0d866ced1e916a49d36de832fd8b83dc916b718ae72893"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-std",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "tracing",
 ]
 
 [[package]]
@@ -1050,13 +1087,16 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-groth16",
+ "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
  "ark-std",
+ "blake2 0.10.5",
  "blst",
  "byte-slice-cast",
  "criterion",
  "fastcrypto",
+ "hex",
  "proptest",
  "untrusted",
 ]
@@ -2232,7 +2272,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,3 @@ members = [
     "fastcrypto-derive",
     "fastcrypto-zkp"
 ]
-

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -27,8 +27,10 @@ fastcrypto = { path = "../fastcrypto" }
 [dev-dependencies]
 ark-bls12-377 = "0.3.0"
 ark-bn254 = "0.3.0"
-ark-crypto-primitives = "0.3.0"
+ark-crypto-primitives = { version = "0.3.0", features = ["r1cs"] }
+ark-r1cs-std = "0.3.1"
 ark-std = { version = "0.3.0", features = ["parallel"]}
+blake2 = "0.10.5"
 criterion = "0.4.0"
+hex = "0.4.3"
 proptest = "1.0.0"
-

--- a/fastcrypto-zkp/examples/blake2s_demo.rs
+++ b/fastcrypto-zkp/examples/blake2s_demo.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_ff::ToConstraintField;
+use ark_groth16::{create_random_proof, generate_random_parameters};
+
+use ark_crypto_primitives::{
+    prf::blake2s::constraints::Blake2sGadget, prf::blake2s::Blake2s as B2SPRF, PRFGadget, PRF,
+};
+use ark_relations::r1cs::{
+    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, SynthesisError,
+};
+use blake2::{digest::Digest, Blake2s256};
+
+use ark_r1cs_std::prelude::*;
+use fastcrypto_zkp::verifier::{process_vk_special, verify_with_processed_vk};
+
+#[derive(Clone, Copy, Debug)]
+struct Blake2sCircuit {
+    input: [u8; 32],
+    blake2_seed: [u8; 32],
+    pub expected_output: [u8; 32],
+}
+
+impl Blake2sCircuit {
+    fn new() -> Self {
+        // We're going to prove knowledge of the blake2 hash of this secret
+        // see https://en.wikipedia.org/wiki/Cluedo
+        let statement = b"butler in the yard with a wrench";
+        let bytes = statement.to_vec();
+
+        // as a sanity-check, we'll also compute the blake2 hash of the secret
+        // with the reference implementation
+
+        // Blake2s takes a seed parameter. We use a default seed.
+        let seed: [u8; 32] = [0u8; 32];
+
+        // Compute the hash by traditional means.
+        let mut h = Blake2s256::new_with_prefix(seed);
+        h.update(&bytes);
+        let hash_result = h.finalize();
+
+        // We use the arkworks API for blake2s as well and check it matches
+        let input: [u8; 32] = bytes[..].try_into().unwrap();
+        let out = B2SPRF::evaluate(&seed, &input).unwrap();
+
+        // the traditional means and the arkworks implementation match
+        assert_eq!(hash_result.as_slice(), out.as_slice());
+
+        // at this stage, we can publish the seed and the expected hash output,
+        // and we'll prove we know the input
+        Self {
+            input: statement.to_owned(),
+            blake2_seed: seed,
+            expected_output: out,
+        }
+    }
+}
+
+impl ConstraintSynthesizer<Fr> for Blake2sCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        // initialize the blake2s gadget and allocate the seed
+        let seed_var = UInt8::new_input_vec(cs.clone(), &self.blake2_seed).unwrap();
+
+        // declare the witnesses
+        let input_var = UInt8::new_witness_vec(cs.clone(), &self.input).unwrap();
+
+        // declare the public intended output
+        let desired_out_var = <Blake2sGadget as PRFGadget<_, Fr>>::OutputVar::new_input(cs, || {
+            Ok(self.expected_output)
+        })
+        .unwrap();
+
+        // link the intended output to a blake2s computation on the input, i.e. constrain Blake2s(seed, input) == output
+        let output_var = Blake2sGadget::evaluate(&seed_var, &input_var).unwrap();
+        output_var.enforce_equal(&desired_out_var).unwrap();
+
+        Ok(())
+    }
+}
+
+fn main() {
+    let mut rng = &mut ark_std::test_rng();
+
+    let circuit = Blake2sCircuit::new();
+    // Sanity-check
+    {
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        circuit.generate_constraints(cs.clone()).unwrap();
+        println!("Num constraints: {}", cs.num_constraints());
+        assert!(cs.is_satisfied().unwrap());
+    }
+
+    let params = generate_random_parameters::<Bls12_381, _, _>(circuit, &mut rng).unwrap();
+
+    // prepare the verification key
+    let pvk = process_vk_special(&params.vk);
+
+    // prepare a proof (note: there is nothing trustable about the trivial setup involved here)
+    let proof = create_random_proof(circuit, &params, &mut rng).unwrap();
+    println!(
+        "Generated proof of knowledge of Blake2s preimage of {}",
+        hex::encode(circuit.expected_output)
+    );
+
+    // provide the public inputs (the hash target) for verification
+    let inputs: Vec<Fr> = [&circuit.blake2_seed[..], &circuit.expected_output[..]]
+        .iter()
+        .flat_map(|x| x.to_field_elements().unwrap())
+        .collect();
+
+    // Verify the proof
+    assert!(verify_with_processed_vk(&pvk, &inputs, &proof).unwrap());
+    println!(
+        "Checked proof of knowledge of Blake2s preimage of {}!",
+        hex::encode(circuit.expected_output)
+    );
+}

--- a/fastcrypto-zkp/src/conversions.rs
+++ b/fastcrypto-zkp/src/conversions.rs
@@ -16,11 +16,12 @@ use blst::{blst_fr, blst_fr_from_uint64, blst_uint64_from_fr};
 use byte_slice_cast::AsByteSlice;
 
 const SCALAR_SIZE: usize = 32;
-const G1_UNCOMPRESSED_SIZE: usize = 96;
 /// G1 affine point compressed size.
 pub const G1_COMPRESSED_SIZE: usize = 48;
-const G2_UNCOMPRESSED_SIZE: usize = 192;
 const G2_COMPRESSED_SIZE: usize = 96;
+
+const G1_UNCOMPRESSED_SIZE: usize = 96;
+const G2_UNCOMPRESSED_SIZE: usize = 192;
 
 #[inline]
 fn u64s_from_bytes(bytes: &[u8; 32]) -> [u64; 4] {


### PR DESCRIPTION
This proves the knowledge of a Blakek2 hash preimage using Groth16, with a trivial (RNG'd) setup, with the preimage a hidden witness of the proof.