### PR TITLE
Remove Default from signature related traits

### DIFF
--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -163,16 +163,6 @@ impl ToFromBytes for Secp256k1PublicKey {
     }
 }
 
-impl Default for Secp256k1PublicKey {
-    fn default() -> Self {
-        // Return the generator for k256 (https://www.secg.org/sec2-v2.pdf)
-        Secp256k1PublicKey {
-            pubkey: PublicKey::from_slice(hex::decode("0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8").unwrap().as_slice()).unwrap(),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
 impl Display for Secp256k1PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Base64::encode(self.as_ref()))
@@ -281,12 +271,6 @@ impl std::hash::Hash for Secp256k1Signature {
 impl Display for Secp256k1Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl Default for Secp256k1Signature {
-    fn default() -> Self {
-        <Secp256k1Signature as Signature>::from_bytes(&[1u8; SECP256K1_SIGNATURE_LENGTH]).unwrap()
     }
 }
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -164,16 +164,6 @@ impl ToFromBytes for Secp256k1RecoverablePublicKey {
     }
 }
 
-impl Default for Secp256k1RecoverablePublicKey {
-    fn default() -> Self {
-        // Return the generator for k256 (https://www.secg.org/sec2-v2.pdf)
-        Secp256k1RecoverablePublicKey {
-            pubkey: PublicKey::from_slice(hex::decode("0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8").unwrap().as_slice()).unwrap(),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
 impl Display for Secp256k1RecoverablePublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Base64::encode(self.as_ref()))
@@ -293,15 +283,6 @@ impl Eq for Secp256k1RecoverableSignature {}
 impl Display for Secp256k1RecoverableSignature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl Default for Secp256k1RecoverableSignature {
-    fn default() -> Self {
-        <Secp256k1RecoverableSignature as Signature>::from_bytes(
-            &[1u8; SECP256K1_RECOVERABLE_SIGNATURE_SIZE],
-        )
-        .unwrap()
     }
 }
 

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -27,7 +27,7 @@ use p256::ecdsa::{
 };
 use p256::elliptic_curve::group::GroupEncoding;
 use p256::elliptic_curve::IsHigh;
-use p256::{AffinePoint, NistP256, Scalar};
+use p256::NistP256;
 use signature::{Error, Signature, Signer, Verifier};
 use std::{
     fmt::{self, Debug, Display},

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -156,16 +156,6 @@ impl ToFromBytes for Secp256r1PublicKey {
     }
 }
 
-impl Default for Secp256r1PublicKey {
-    fn default() -> Self {
-        // Default public key is just the generator for the group
-        Secp256r1PublicKey {
-            pubkey: ExternalPublicKey::from_affine(AffinePoint::GENERATOR).unwrap(),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
 impl Display for Secp256r1PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Base64::encode(self.as_ref()))
@@ -288,17 +278,6 @@ impl Eq for Secp256r1Signature {}
 impl Display for Secp256r1Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl Default for Secp256r1Signature {
-    fn default() -> Self {
-        // Return the signature (1,1)
-        Secp256r1Signature {
-            sig: ExternalSignature::from_scalars(Scalar::ONE.to_bytes(), Scalar::ONE.to_bytes())
-                .unwrap(),
-            bytes: OnceCell::new(),
-        }
     }
 }
 

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -168,16 +168,6 @@ impl ToFromBytes for Secp256r1RecoverablePublicKey {
     }
 }
 
-impl Default for Secp256r1RecoverablePublicKey {
-    fn default() -> Self {
-        // Default public key is just the generator for the group
-        Secp256r1RecoverablePublicKey {
-            pubkey: ExternalPublicKey::from_affine(AffinePoint::GENERATOR).unwrap(),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
 impl Display for Secp256r1RecoverablePublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Base64::encode(self.as_ref()))
@@ -284,18 +274,6 @@ impl Eq for Secp256r1RecoverableSignature {}
 impl Display for Secp256r1RecoverableSignature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl Default for Secp256r1RecoverableSignature {
-    fn default() -> Self {
-        // Return the signature (1,1)
-        Secp256r1RecoverableSignature {
-            sig: ExternalSignature::from_scalars(Scalar::ONE.to_bytes(), Scalar::ONE.to_bytes())
-                .unwrap(),
-            bytes: OnceCell::new(),
-            recovery_id: 0u8,
-        }
     }
 }
 

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -184,14 +184,7 @@ pub trait SigningKey: ToFromBytes + Serialize + DeserializeOwned + Send + Sync +
 /// to the ones on its associated types for private key and public key material.
 ///
 pub trait Authenticator:
-    signature::Signature
-    + Display
-    + Serialize
-    + DeserializeOwned
-    + Send
-    + Sync
-    + 'static
-    + Clone
+    signature::Signature + Display + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
 {
     type PubKey: VerifyingKey<Sig = Self>;
     type PrivKey: SigningKey<Sig = Self>;

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -87,7 +87,6 @@ pub trait VerifyingKey:
     + Display
     + Eq  // required to make some cached bytes representations explicit.
     + Ord // required to put keys in BTreeMap.
-    + Default // see [#34](https://github.com/MystenLabs/narwhal/issues/34).
     + ToFromBytes
     + signature::Verifier<Self::Sig>
     + for<'a> From<&'a Self::PrivKey> // conversion PrivateKey -> PublicKey.
@@ -187,7 +186,6 @@ pub trait SigningKey: ToFromBytes + Serialize + DeserializeOwned + Send + Sync +
 pub trait Authenticator:
     signature::Signature
     + Display
-    + Default
     + Serialize
     + DeserializeOwned
     + Send
@@ -228,7 +226,7 @@ pub trait KeyPair:
 /// where aggregation is not possible, a trivial implementation is provided.
 ///
 pub trait AggregateAuthenticator:
-    Display + Default + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
+    Display + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
 {
     type Sig: Authenticator<PubKey = Self::PubKey>;
     type PubKey: VerifyingKey<Sig = Self::Sig>;


### PR DESCRIPTION
And remove the default impl of ECDSA.
Tested that doesn't break `sui`.

Related to #401 