### PR TITLE
Update the serializer of aggregated BLS

### DIFF
--- a/fastcrypto/src/bls12381/min_pk/mod.rs
+++ b/fastcrypto/src/bls12381/min_pk/mod.rs
@@ -4,7 +4,6 @@
 //! Module minimizing the size of public keys. See also [min_sig].
 
 use super::*;
-use crate::serde_helpers::min_pk::BlsSignature;
 use blst::min_pk as blst;
 /// Hash-to-curve domain separation tag.
 pub const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";

--- a/fastcrypto/src/bls12381/min_sig/mod.rs
+++ b/fastcrypto/src/bls12381/min_sig/mod.rs
@@ -4,7 +4,6 @@
 //! Module minimizing the size of signatures. See also [min_pk].
 
 use super::*;
-use crate::serde_helpers::min_sig::BlsSignature;
 use blst::min_sig as blst;
 /// Hash-to-curve domain separation tag.
 pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";

--- a/fastcrypto/src/serde_helpers.rs
+++ b/fastcrypto/src/serde_helpers.rs
@@ -18,7 +18,7 @@ use crate::{
     traits::{KeyPair, SigningKey, ToFromBytes, VerifyingKey},
 };
 
-pub fn to_custom_error<'de, D, E>(e: E) -> D::Error
+pub(crate) fn to_custom_error<'de, D, E>(e: E) -> D::Error
 where
     E: Debug,
     D: Deserializer<'de>,

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -302,6 +302,13 @@ fn test_serialize_deserialize_aggregate_signatures() {
     let serialized = bincode::serialize(&sig).unwrap();
     let deserialized: BLS12381AggregateSignature = bincode::deserialize(&serialized).unwrap();
     assert_eq!(deserialized.as_ref(), sig.as_ref());
+
+    let sig_as_bytes = BLS12381AggregateSignatureAsBytes::from(&sig);
+    let as_bytes_ser = bincode::serialize(&sig_as_bytes).unwrap();
+    assert_eq!(serialized, as_bytes_ser);
+    let as_bytes_des: BLS12381AggregateSignatureAsBytes = bincode::deserialize(&as_bytes_ser).unwrap();
+    let sig2 = BLS12381AggregateSignature::try_from(&as_bytes_des).unwrap();
+    assert_eq!(sig.sig, sig2.sig);
 }
 
 #[test]
@@ -680,8 +687,8 @@ proptest! {
 pub mod min_sig {
     use super::*;
     use crate::bls12381::min_sig::{
-        BLS12381AggregateSignature, BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey,
-        BLS12381Signature,
+        BLS12381AggregateSignature, BLS12381AggregateSignatureAsBytes, BLS12381KeyPair,
+        BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
     };
     define_tests!();
 }
@@ -689,8 +696,8 @@ pub mod min_sig {
 pub mod min_pk {
     use super::*;
     use crate::bls12381::min_pk::{
-        BLS12381AggregateSignature, BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey,
-        BLS12381Signature,
+        BLS12381AggregateSignature, BLS12381AggregateSignatureAsBytes, BLS12381KeyPair,
+        BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
     };
     define_tests!();
 


### PR DESCRIPTION
- Move the serializer of aggregated BLS to the same file with the rest of the code
- Use SerializationHelper to serialize a fixed length array (as it previously used more bytes since it added the length as a prefix)