### PR TITLE
Code cleanup and extract method helper functions.

### DIFF
--- a/fastcrypto-zkp/src/conversions.rs
+++ b/fastcrypto-zkp/src/conversions.rs
@@ -6,7 +6,6 @@ use blst::{blst_fp, blst_fp12, blst_fp6, blst_fp_from_lendian, blst_p1_affine};
 use blst::{blst_fp2, blst_p1_deserialize};
 use blst::{blst_p1_affine_serialize, blst_uint64_from_fp};
 use blst::{blst_p2_affine, blst_p2_affine_serialize, blst_p2_deserialize, BLST_ERROR};
-use byte_slice_cast::AsByteSlice;
 
 pub use ark_bls12_381::Fr as BlsFr;
 use ark_bls12_381::{Fq, Fq2};
@@ -14,10 +13,11 @@ use ark_bls12_381::{Fq12, G2Affine as BlsG2Affine};
 use ark_bls12_381::{Fq6, G1Affine as BlsG1Affine};
 
 use blst::{blst_fr, blst_fr_from_uint64, blst_uint64_from_fr};
+use byte_slice_cast::AsByteSlice;
 
 const SCALAR_SIZE: usize = 32;
 const G1_UNCOMPRESSED_SIZE: usize = 96;
-/// G1 Affline point compressed size
+/// G1 affine point compressed size.
 pub const G1_COMPRESSED_SIZE: usize = 48;
 const G2_UNCOMPRESSED_SIZE: usize = 192;
 const G2_COMPRESSED_SIZE: usize = 96;
@@ -33,7 +33,7 @@ fn u64s_from_bytes(bytes: &[u8; 32]) -> [u64; 4] {
 }
 
 // Scalar Field conversions
-/// Convert an Arkworks BLS12-381 scalar field element to a blst scalar field element
+/// Convert an Arkworks BLS12-381 scalar field element to a blst scalar field element.
 pub fn bls_fr_to_blst_fr(fe: &BlsFr) -> blst_fr {
     debug_assert_eq!(fe.serialized_size(), SCALAR_SIZE);
     let mut bytes = [0u8; SCALAR_SIZE];
@@ -46,7 +46,7 @@ pub fn bls_fr_to_blst_fr(fe: &BlsFr) -> blst_fr {
     out
 }
 
-/// Convert a blst scalar field element to an Arkworks BLS12-381 scalar field element
+/// Convert a blst scalar field element to an Arkworks BLS12-381 scalar field element.
 pub fn blst_fr_to_bls_fr(fe: &blst_fr) -> BlsFr {
     let mut out = [0u64; 4];
     unsafe { blst_uint64_from_fr(out.as_mut_ptr(), fe) };
@@ -56,7 +56,7 @@ pub fn blst_fr_to_bls_fr(fe: &blst_fr) -> BlsFr {
 }
 
 // Base Field conversions
-/// Convert an Arkworks BLS12-381 prime field element to a blst prime field element
+/// Convert an Arkworks BLS12-381 prime field element to a blst prime field element.
 pub fn bls_fq_to_blst_fp(f: &Fq) -> blst_fp {
     let mut fp_bytes_le = [0u8; G1_UNCOMPRESSED_SIZE / 2];
     f.serialize_uncompressed(&mut fp_bytes_le[..])
@@ -69,7 +69,7 @@ pub fn bls_fq_to_blst_fp(f: &Fq) -> blst_fp {
     blst_fp
 }
 
-/// Convert a blst prime field element to an Arkworks BLS12-381 prime field element
+/// Convert a blst prime field element to an Arkworks BLS12-381 prime field element.
 pub fn blst_fp_to_bls_fq(f: &blst_fp) -> Fq {
     let mut out = [0u64; 6];
     unsafe { blst_uint64_from_fp(out.as_mut_ptr(), f) };
@@ -78,7 +78,9 @@ pub fn blst_fp_to_bls_fq(f: &blst_fp) -> Fq {
 }
 
 // QFE conversions
-/// Convert an Arkworks BLS12-381 quadratic extension field element to a blst quadratic extension field element
+
+/// Convert an Arkworks BLS12-381 quadratic extension field element to a blst quadratic extension
+/// field element.
 pub fn bls_fq2_to_blst_fp2(f: &Fq2) -> blst_fp2 {
     let mut fp_bytes_le = [0u8; G2_UNCOMPRESSED_SIZE / 2];
     f.serialize_uncompressed(&mut fp_bytes_le[..])
@@ -100,7 +102,8 @@ pub fn bls_fq2_to_blst_fp2(f: &Fq2) -> blst_fp2 {
     }
 }
 
-/// Convert a blst quadratic extension field element to an Arkworks BLS12-381 quadratic extension field element
+/// Convert a blst quadratic extension field element to an Arkworks BLS12-381 quadratic extension
+/// field element.
 pub fn blst_fp2_to_bls_fq2(f: &blst_fp2) -> Fq2 {
     let [fp1, fp2] = f.fp;
     let bls_fp1 = blst_fp_to_bls_fq(&fp1);
@@ -110,7 +113,8 @@ pub fn blst_fp2_to_bls_fq2(f: &blst_fp2) -> Fq2 {
 
 // Target Field conversions
 
-/// Convert an Arkworks BLS12-381 degree-6 extension field element to a blst degree-6 extension field element
+/// Convert an Arkworks BLS12-381 degree-6 extension field element to a blst degree-6 extension
+/// field element.
 pub fn bls_fq6_to_blst_fp6(f: &Fq6) -> blst_fp6 {
     let c0 = bls_fq2_to_blst_fp2(&f.c0);
     let c1 = bls_fq2_to_blst_fp2(&f.c1);
@@ -118,7 +122,8 @@ pub fn bls_fq6_to_blst_fp6(f: &Fq6) -> blst_fp6 {
     blst_fp6 { fp2: [c0, c1, c2] }
 }
 
-/// Convert a blst degree-6 extension field element to an Arkworks BLS12-381 degree-6 extension field element
+/// Convert a blst degree-6 extension field element to an Arkworks BLS12-381 degree-6 extension
+/// field element.
 pub fn blst_fp6_to_bls_fq6(f: &blst_fp6) -> Fq6 {
     let c0 = blst_fp2_to_bls_fq2(&f.fp2[0]);
     let c1 = blst_fp2_to_bls_fq2(&f.fp2[1]);
@@ -126,14 +131,14 @@ pub fn blst_fp6_to_bls_fq6(f: &blst_fp6) -> Fq6 {
     Fq6::new(c0, c1, c2)
 }
 
-/// Convert an Arkworks BLS12-381 target field element to a blst target field element
+/// Convert an Arkworks BLS12-381 target field element to a blst target field element.
 pub fn bls_fq12_to_blst_fp12(f: &Fq12) -> blst_fp12 {
     let c0 = bls_fq6_to_blst_fp6(&f.c0);
     let c1 = bls_fq6_to_blst_fp6(&f.c1);
     blst_fp12 { fp6: [c0, c1] }
 }
 
-/// Convert a blst target field element to an Arkworks BLS12-381 target field element
+/// Convert a blst target field element to an Arkworks BLS12-381 target field element.
 pub fn blst_fp12_to_bls_fq12(f: &blst_fp12) -> Fq12 {
     let c0 = blst_fp6_to_bls_fq6(&f.fp6[0]);
     let c1 = blst_fp6_to_bls_fq6(&f.fp6[1]);
@@ -154,7 +159,7 @@ fn bls_g1_affine_infinity() -> BlsG1Affine {
     BlsG1Affine::new(Fq::zero(), Fq::one(), true)
 }
 
-/// Convert an Arkworks BLS12-381 affine G1 point to a blst affine G1 point
+/// Convert an Arkworks BLS12-381 affine G1 point to a blst affine G1 point.
 pub fn bls_g1_affine_to_blst_g1_affine(pt: &BlsG1Affine) -> blst_p1_affine {
     debug_assert_eq!(pt.uncompressed_size(), G1_UNCOMPRESSED_SIZE);
     // BLST disagrees with Arkworks on the uncompressed representation of the infinity point on G1
@@ -171,20 +176,24 @@ pub fn bls_g1_affine_to_blst_g1_affine(pt: &BlsG1Affine) -> blst_p1_affine {
         y: bls_fq_to_blst_fp(&pt.y),
     };
     // See https://github.com/arkworks-rs/curves/issues/14 for why the double serialize
-    // we're in fact applying correct masks that arkworks does not use. This may be solved alternatively using
-    // https://github.com/arkworks-rs/algebra/issues/308 in a later release of arkworks. Note:
-    // this is an uncompressed serialization - deserialization.
+    // we're in fact applying correct masks that arkworks does not use. This may be solved
+    // alternatively using https://github.com/arkworks-rs/algebra/issues/308 in a later release of
+    // Arkworks.
+    // Note: this is an uncompressed serialization - deserialization.
     let mut tmp2 = [0u8; 96];
     unsafe {
         blst_p1_affine_serialize(tmp2.as_mut_ptr(), &tmp_p1);
     };
 
     let mut g1 = blst_p1_affine::default();
-    assert!(unsafe { blst_p1_deserialize(&mut g1, tmp2.as_ptr()) } == BLST_ERROR::BLST_SUCCESS);
+    assert_eq!(
+        unsafe { blst_p1_deserialize(&mut g1, tmp2.as_ptr()) },
+        BLST_ERROR::BLST_SUCCESS
+    );
     g1
 }
 
-/// Convert a blst affine G1 point to an Arkworks BLS12-381 affine G1 point
+/// Convert a blst affine G1 point to an Arkworks BLS12-381 affine G1 point.
 pub fn blst_g1_affine_to_bls_g1_affine(pt: &blst_p1_affine) -> BlsG1Affine {
     let mut out = [0u8; G1_UNCOMPRESSED_SIZE];
     unsafe {
@@ -202,7 +211,7 @@ pub fn blst_g1_affine_to_bls_g1_affine(pt: &blst_p1_affine) -> BlsG1Affine {
     }
     let y = Fp384::from_be_bytes_mod_order(&out[48..]);
     let x = {
-        // Mask away the flag bits (which Arkworks doesn't use)
+        // Mask away the flag bits (which Arkworks doesn't use).
         out[0] &= 0b0001_1111;
         Fp384::from_be_bytes_mod_order(&out[..48])
     };
@@ -220,7 +229,7 @@ fn bls_g2_affine_infinity() -> BlsG2Affine {
     BlsG2Affine::new(Fq2::zero(), Fq2::one(), true)
 }
 
-/// Convert an Arkworks BLS12-381 affine G2 point to a blst affine G2 point
+/// Convert an Arkworks BLS12-381 affine G2 point to a blst affine G2 point.
 pub fn bls_g2_affine_to_blst_g2_affine(pt: &BlsG2Affine) -> blst_p2_affine {
     debug_assert_eq!(pt.uncompressed_size(), G2_UNCOMPRESSED_SIZE);
     // BLST disagrees with Arkworks on the uncompressed representation of the infinity point on G2
@@ -237,20 +246,24 @@ pub fn bls_g2_affine_to_blst_g2_affine(pt: &BlsG2Affine) -> blst_p2_affine {
         y: bls_fq2_to_blst_fp2(&pt.y),
     };
     // See https://github.com/arkworks-rs/curves/issues/14 for why the double serialize
-    // we're in fact applying correct masks that arkworks does not use. This may be solved alternatively using
-    // https://github.com/arkworks-rs/algebra/issues/308 in a later release of arkworks. Note:
-    // this is an uncompressed serialization - deserialization.
+    // we're in fact applying correct masks that arkworks does not use. This may be solved
+    // alternatively using https://github.com/arkworks-rs/algebra/issues/308 in a later release of
+    // Arkworks.
+    // Note: this is an uncompressed serialization - deserialization.
     let mut tmp2 = [0u8; G2_UNCOMPRESSED_SIZE];
     unsafe {
         blst_p2_affine_serialize(tmp2.as_mut_ptr(), &tmp_p2);
     };
 
     let mut g2 = blst_p2_affine::default();
-    assert!(unsafe { blst_p2_deserialize(&mut g2, tmp2.as_ptr()) } == BLST_ERROR::BLST_SUCCESS);
+    assert_eq!(
+        unsafe { blst_p2_deserialize(&mut g2, tmp2.as_ptr()) },
+        BLST_ERROR::BLST_SUCCESS
+    );
     g2
 }
 
-/// Convert a blst affine G2 point to an Arkworks BLS12-381 affine G2 point
+/// Convert a blst affine G2 point to an Arkworks BLS12-381 affine G2 point.
 pub fn blst_g2_affine_to_bls_g2_affine(pt: &blst_p2_affine) -> BlsG2Affine {
     let ptx = blst_fp2_to_bls_fq2(&pt.x);
     let pty = blst_fp2_to_bls_fq2(&pt.y);
@@ -280,7 +293,7 @@ pub fn blst_g2_affine_to_bls_g2_affine(pt: &blst_p2_affine) -> BlsG2Affine {
 // and https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/ Appendix A
 // for its choice as a standard.
 
-// A note on BLST: blst uses zcash point encoding formats across the board.
+// A note on BLST: blst uses Zcash point encoding formats across the board.
 
 fn bls_fq_to_zcash_bytes(field: &Fq) -> [u8; G1_COMPRESSED_SIZE] {
     let mut result = [0u8; G1_COMPRESSED_SIZE];
@@ -344,26 +357,18 @@ impl EncodingFlags {
 
 /// This deserializes an Arkworks G1Affine point from a Zcash point encoding.
 pub fn bls_g1_affine_from_zcash_bytes(bytes: &[u8; G1_COMPRESSED_SIZE]) -> Option<BlsG1Affine> {
-    // Obtain the three flags from the start of the byte sequence
+    // Obtain the three flags from the start of the byte sequence.
     let flags = EncodingFlags::from(&bytes[..]);
 
     if !flags.is_compressed {
-        return None; // We only support compressed points
+        return None; // We only support compressed points.
     }
 
     if flags.is_infinity {
         return Some(BlsG1Affine::default());
     }
-    // Attempt to obtain the x-coordinate
-    let x = {
-        let mut tmp = [0; G1_COMPRESSED_SIZE];
-        tmp.copy_from_slice(&bytes[0..48]);
-
-        // Mask away the flag bits
-        tmp[0] &= 0b0001_1111;
-
-        bls_fq_from_zcash_bytes(&tmp)?
-    };
+    // Attempt to obtain the x-coordinate.
+    let x = obtain_x_coordinate(bytes.as_slice())?;
 
     BlsG1Affine::get_point_from_x(x, flags.is_lexicographically_largest)
 }
@@ -386,23 +391,14 @@ pub fn bls_g2_affine_from_zcash_bytes(bytes: &[u8; G2_COMPRESSED_SIZE]) -> Optio
     let flags = EncodingFlags::from(&bytes[..]);
 
     if !flags.is_compressed {
-        return None; // We only support compressed points
+        return None; // We only support compressed points.
     }
 
     if flags.is_infinity {
         return Some(BlsG2Affine::default());
     }
 
-    // Attempt to obtain the x-coordinate
-    let xc1 = {
-        let mut tmp = [0; G1_COMPRESSED_SIZE];
-        tmp.copy_from_slice(&bytes[0..48]);
-
-        // Mask away the flag bits
-        tmp[0] &= 0b0001_1111;
-
-        bls_fq_from_zcash_bytes(&tmp)?
-    };
+    let xc1 = obtain_x_coordinate(bytes.as_slice())?;
     let xc0 = {
         let mut tmp = [0; G1_COMPRESSED_SIZE];
         tmp.copy_from_slice(&bytes[48..96]);
@@ -434,6 +430,19 @@ pub fn bls_g2_affine_to_zcash_bytes(p: &BlsG2Affine) -> [u8; G2_COMPRESSED_SIZE]
     bytes
 }
 
+// Attempt to obtain x_coordinate
+fn obtain_x_coordinate(bytes: &[u8]) -> Option<Fq> {
+    let mut tmp = [0; G1_COMPRESSED_SIZE];
+    // this is safe as the private obtain_x_coordinate function is only invoked with G1 (48) and
+    // G2 (96) size inputs.
+    tmp.copy_from_slice(&bytes[0..G1_COMPRESSED_SIZE]);
+
+    // Mask away the flag bits
+    tmp[0] &= 0b0001_1111;
+
+    bls_fq_from_zcash_bytes(&tmp)
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -447,14 +456,14 @@ pub(crate) mod tests {
     };
     use proptest::{collection, prelude::*};
 
-    // Scalar roundtrips
+    // Scalar roundtrips.
 
     pub(crate) fn arb_bls_fr() -> impl Strategy<Value = BlsFr> {
         collection::vec(any::<u8>(), 32..=32)
             .prop_map(|bytes| BlsFr::from_random_bytes(&bytes[..]))
             .prop_filter("Valid field elements", Option::is_some)
             .prop_map(|opt_fr| opt_fr.unwrap())
-            .no_shrink() // this is arbitrary
+            .no_shrink() // this is arbitrary.
     }
 
     fn arb_blst_fr() -> impl Strategy<Value = blst_fr> {
@@ -464,7 +473,7 @@ pub(crate) mod tests {
                 unsafe { blst_fr_from_uint64(&mut out, u64s[..].as_ptr()) };
                 out
             })
-            .no_shrink() // this is arbitrary
+            .no_shrink() // this is arbitrary.
     }
 
     proptest! {
@@ -483,14 +492,14 @@ pub(crate) mod tests {
         }
     }
 
-    // Base field rountrips
+    // Base field roundtrips.
 
     fn arb_bls_fq() -> impl Strategy<Value = Fp384<FqParameters>> {
         collection::vec(any::<u8>(), 48..=48)
             .prop_map(|bytes| Fp384::from_random_bytes(&bytes[..]))
             .prop_filter("Valid field elements", Option::is_some)
             .prop_map(|opt_fr| opt_fr.unwrap())
-            .no_shrink() // this is arbitrary
+            .no_shrink() // this is arbitrary.
     }
 
     fn arb_blst_fp() -> impl Strategy<Value = blst_fp> {
@@ -500,7 +509,7 @@ pub(crate) mod tests {
                 unsafe { blst_fp_from_uint64(&mut out, u64s[..].as_ptr()) };
                 out
             })
-            .no_shrink() // this is arbitrary
+            .no_shrink() // this is arbitrary.
     }
 
     proptest! {
@@ -526,7 +535,8 @@ pub(crate) mod tests {
         }
     }
 
-    // QFE roundtrips
+    // QFE roundtrips.
+
     fn arb_bls_fq2() -> impl Strategy<Value = Fq2> {
         (arb_bls_fq(), arb_bls_fq())
             .prop_map(|(fp1, fp2)| Fq2::new(fp1, fp2))
@@ -555,7 +565,7 @@ pub(crate) mod tests {
         }
     }
 
-    // Target field roundtrips
+    // Target field roundtrips.
 
     fn arb_bls_fq6() -> impl Strategy<Value = Fq6> {
         (arb_bls_fq2(), arb_bls_fq2(), arb_bls_fq2())
@@ -615,7 +625,7 @@ pub(crate) mod tests {
         }
     }
 
-    // Affine point roundtrips
+    // Affine point roundtrips.
 
     fn bls_g1_affine_infinity() -> BlsG1Affine {
         let res = BlsG1Affine::zero();
@@ -625,10 +635,10 @@ pub(crate) mod tests {
 
     pub(crate) fn arb_bls_g1_affine() -> impl Strategy<Value = BlsG1Affine> {
         prop_oneof![
-            // 1% chance of being the point at infinity
+            // 1% chance of being the point at infinity.
             1 =>
             Just(bls_g1_affine_infinity()),
-            99 =>  // slow, but good enough for tests
+            99 =>  // slow, but good enough for tests.
             (arb_bls_fr()).prop_map(|s| {
 
                     BlsG1Affine::prime_subgroup_generator()
@@ -643,21 +653,21 @@ pub(crate) mod tests {
         let mut res = [0u8; G1_UNCOMPRESSED_SIZE];
         res[0] = 0x40;
         let mut g1_infinity = blst_p1_affine::default();
-        assert!(
-            unsafe { blst_p1_deserialize(&mut g1_infinity, res.as_ptr()) }
-                == BLST_ERROR::BLST_SUCCESS
+        assert_eq!(
+            unsafe { blst_p1_deserialize(&mut g1_infinity, res.as_ptr()) },
+            BLST_ERROR::BLST_SUCCESS
         );
         g1_infinity
     }
 
     pub(crate) fn arb_blst_g1_affine() -> impl Strategy<Value = blst_p1_affine> {
         prop_oneof![
-                // 1% chance of being the point at infinity
+                // 1% chance of being the point at infinity.
                 1 => Just(blst_g1_affine_infinity()),
                 99 =>
                 (collection::vec(any::<u8>(), 32..=32)).prop_map(|msg| {
 
-                        // we actually hash to a G1Projective, then convert to affine
+                        // We actually hash to a G1Projective, then convert to affine.
                         let mut out = blst_p1::default();
                         const DST: [u8; 16] = [0; 16];
                         const AUG: [u8; 16] = [0; 16];
@@ -708,11 +718,11 @@ pub(crate) mod tests {
         #[test]
         fn compatibility_bls_blst_g1_affine_serde(b in arb_bls_g1_affine(), bt in arb_blst_g1_affine()) {
             let zcash_bytes = bls_g1_affine_to_zcash_bytes(&b);
-            // blst accepts & expects zcash encodings
+            // blst accepts & expects Zcash encodings.
             let mut g1 = blst_p1_affine::default();
-            assert!(unsafe { blst_p1_uncompress(&mut g1, zcash_bytes.as_ptr()) } == BLST_ERROR::BLST_SUCCESS);
+            assert_eq!(unsafe { blst_p1_uncompress(&mut g1, zcash_bytes.as_ptr()) }, BLST_ERROR::BLST_SUCCESS);
 
-            // blst produces zcash encodings
+            // blst produces Zcash encodings.
             let mut tmp2 = [0u8; 48];
             unsafe {
                 blst_p1_affine_compress(tmp2.as_mut_ptr(), &bt);
@@ -728,7 +738,7 @@ pub(crate) mod tests {
     }
 
     fn arb_bls_g2_affine() -> impl Strategy<Value = BlsG2Affine> {
-        // slow, but good enough for tests
+        // slow, but good enough for tests.
         (arb_bls_fr(), any::<f32>()).prop_map(|(s, maybe_infinity)| {
             if maybe_infinity < 0.1 {
                 bls_g2_affine_infinity()
@@ -744,19 +754,19 @@ pub(crate) mod tests {
         let mut res = [0u8; G2_UNCOMPRESSED_SIZE];
         res[0] = 0x40;
         let mut g2_infinity = blst_p2_affine::default();
-        assert!(
-            unsafe { blst_p2_deserialize(&mut g2_infinity, res.as_ptr()) }
-                == BLST_ERROR::BLST_SUCCESS
+        assert_eq!(
+            unsafe { blst_p2_deserialize(&mut g2_infinity, res.as_ptr()) },
+            BLST_ERROR::BLST_SUCCESS
         );
         g2_infinity
     }
 
     pub(crate) fn arb_blst_g2_affine() -> impl Strategy<Value = blst_p2_affine> {
         prop_oneof![
-            1 =>// 1% chance of being the point at infinity
+            1 => // 1% chance of being the point at infinity.
                 Just(blst_g2_affine_infinity()),
             99 => (collection::vec(any::<u8>(), 32..=32)).prop_map(|msg| {
-                // we actually hash to a G2Projective, then convert to affine
+                // We actually hash to a G2Projective, then convert to affine.
                 let mut out = blst_p2::default();
                 const DST: [u8; 16] = [0; 16];
                 const AUG: [u8; 16] = [0; 16];
@@ -807,10 +817,10 @@ pub(crate) mod tests {
         fn compatibility_bls_blst_g2_affine_serde(b in arb_bls_g2_affine(), bt in arb_blst_g2_affine()) {
             let zcash_bytes = bls_g2_affine_to_zcash_bytes(&b);
             let mut g2 = blst_p2_affine::default();
-            // blst accepts & expects zcash encodings
+            // blst accepts & expects Zcash encodings.
             assert!(unsafe { blst_p2_uncompress(&mut g2, zcash_bytes.as_ptr()) } == BLST_ERROR::BLST_SUCCESS);
 
-            // blst produces zcash encodings
+            // blst produces Zcash encodings.
             let mut tmp2 = [0u8; 96];
             unsafe {
                 blst_p2_affine_compress(tmp2.as_mut_ptr(), &bt);

--- a/fastcrypto-zkp/src/dummy_circuits.rs
+++ b/fastcrypto-zkp/src/dummy_circuits.rs
@@ -26,7 +26,7 @@ pub struct DummyCircuit<F: PrimeField> {
 }
 
 impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
-    // We'll be proving a relationship involving the product c of a & b
+    // We'll be proving a relationship involving the product c of a & b.
     fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
         let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
         let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
@@ -53,7 +53,7 @@ impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
 }
 
 /// A circuit that checks a parametrized number of R1CS constraints that verify the computation of the Fibonacci sequence.
-/// It generates constraints in layers, numbered from 1 to num_constraints, sepcifying the computation of the Fibonacci sequence.
+/// It generates constraints in layers, numbered from 1 to num_constraints, specifying the computation of the Fibonacci sequence.
 /// On each layer, it does:
 ///
 /// 1. Add two new public inputs a = initial_a and b = initial_b at the first layer, or retrieve them from the previous layer if the layer if larger.

--- a/fastcrypto-zkp/src/verifier.rs
+++ b/fastcrypto-zkp/src/verifier.rs
@@ -48,7 +48,7 @@ impl PreparedVerifyingKey {
         alpha_g1_beta_g2_bytes: &[u8],
         gamma_g2_neg_pc_bytes: &[u8],
         delta_g2_neg_pc_bytes: &[u8],
-    ) -> Result<Self, fastcrypto::error::FastCryptoError> {
+    ) -> Result<Self, FastCryptoError> {
         let mut vk_gamma_abc_g1: Vec<G1Affine> = Vec::new();
         for g1_bytes in vk_gamma_abc_g1_bytes.chunks(G1_COMPRESSED_SIZE) {
             let g1_reader = Input::from(g1_bytes);

--- a/fastcrypto/src/bls12381.rs
+++ b/fastcrypto/src/bls12381.rs
@@ -504,7 +504,7 @@ impl FromStr for BLS12381KeyPair {
 /// Implement AggregateAuthenticator
 ///
 
-// Don't try to use this externally
+// Don't try to use this externally.
 impl AsRef<[u8]> for BLS12381AggregateSignature {
     fn as_ref(&self) -> &[u8] {
         match self.sig {
@@ -523,7 +523,7 @@ impl Display for BLS12381AggregateSignature {
     }
 }
 
-// see [#34](https://github.com/MystenLabs/narwhal/issues/34)
+// see [#34](https://github.com/MystenLabs/narwhal/issues/34).
 impl Default for BLS12381AggregateSignature {
     fn default() -> Self {
         BLS12381AggregateSignature {
@@ -538,7 +538,7 @@ impl AggregateAuthenticator for BLS12381AggregateSignature {
     type PubKey = BLS12381PublicKey;
     type PrivKey = BLS12381PrivateKey;
 
-    /// Parse a key from its byte representation
+    /// Parse a key from its byte representation.
     fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
         signatures: I,
     ) -> Result<Self, FastCryptoError> {
@@ -665,7 +665,7 @@ impl AggregateAuthenticator for BLS12381AggregateSignature {
 }
 
 ///
-/// Implement VerifyingKeyBytes
+/// Implement VerifyingKeyBytes.
 ///
 
 impl TryFrom<BLS12381PublicKeyBytes> for BLS12381PublicKey {
@@ -721,7 +721,7 @@ impl ToFromBytes for BLS12381AggregateSignature {
     }
 }
 
-}} // macro_rules! define_bls12381
+}} // macro_rules! define_bls12381.
 
 /// The length of a private key in bytes.
 pub const BLS_PRIVATE_KEY_LENGTH: usize = 32;
@@ -737,7 +737,7 @@ pub mod min_sig {
     use super::*;
     use crate::serde_helpers::min_sig::BlsSignature;
     use blst::min_sig as blst;
-    /// Hash-to-curve domain seperation tag.
+    /// Hash-to-curve domain separation tag.
     pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
     define_bls12381!(BLS_G2_LENGTH, BLS_G1_LENGTH, DST_G1);
 }
@@ -747,7 +747,7 @@ pub mod min_pk {
     use super::*;
     use crate::serde_helpers::min_pk::BlsSignature;
     use blst::min_pk as blst;
-    /// Hash-to-curve domain seperation tag.
+    /// Hash-to-curve domain separation tag.
     pub const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
     define_bls12381!(BLS_G1_LENGTH, BLS_G2_LENGTH, DST_G2);
 
@@ -797,23 +797,23 @@ pub mod min_pk {
                 let mut serialized: [u8; 96] = [0; 96];
 
                 unsafe {
-                    // Public key as affine point
+                    // Public key as affine point.
                     let mut pubkey_affine_pt = blst_p1_affine::default();
                     blst_p1_deserialize(&mut pubkey_affine_pt, pubkey_bytes.as_ptr());
 
-                    // Public key as point
+                    // Public key as point.
                     let mut pubkey_pt = blst_p1::default();
                     blst_p1_from_affine(&mut pubkey_pt, &pubkey_affine_pt);
 
-                    // Randomization factor as scalar
+                    // Randomization factor as scalar.
                     let mut scalar = blst_scalar::default();
                     blst_scalar_from_fr(&mut scalar, r);
 
-                    // Randomized public key as point
+                    // Randomized public key as point.
                     let mut randomized_pt = blst_p1::default();
                     blst_p1_mult(&mut randomized_pt, &pubkey_pt, &(scalar.b[0]), 256);
 
-                    // Serialize randomized public key
+                    // Serialize randomized public key.
                     blst_p1_serialize(serialized.as_mut_ptr(), &randomized_pt);
                 }
                 BLS12381PublicKey {
@@ -833,23 +833,23 @@ pub mod min_pk {
                 let mut serialized: [u8; 192] = [0; 192];
 
                 unsafe {
-                    // Signagure as affine point
+                    // Signature as affine point.
                     let mut pubkey_affine_pt = blst_p2_affine::default();
                     blst_p2_deserialize(&mut pubkey_affine_pt, pubkey_bytes.as_ptr());
 
-                    // Signature as point
+                    // Signature as point.
                     let mut pubkey_pt = blst_p2::default();
                     blst_p2_from_affine(&mut pubkey_pt, &pubkey_affine_pt);
 
-                    // Randomization factor as scalar
+                    // Randomization factor as scalar.
                     let mut scalar = blst_scalar::default();
                     blst_scalar_from_fr(&mut scalar, r);
 
-                    // Randomized signature as point
+                    // Randomized signature as point.
                     let mut randomized_pt = blst_p2::default();
                     blst_p2_mult(&mut randomized_pt, &pubkey_pt, &(scalar.b[0]), 256);
 
-                    // Serialize randomized signature
+                    // Serialize randomized signature.
                     blst_p2_serialize(serialized.as_mut_ptr(), &randomized_pt);
                 }
 
@@ -868,23 +868,23 @@ pub mod min_pk {
                 let mut randomized_bytes: [u8; 32] = [0; 32];
 
                 unsafe {
-                    // Parse private key as scalar
+                    // Parse private key as scalar.
                     let mut as_scalar = blst_scalar::default();
                     blst_scalar_from_bendian(&mut as_scalar, privkey_bytes.as_ptr());
 
-                    // Convert scalar to field element
+                    // Convert scalar to field element.
                     let mut as_field_element = blst_fr::default();
                     blst_fr_from_scalar(&mut as_field_element, &as_scalar);
 
-                    // Randomize field element
+                    // Randomize field element.
                     let mut randomized_as_field_element = blst_fr::default();
                     blst_fr_mul(&mut randomized_as_field_element, &as_field_element, r);
 
-                    // Convert to scalar
+                    // Convert to scalar.
                     let mut randomized = blst_scalar::default();
                     blst_scalar_from_fr(&mut randomized, &randomized_as_field_element);
 
-                    // Serialize scalar
+                    // Serialize scalar.
                     blst_bendian_from_scalar(randomized_bytes.as_mut_ptr(), &randomized);
                 }
 

--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -26,7 +26,7 @@ use std::{fmt, marker::PhantomData};
 use crate::encoding::{Base64, Encoding};
 
 /// Represents a digest of `DIGEST_LEN` bytes.
-#[serde_with::serde_as]
+#[serde_as]
 #[derive(Hash, PartialEq, Eq, Clone, Serialize, Deserialize, Ord, PartialOrd, Copy)]
 pub struct Digest<const DIGEST_LEN: usize> {
     #[serde_as(as = "[_; DIGEST_LEN]")]

--- a/fastcrypto/src/pubkey_bytes.rs
+++ b/fastcrypto/src/pubkey_bytes.rs
@@ -29,7 +29,7 @@ where
 }
 
 impl<T, const N: usize> Display for PublicKeyBytes<T, N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let s = hex::encode(self.bytes);
         write!(f, "k#{}", s)?;
         Ok(())

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -63,7 +63,7 @@ pub trait EncodeDecodeBase64: Sized {
     fn decode_base64(value: &str) -> Result<Self, eyre::Report>;
 }
 
-// The Base64ct is not strictly necessary for (PubKey|Signature), but this simplifies things a lot
+// The Base64ct is not strictly necessary for (PubKey|Signature), but this simplifies things a lot.
 impl<T: ToFromBytes> EncodeDecodeBase64 for T {
     fn encode_base64(&self) -> String {
         Base64::encode(self.as_bytes())
@@ -106,12 +106,12 @@ pub trait VerifyingKey:
     + DeserializeOwned
     + std::hash::Hash
     + Display
-    + Eq  // required to make some cached bytes representations explicit
-    + Ord // required to put keys in BTreeMap
-    + Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34)
+    + Eq  // required to make some cached bytes representations explicit.
+    + Ord // required to put keys in BTreeMap.
+    + Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34).
     + ToFromBytes
     + signature::Verifier<Self::Sig>
-    + for<'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey
+    + for<'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey.
     + Send
     + Sync
     + 'static


### PR DESCRIPTION
Tiny changes.
Mainly extra private method for obtaining x-coordinate in conversions.rs, for which I have a question for @huitseeker actually: The method returns an Option<Fq> but we always unwrap it (this was the behavior previously as well), is this safe?