### PR TITLE
crypto: Add Intent and IntentMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
+name = "bcs"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b06b4c1f053002b70e7084ac944c77d58d5d92b2110dbc5e852735e00ad3ccc"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1041,7 @@ dependencies = [
  "base58",
  "base64 0.20.0",
  "base64ct",
+ "bcs",
  "bincode",
  "blake2 0.10.6",
  "blake3",
@@ -1070,6 +1081,7 @@ dependencies = [
  "serde-reflection",
  "serde_bytes",
  "serde_json",
+ "serde_repr",
  "serde_with",
  "sha2 0.10.6",
  "sha3 0.10.6",
@@ -2028,6 +2040,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -51,6 +51,8 @@ thiserror = "1.0.38"
 twox-hash = { version = "1.6.3", optional = true }
 schemars ="0.8.10"
 bincode = "1.3.3"
+serde_repr = "0.1"
+bcs = "0.1.4"
 
 fastcrypto-derive = { path = "../fastcrypto-derive", version = "0.1.2" }
 
@@ -74,6 +76,7 @@ copy_key = []
 unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]
 no-threads-blst = ["blst/no-threads"]
 experimental = []
+intent = []
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/fastcrypto/src/intent.rs
+++ b/fastcrypto/src/intent.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
+
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[repr(u8)]
+pub enum IntentVersion {
+    V0 = 0,
+}
+
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[repr(u8)]
+pub enum AppId {
+    Sui = 0,
+    Narwhal = 1,
+}
+
+pub trait SecureIntent: Serialize + private::SealedIntent {}
+
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[repr(u8)]
+pub enum IntentScope {
+    TransactionData = 0,
+    CheckpointSummary = 1,
+    PersonalMessage = 2,
+    SenderSignedTransaction = 3,
+    ProofOfPossession = 4,
+    Genesis = 5,
+    CertificateDigest = 6,
+    VoteDigest = 7,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Hash)]
+pub struct Intent {
+    scope: IntentScope,
+    version: IntentVersion,
+    app_id: AppId,
+}
+
+impl Intent {
+    pub fn with_app_id(mut self, app_id: AppId) -> Self {
+        self.app_id = app_id;
+        self
+    }
+
+    pub fn with_scope(mut self, scope: IntentScope) -> Self {
+        self.scope = scope;
+        self
+    }
+
+    pub fn with_version(mut self, version: IntentVersion) -> Self {
+        self.version = version;
+        self
+    }
+}
+
+impl Default for Intent {
+    fn default() -> Self {
+        Self {
+            version: IntentVersion::V0,
+            scope: IntentScope::TransactionData,
+            app_id: AppId::Sui,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Clone, Hash, Deserialize)]
+pub struct IntentMessage<T> {
+    pub intent: Intent,
+    pub value: T,
+}
+
+impl<T> IntentMessage<T> {
+    pub fn new(intent: Intent, value: T) -> Self {
+        Self { intent, value }
+    }
+}
+
+// --- PersonalMessage intent ---
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct PersonalMessage {
+    pub message: Vec<u8>,
+}
+
+pub(crate) mod private {
+    use super::IntentMessage;
+
+    pub trait SealedIntent {}
+    impl<T> SealedIntent for IntentMessage<T> {}
+}

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -70,6 +70,11 @@ pub mod ristretto255_tests;
 #[path = "tests/bls12381_group_tests.rs"]
 pub mod bls12381_group_tests;
 
+#[cfg(feature = "intent")]
+#[cfg(test)]
+#[path = "tests/intent_tests.rs"]
+pub mod intent_tests;
+
 // Signing traits
 pub mod traits;
 // Key scheme implementations
@@ -90,6 +95,10 @@ pub mod error;
 pub mod private_seed;
 pub mod serde_helpers;
 pub mod signature_service;
+
+/// This module contains enums and structs related to intent signing.
+#[cfg(feature = "intent")]
+pub mod intent;
 
 /// This module contains unsecure cryptographic primitives. The purpose of this library is to allow seamless
 /// benchmarking of systems without taking into account the cost of cryptographic primitives - and hence

--- a/fastcrypto/src/tests/intent_tests.rs
+++ b/fastcrypto/src/tests/intent_tests.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::intent::{Intent, IntentMessage, IntentScope};
+
+#[test]
+fn test_intent_msg_serde() {
+    let msg = IntentMessage::new(Intent::default(), "test".to_string());
+    let serialized = bcs::to_bytes(&msg).unwrap();
+    assert_eq!(serialized[..3], [0, 0, 0]);
+
+    let msg = IntentMessage::new(
+        Intent::default().with_scope(IntentScope::PersonalMessage),
+        "test".to_string(),
+    );
+    let serialized = bcs::to_bytes(&msg).unwrap();
+    assert_eq!(serialized[..3], [2, 0, 0]);
+}


### PR DESCRIPTION
moving this from sui to fastcrypto since both sui and narwhal depends on it. see https://github.com/MystenLabs/sui/pull/6927 for usage

this contains some basic tests, the meaty tests lives in sui and narwhal where the struct to bcs serialize is defined. putting behind feature flag since not all users of fastcrypto care about this. 