### PR TITLE
Add benchmarks for ECVRF

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -64,6 +64,10 @@ name = "encoding"
 harness = false
 
 [[bench]]
+name = "vrf"
+harness = false
+
+[[bench]]
 name = "mskr"
 harness = false
 required-features = ["experimental"]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -64,7 +64,7 @@ name = "encoding"
 harness = false
 
 [[bench]]
-name = "vrf"
+name = "ecvrf_ristretto"
 harness = false
 
 [[bench]]

--- a/fastcrypto/benches/ecvrf_ristretto.rs
+++ b/fastcrypto/benches/ecvrf_ristretto.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate criterion;
 
-mod vrf_benches {
+mod ecvrf_ristretto_benches {
 
     use criterion::Criterion;
     use fastcrypto::vrf::ecvrf::ECVRFKeyPair;
@@ -14,7 +14,7 @@ mod vrf_benches {
 
     fn keygen(c: &mut Criterion) {
         let mut csprng: ThreadRng = thread_rng();
-        c.bench_function("ECVRF key generation", move |b| {
+        c.bench_function("ECVRF Ristretto key generation", move |b| {
             b.iter(|| ECVRFKeyPair::generate(&mut csprng))
         });
     }
@@ -22,23 +22,25 @@ mod vrf_benches {
     fn proof(c: &mut Criterion) {
         let kp = ECVRFKeyPair::generate(&mut thread_rng());
         let input = b"Hello, world!";
-        c.bench_function("ECVRF proving", move |b| b.iter(|| kp.prove(input)));
+        c.bench_function("ECVRF Ristretto proving", move |b| {
+            b.iter(|| kp.prove(input))
+        });
     }
 
     fn verify(c: &mut Criterion) {
         let kp = ECVRFKeyPair::generate(&mut thread_rng());
         let input = b"Hello, world!";
         let proof = kp.prove(input);
-        c.bench_function("ECVRF verification", move |b| {
+        c.bench_function("ECVRF Ristretto verification", move |b| {
             b.iter(|| proof.verify(input, &kp.pk))
         });
     }
 
     criterion_group! {
-        name = vrf_benches;
+        name = ecvrf_ristretto_benches;
         config = Criterion::default().sample_size(100);
         targets = keygen, proof, verify,
     }
 }
 
-criterion_main!(vrf_benches::vrf_benches,);
+criterion_main!(ecvrf_ristretto_benches::ecvrf_ristretto_benches,);

--- a/fastcrypto/benches/vrf.rs
+++ b/fastcrypto/benches/vrf.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate criterion;
+
+mod vrf_benches {
+
+    use criterion::Criterion;
+    use fastcrypto::vrf::ecvrf::ECVRFKeyPair;
+    use fastcrypto::vrf::VRFKeyPair;
+    use fastcrypto::vrf::VRFProof;
+    use rand::rngs::ThreadRng;
+    use rand::thread_rng;
+
+    fn keygen(c: &mut Criterion) {
+        let mut csprng: ThreadRng = thread_rng();
+        c.bench_function("ECVRF key generation", move |b| {
+            b.iter(|| ECVRFKeyPair::generate(&mut csprng))
+        });
+    }
+
+    fn proof(c: &mut Criterion) {
+        let kp = ECVRFKeyPair::generate(&mut thread_rng());
+        let input = b"Hello, world!";
+        c.bench_function("ECVRF proving", move |b| b.iter(|| kp.prove(input)));
+    }
+
+    fn verify(c: &mut Criterion) {
+        let kp = ECVRFKeyPair::generate(&mut thread_rng());
+        let input = b"Hello, world!";
+        let proof = kp.prove(input);
+        c.bench_function("ECVRF verification", move |b| {
+            b.iter(|| proof.verify(input, &kp.pk))
+        });
+    }
+
+    criterion_group! {
+        name = vrf_benches;
+        config = Criterion::default().sample_size(100);
+        targets = keygen, proof, verify,
+    }
+}
+
+criterion_main!(vrf_benches::vrf_benches,);


### PR DESCRIPTION
Fore reference, here are the benchmarks run on my laptop:
```
ECVRF Ristretto key generation
                        time:   [31.628 µs 31.731 µs 31.836 µs]
                        change: [-0.8404% -0.3259% +0.2225%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

ECVRF Ristretto proving time:   [130.41 µs 130.84 µs 131.29 µs]

ECVRF Ristretto verification
                        time:   [158.36 µs 158.87 µs 159.41 µs]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```
For comparison, here are benchmarks for signing and verifying BLS12381 signatures. Note that proving/signing is about the same if we use MinSig, but verification with ECVRF is about x4 times faster than MinSig and x5 faster than MinPk mode:
```
Sign/BLS12381MinSig     time:   [138.05 µs 138.66 µs 139.28 µs]
                        change: [+1.0652% +2.0322% +3.1337%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe

Sign/BLS12381MinPk      time:   [306.88 µs 308.04 µs 309.54 µs]
                        change: [+1.7329% +2.1874% +2.6502%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 20 measurements (15.00%)
  1 (5.00%) low mild
  1 (5.00%) high mild
  1 (5.00%) high severe

Verify/BLS12381MinSig   time:   [641.00 µs 644.32 µs 648.58 µs]
                        change: [+1.1418% +1.9667% +2.9040%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe

Verify/BLS12381MinPk    time:   [738.40 µs 743.03 µs 748.39 µs]
                        change: [+1.0877% +1.6979% +2.3319%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
```