### PR TITLE
Add benchmarks for group operations

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -68,6 +68,10 @@ name = "ecvrf_ristretto"
 harness = false
 
 [[bench]]
+name = "groups"
+harness = false
+
+[[bench]]
 name = "mskr"
 harness = false
 required-features = ["experimental"]

--- a/fastcrypto/benches/groups.rs
+++ b/fastcrypto/benches/groups.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate criterion;
+
+mod group_benches {
+    use criterion::{measurement, BenchmarkGroup, Criterion};
+    use fastcrypto::groups::bls12381::{G1Element, G2Element, GTElement};
+    use fastcrypto::groups::ristretto255::RistrettoPoint;
+    use fastcrypto::groups::{GroupElement, HashToGroupElement, Pairing, Scalar};
+    use rand::thread_rng;
+
+    fn add_single<G: GroupElement, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let x = G::generator() * G::ScalarType::rand(&mut thread_rng());
+        let y = G::generator() * G::ScalarType::rand(&mut thread_rng());
+        c.bench_function(&(name.to_string()), move |b| b.iter(|| x + y));
+    }
+
+    fn add(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Add");
+        add_single::<G1Element, _>("BLS12381-G1", &mut group);
+        add_single::<G2Element, _>("BLS12381-G2", &mut group);
+        add_single::<GTElement, _>("BLS12381-GT", &mut group);
+        add_single::<RistrettoPoint, _>("Ristretto255", &mut group);
+    }
+
+    fn scale_single<G: GroupElement, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let x = G::generator() * G::ScalarType::rand(&mut thread_rng());
+        let y = G::ScalarType::rand(&mut thread_rng());
+        c.bench_function(&(name.to_string()), move |b| b.iter(|| x * y));
+    }
+
+    fn scale(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Scale");
+        scale_single::<G1Element, _>("BLS12381-G1", &mut group);
+        scale_single::<G2Element, _>("BLS12381-G2", &mut group);
+        scale_single::<GTElement, _>("BLS12381-GT", &mut group);
+        scale_single::<RistrettoPoint, _>("Ristretto255", &mut group);
+    }
+
+    fn hash_to_group_single<G: GroupElement + HashToGroupElement, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let seed = b"Hello, World!";
+        c.bench_function(&(name.to_string()), move |b| {
+            b.iter(|| G::hash_to_group_element(seed))
+        });
+    }
+
+    fn hash_to_group(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Hash-to-group");
+        hash_to_group_single::<G1Element, _>("BLS12381-G1", &mut group);
+        hash_to_group_single::<G2Element, _>("BLS12381-G2", &mut group);
+        hash_to_group_single::<RistrettoPoint, _>("Ristretto255", &mut group);
+    }
+
+    fn pairing_single<G: GroupElement + Pairing, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let x = G::generator() * G::ScalarType::rand(&mut thread_rng());
+        let y = G::Other::generator()
+            * <<G as Pairing>::Other as GroupElement>::ScalarType::rand(&mut thread_rng());
+        c.bench_function(&(name.to_string()), move |b| b.iter(|| G::pairing(&x, &y)));
+    }
+
+    fn pairing(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Pairing");
+        pairing_single::<G1Element, _>("BLS12381-G1", &mut group);
+    }
+
+    criterion_group! {
+        name = group_benches;
+        config = Criterion::default().sample_size(100);
+        targets =
+            add,
+            scale,
+            hash_to_group,
+            pairing,
+    }
+}
+
+criterion_main!(group_benches::group_benches,);

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -84,6 +84,12 @@ impl TryFrom<&[u8]> for RistrettoPoint {
     }
 }
 
+impl HashToGroupElement for RistrettoPoint {
+    fn hash_to_group_element(msg: &[u8]) -> Self {
+        RistrettoPoint::map_to_point::<Sha512>(msg)
+    }
+}
+
 impl ToFromByteArray<RISTRETTO_POINT_BYTE_LENGTH> for RistrettoPoint {
     fn from_byte_array(bytes: &[u8; RISTRETTO_POINT_BYTE_LENGTH]) -> Result<Self, FastCryptoError> {
         Self::try_from(bytes.as_slice())


### PR DESCRIPTION
Closing #387 

Below are results from the new benchmarks. For scaling/exponentiation, it doesn't seem to matter whether the base is a random point or the generator for the groups tested here, so there are apparently no pre computation of powers of the generator done.

![Group operations (µs)](https://user-images.githubusercontent.com/6288307/216025566-8d4b06c1-d10c-4466-9fab-76cacbecbbce.png)
Below we omit pairing and G_t scaling to more clearly see the difference between Ristretto and G1/G2:
![Group operations (µs)-2](https://user-images.githubusercontent.com/6288307/216025561-0054b48d-f76c-4219-81c4-2848d3eb0dc7.png)

