### PR TITLE
Add digest function to multiset hash

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -50,6 +50,7 @@ sha3 = "0.10.6"
 thiserror = "1.0.37"
 twox-hash = { version = "1.6.3", optional = true }
 schemars ="0.8.10"
+bincode = "1.3.3"
 
 fastcrypto-derive = { path = "../fastcrypto-derive", version = "0.1.2" }
 
@@ -75,7 +76,6 @@ no-threads-blst = ["blst/no-threads"]
 experimental = []
 
 [dev-dependencies]
-bincode = "1.3.3"
 criterion = "0.4.0"
 hex-literal = "0.3.4"
 k256 = { version = "0.11.6", features = ["ecdsa", "sha256", "keccak256"] }

--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -254,8 +254,9 @@ pub trait MultisetHash<const DIGEST_LENGTH: usize>: Eq {
 /// For more information about the construction of ECMH and its security, see ["Elliptic Curve Multiset Hash" by J.
 /// Maitin-Shepard et al.](https://arxiv.org/abs/1601.06502).
 ///
-/// It uses Sha512 to hash to construct a RistrettoPoint from the given data using an Ristretto-flavoured Elligator 2 map,
-/// and Sha256 to construct a digest from a serialization of the resulting RistrettoPoint, so digests are 32 bytes long.
+/// Under the hood, it uses an Ristretto-flavoured Elligator 2 map to map a Sha512 hash of the provided
+/// data into points in the Ristretto group, and Sha256 to construct a digest from a serialization of
+/// the resulting RistrettoPoint, so digests are 32 bytes long.
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct EllipticCurveMultisetHash {
     accumulator: RistrettoPoint,

--- a/fastcrypto/src/tests/hash_tests.rs
+++ b/fastcrypto/src/tests/hash_tests.rs
@@ -81,11 +81,13 @@ fn test_accumulator() {
     let check1 = accumulator.clone();
     accumulator.insert(b"World");
     assert_ne!(check1, accumulator);
+    assert_ne!(check1.digest(), accumulator.digest());
 
     // Hashing the same elements should give the same hash
     let mut accumulator2 = EllipticCurveMultisetHash::default();
     accumulator2.insert_all([b"Hello", b"World"]);
     assert_eq!(accumulator, accumulator2);
+    assert_eq!(accumulator.digest(), accumulator2.digest());
 
     // The order doesn't matter
     let mut accumulator3 = EllipticCurveMultisetHash::default();


### PR DESCRIPTION
I missed the digest function from the accumulator in sui in PR #299 so it's added here.