### PR TITLE
Add recover_hashed to secp256_k1

### DIFF
--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -109,23 +109,19 @@ impl Verifier<Secp256k1RecoverableSignature> for Secp256k1RecoverablePublicKey {
         signature: &Secp256k1RecoverableSignature,
     ) -> Result<(), signature::Error> {
         let message = hash_message(msg);
-
-        // If pubkey recovered from signature matches original pubkey, verifies signature.
-        // To ensure non-malleability of v, signature.verify_ecdsa() is not used since it will verify using only [r, s] without considering v.
-        match signature.sig.recover(&message) {
-            Ok(recovered_key) if self.as_bytes() == recovered_key.serialize().as_slice() => Ok(()),
-            _ => Err(signature::Error::new()),
-        }
+        self.verify_hashed(message.as_ref(), signature)
     }
 }
 
 impl Secp256k1RecoverablePublicKey {
     pub fn verify_hashed(
         &self,
-        hased_msg: &[u8],
+        hashed_msg: &[u8],
         signature: &Secp256k1RecoverableSignature,
     ) -> Result<(), signature::Error> {
-        match Message::from_slice(hased_msg) {
+        // If pubkey recovered from signature matches original pubkey, verifies signature.
+        // To ensure non-malleability of v, signature.verify_ecdsa() is not used since it will verify using only [r, s] without considering v.
+        match Message::from_slice(hashed_msg) {
             Ok(message) => match signature.sig.recover(&message) {
                 Ok(recovered_key) if self.as_bytes() == recovered_key.serialize().as_slice() => {
                     Ok(())

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -12,7 +12,7 @@
 //! let kp = Secp256k1RecoverableKeyPair::generate(&mut thread_rng());
 //! let message: &[u8] = b"Hello, world!";
 //! let signature = kp.sign(message);
-//! assert_eq!(signature.recover(message).unwrap(), kp.name);
+//! assert_eq!(&signature.recover(message).unwrap(), kp.public());
 //! ```
 
 use crate::{

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -114,7 +114,7 @@ impl Verifier<Secp256k1RecoverableSignature> for Secp256k1RecoverablePublicKey {
 }
 
 impl Secp256k1RecoverablePublicKey {
-    pub fn verify_hashed(
+    pub(crate) fn verify_hashed(
         &self,
         hashed_msg: &[u8],
         signature: &Secp256k1RecoverableSignature,
@@ -414,7 +414,7 @@ impl Secp256k1RecoverableSignature {
     }
 
     /// Recover public key from signature and an already hashed message.
-    pub fn recover_hashed(
+    pub(crate) fn recover_hashed(
         &self,
         hashed_msg: &[u8],
     ) -> Result<Secp256k1RecoverablePublicKey, FastCryptoError> {

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -71,9 +71,7 @@ fn test_public_key_recovery() {
     let kp = keys().pop().unwrap();
     let message: &[u8] = b"Hello, world!";
     let signature: Secp256k1RecoverableSignature = kp.sign(message);
-    let recovered_key = signature
-        .recover(Keccak256::digest(message).as_ref())
-        .unwrap();
+    let recovered_key = signature.recover(message).unwrap();
     assert_eq!(*kp.public(), recovered_key);
 }
 
@@ -87,13 +85,12 @@ fn test_public_key_recovery_error() {
 
     let signature = <Secp256k1RecoverableSignature as ToFromBytes>::from_bytes(&[0u8; 65]).unwrap();
     let message: &[u8] = b"Hello, world!";
-    assert!(signature
-        .recover(Keccak256::digest(message).as_ref())
-        .is_err());
+    assert!(signature.recover(message).is_err());
 
+    // Verify signature over non-hashed message
     let kp = keys().pop().unwrap();
     let signature_2: Secp256k1RecoverableSignature = kp.sign(message);
-    assert!(signature_2.recover(message).is_err());
+    assert!(signature_2.recover_hashed(message).is_err());
 }
 #[test]
 fn import_export_secret_key() {


### PR DESCRIPTION
Also ensure that the right hash function is used internally in tests.