### PR TITLE
Bump secp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
  "bitcoin_hashes",
  "rand",
@@ -1959,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
 dependencies = [
  "cc",
 ]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -17,7 +17,7 @@ eyre = "0.6.8"
 hex = "0.4.3"
 hkdf = { version = "0.12.3", features = ["std"] }
 rand.workspace = true
-rust_secp256k1 = { version = "0.24.1", package = "secp256k1", features = ["recovery", "rand-std", "bitcoin_hashes", "global-context"] }
+rust_secp256k1 = { version = "0.26.0", package = "secp256k1", features = ["recovery", "rand-std", "bitcoin_hashes", "global-context"] }
 serde.workspace = true
 serde_bytes = "0.11.8"
 serde_with = "2.1.0"

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -229,7 +229,9 @@ impl AsRef<[u8]> for Secp256k1PrivateKey {
 
 impl zeroize::Zeroize for Secp256k1PrivateKey {
     fn zeroize(&mut self) {
-        self.privkey = rust_secp256k1::ONE_KEY;
+        // Unwrap is safe here because we are using a constant and it has been tested
+        // (see fastcrypto/src/tests/secp256k1_tests::test_sk_zeroization_on_drop)
+        self.privkey = SecretKey::from_slice(&constants::ONE).unwrap();
         self.bytes.take().zeroize();
     }
 }

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -463,7 +463,9 @@ impl Secp256k1RecoverableSignature {
 
 impl zeroize::Zeroize for Secp256k1RecoverablePrivateKey {
     fn zeroize(&mut self) {
-        self.privkey = rust_secp256k1::ONE_KEY;
+        // Unwrap is safe here because we are using a constant and it has been tested
+        // (see fastcrypto/src/tests/secp256k1_recoverable_tests::test_sk_zeroization_on_drop)
+        self.privkey = SecretKey::from_slice(&constants::ONE).unwrap();
         self.bytes.take().zeroize();
     }
 }


### PR DESCRIPTION
Dependabot has given an alert: ["Unsound API in `secp256k1` allows use-after-free and invalid deallocation from safe code"](https://github.com/MystenLabs/fastcrypto/security/dependabot/1). This PR bumps the secp256k1 to the most recent version to fix that.