### PR TITLE
crypto: PartialEq compares bytes representation

### DIFF
--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -330,7 +330,7 @@ impl std::hash::Hash for BLS12381Signature {
 
 impl PartialEq for BLS12381Signature {
     fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
+        self.as_ref() == other.as_ref()
     }
 }
 

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -82,13 +82,20 @@ impl PartialEq for Ed25519PrivateKey {
 impl Eq for Ed25519PrivateKey {}
 
 /// Ed25519 signature.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Ed25519Signature {
     pub sig: ed25519_consensus::Signature,
     // Helps implementing AsRef<[u8]>.
     pub bytes: OnceCell<[u8; ED25519_SIGNATURE_LENGTH]>,
 }
 
+impl PartialEq for Ed25519Signature {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for Ed25519Signature {}
 /// Aggregation of multiple Ed25519 signatures.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/fastcrypto/src/secp256k1.rs
+++ b/fastcrypto/src/secp256k1.rs
@@ -291,7 +291,7 @@ impl std::hash::Hash for Secp256k1Signature {
 
 impl PartialEq for Secp256k1Signature {
     fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
+        self.as_ref() == other.as_ref()
     }
 }
 

--- a/fastcrypto/src/secp256r1.rs
+++ b/fastcrypto/src/secp256r1.rs
@@ -310,7 +310,7 @@ impl std::hash::Hash for Secp256r1Signature {
 
 impl PartialEq for Secp256r1Signature {
     fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
+        self.sig.as_ref() == other.sig.as_ref()
     }
 }
 

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -54,7 +54,7 @@ fn test_serde_signatures_non_human_readable() {
     let sig = keys().pop().unwrap().sign(message);
     let serialized = bincode::serialize(&sig).unwrap();
     let deserialized: Ed25519Signature = bincode::deserialize(&serialized).unwrap();
-    assert_eq!(deserialized.sig, sig.sig);
+    assert_eq!(deserialized, sig);
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn to_from_bytes_signature() {
     let signature = kpref.sign(b"Hello, world");
     let sig_bytes = signature.as_ref();
     let rebuilt_sig = <Ed25519Signature as ToFromBytes>::from_bytes(sig_bytes).unwrap();
-    assert_eq!(rebuilt_sig.as_ref(), signature.as_ref());
+    assert_eq!(rebuilt_sig, signature);
 }
 
 #[test]

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -50,7 +50,7 @@ fn serialize_deserialize() {
     let serialized = serde_json::to_string(&signature).unwrap();
     println!("{:?}", serialized);
     let deserialized: Secp256k1Signature = serde_json::from_str(&serialized).unwrap();
-    assert_eq!(deserialized.as_ref(), signature.as_ref());
+    assert_eq!(deserialized, signature);
 }
 
 #[test]

--- a/fastcrypto/src/tests/secp256r1_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_tests.rs
@@ -52,7 +52,7 @@ fn serialize_deserialize() {
     let serialized = serde_json::to_string(&signature).unwrap();
     println!("{:?}", serialized);
     let deserialized: Secp256r1Signature = serde_json::from_str(&serialized).unwrap();
-    assert_eq!(deserialized.as_ref(), signature.as_ref());
+    assert_eq!(deserialized, signature);
 }
 
 #[test]


### PR DESCRIPTION
make sure the equality is checked on bytes. otherewise the struct may not have oncecell initialized and fails equality check. 