### PR TITLE
Pin GitHub Actions in workflows to commit SHA

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -5,33 +5,33 @@ on:
     types: [published]
 
 jobs:
-   benchmark:
-     name: Continuous benchmarking
-     runs-on: ubuntu-ghcloud
-     steps:
-       - uses: actions/checkout@v3
-       - name: Get old benchmarks
-         uses: actions/checkout@v3
-         with:
-           ref: gh-pages
-           path: gh-pages
-       - run: mkdir -p target; cp -r gh-pages/benchmarks/criterion target;
-       - name: Install criterion
-         run: cargo install cargo-criterion
-       - name: Run benchmarks
-         run: cd fastcrypto; cargo criterion --message-format=json --no-default-features --features no-threads-blst > ../${{ github.sha }}.json; cd ..
-       - name: Deploy latest benchmark report
-         uses: peaceiris/actions-gh-pages@v3
-         with:
-           github_token: ${{ secrets.GITHUB_TOKEN }}
-           publish_dir: ./target/criterion
-           destination_dir: benchmarks/criterion
-       - name: Move benchmark json to history
-         run: mkdir history; cp ${{ github.sha }}.json history/
-       - name: Deploy benchmark history
-         uses: peaceiris/actions-gh-pages@v3
-         with:
-           github_token: ${{ secrets.GITHUB_TOKEN }}
-           publish_dir: history/
-           destination_dir: benchmarks/history
-           keep_files: true
+  benchmark:
+    name: Continuous benchmarking
+    runs-on: ubuntu-ghcloud
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - name: Get old benchmarks
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - run: mkdir -p target; cp -r gh-pages/benchmarks/criterion target;
+      - name: Install criterion
+        run: cargo install cargo-criterion
+      - name: Run benchmarks
+        run: cd fastcrypto; cargo criterion --message-format=json --no-default-features --features no-threads-blst > ../${{ github.sha }}.json; cd ..
+      - name: Deploy latest benchmark report
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # pin@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/criterion
+          destination_dir: benchmarks/criterion
+      - name: Move benchmark json to history
+        run: mkdir history; cp ${{ github.sha }}.json history/
+      - name: Deploy benchmark history
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # pin@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: history/
+          destination_dir: benchmarks/history
+          keep_files: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - uses: ahmadnassri/action-dependabot-auto-merge@7dbc44641f77fb62b23158c1294b5b757d6091a5 # pin@v2.6
         with:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
           command: 'squash and merge'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,23 +11,24 @@ on:
       - "Cargo.lock"
   workflow_dispatch:
 
+
 jobs:
   docs:
     name: Generate crate documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
 
       - name: Generate documentation
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
         with:
@@ -35,7 +36,7 @@ jobs:
           args: --workspace --no-deps
 
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # pin@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,9 @@ jobs:
           - fastcrypto-derive
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           profile: minimal
           toolchain: nightly
@@ -72,7 +72,7 @@ jobs:
           export CURRENT_VERSION="$(./scripts/get_current_version.sh ${{ matrix.package }})"
           git tag "${{ matrix.package }}-v$CURRENT_VERSION"
           git push origin "${{ matrix.package }}-v$CURRENT_VERSION"
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         if: steps.check.outputs.is_new_version == 'yes'
       - name: Login
         run: cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,8 +34,8 @@ jobs:
     name: license-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
       - run: scripts/license_check.sh
 
   test:
@@ -49,9 +49,9 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-      - uses: taiki-e/install-action@nextest
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      - uses: taiki-e/install-action@d30f7ecb94d4d882276efb3967be14b8ef34d289 # pin@nextest
       # make sure benches don't bit-rot
       - name: build benches
         run: cargo build --benches --all-features
@@ -67,8 +67,8 @@ jobs:
   clippy:
     runs-on: ubuntu-ghcloud
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           components: clippy
       # See '.cargo/config' for list of enabled/disappled clippy lints
@@ -78,12 +78,12 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           components: rustfmt
       - name: rustfmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: fmt
           args: --all --check
@@ -92,5 +92,5 @@ jobs:
     name: cargo-deny (advisories, licenses, bans, ...)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+      - uses: EmbarkStudios/cargo-deny-action@8a8607bd8e2b3a514d5a40174cc7c55b229d9ba7 # pin@v1


### PR DESCRIPTION
Used [mheap/pin-github-action](https://github.com/mheap/pin-github-action) to update the workfows in `.github/workflows/*.yml`

The utility updates the actions in the workflow to the specific SHA commit referenced at that particular version. It leaves the specific version pinned as a comment alongside the action.

This change follows best practices documented by:
* [GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
* [OpenSSF](https://github.com/ossf/scorecard/blob/7206a2bdeb7020ab45744a1a6234c9ddf2f3713c/docs/checks.md#pinned-dependencies)