### PR TITLE
Remove redundant structs from recoverable k1

### DIFF
--- a/fastcrypto/benches/crypto.rs
+++ b/fastcrypto/benches/crypto.rs
@@ -8,12 +8,13 @@ extern crate rand;
 mod signature_benches {
     use super::*;
     use criterion::*;
-    use fastcrypto::secp256r1::recoverable::Secp256r1RecoverableKeyPair;
+    use fastcrypto::secp256k1::Secp256k1KeyPair;
+    use fastcrypto::secp256r1::Secp256r1KeyPair;
+    use fastcrypto::traits::{RecoverableSignature, RecoverableSigner};
     use fastcrypto::{
         bls12381,
         ed25519::*,
         hash::{Blake2b256, HashFunction},
-        secp256k1::recoverable::Secp256k1RecoverableKeyPair,
         traits::{AggregateAuthenticator, KeyPair, VerifyingKey},
         Verifier,
     };
@@ -35,8 +36,8 @@ mod signature_benches {
         sign_single::<Ed25519KeyPair, _>("Ed25519", &mut group);
         sign_single::<bls12381::min_sig::BLS12381KeyPair, _>("BLS12381MinSig", &mut group);
         sign_single::<bls12381::min_pk::BLS12381KeyPair, _>("BLS12381MinPk", &mut group);
-        sign_single::<Secp256k1RecoverableKeyPair, _>("Secp256k1", &mut group);
-        sign_single::<Secp256r1RecoverableKeyPair, _>("Secp256r1", &mut group);
+        sign_single::<Secp256k1KeyPair, _>("Secp256k1", &mut group);
+        sign_single::<Secp256r1KeyPair, _>("Secp256r1", &mut group);
     }
 
     fn verify_single<KP: KeyPair, M: measurement::Measurement>(
@@ -53,13 +54,27 @@ mod signature_benches {
         });
     }
 
+    fn recover_single<KP: RecoverableSigner + KeyPair, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let msg = b"";
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = KP::generate(&mut csprng);
+        let signature = keypair.sign_recoverable(msg);
+        c.bench_function(&(name.to_string()), move |b| {
+            b.iter(|| signature.recover(msg))
+        });
+    }
+
     fn verify(c: &mut Criterion) {
         let mut group: BenchmarkGroup<_> = c.benchmark_group("Verify");
         verify_single::<Ed25519KeyPair, _>("Ed25519", &mut group);
         verify_single::<bls12381::min_sig::BLS12381KeyPair, _>("BLS12381MinSig", &mut group);
         verify_single::<bls12381::min_pk::BLS12381KeyPair, _>("BLS12381MinPk", &mut group);
-        verify_single::<Secp256k1RecoverableKeyPair, _>("Secp256k1", &mut group);
-        verify_single::<Secp256r1RecoverableKeyPair, _>("Secp256r1", &mut group);
+        verify_single::<Secp256k1KeyPair, _>("Secp256k1", &mut group);
+        verify_single::<Secp256r1KeyPair, _>("Secp256r1", &mut group);
+        recover_single::<Secp256k1KeyPair, _>("Secp256k1 recoverable", &mut group);
     }
 
     struct TestDataBatchedVerification<KP: KeyPair> {
@@ -339,10 +354,10 @@ mod signature_benches {
             b.iter(|| bls12381::min_pk::BLS12381KeyPair::generate(&mut csprng3))
         });
         group.bench_function("Secp256k1", move |b| {
-            b.iter(|| Secp256k1RecoverableKeyPair::generate(&mut csprng4))
+            b.iter(|| Secp256k1KeyPair::generate(&mut csprng4))
         });
         group.bench_function("Secp256r1", move |b| {
-            b.iter(|| Secp256r1RecoverableKeyPair::generate(&mut csprng5))
+            b.iter(|| Secp256r1KeyPair::generate(&mut csprng5))
         });
     }
 

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -17,7 +17,7 @@
 
 pub mod recoverable;
 
-use crate::secp256k1::recoverable::{Secp256k1RecoverablePublicKey, Secp256k1RecoverableSignature};
+use crate::secp256k1::recoverable::Secp256k1RecoverableSignature;
 use crate::{
     encoding::{Base64, Encoding},
     error::FastCryptoError,
@@ -175,15 +175,6 @@ impl<'a> From<&'a Secp256k1PrivateKey> for Secp256k1PublicKey {
     fn from(secret: &'a Secp256k1PrivateKey) -> Self {
         Secp256k1PublicKey {
             pubkey: secret.privkey.public_key(&SECP256K1),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-impl From<&Secp256k1RecoverablePublicKey> for Secp256k1PublicKey {
-    fn from(pk: &Secp256k1RecoverablePublicKey) -> Self {
-        Secp256k1PublicKey {
-            pubkey: pk.pubkey,
             bytes: OnceCell::new(),
         }
     }

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -142,7 +142,7 @@ impl Secp256k1RecoverableSignature {
 }
 
 impl traits::RecoverableSignature for Secp256k1RecoverableSignature {
-    type PublicKey = Secp256k1PublicKey;
+    type PubKey = Secp256k1PublicKey;
     type Signer = Secp256k1KeyPair;
 
     /// Recover public key from signature.
@@ -196,8 +196,8 @@ impl Secp256k1PublicKey {
 }
 
 impl RecoverableSigner for Secp256k1KeyPair {
-    type PublicKey = Secp256k1PublicKey;
-    type RecoverableSignature = Secp256k1RecoverableSignature;
+    type PubKey = Secp256k1PublicKey;
+    type Sig = Secp256k1RecoverableSignature;
 
     fn sign_recoverable(&self, msg: &[u8]) -> Secp256k1RecoverableSignature {
         let secp = Secp256k1::signing_only();

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -134,7 +134,7 @@ impl Secp256k1RecoverableSignature {
         match Message::from_slice(hashed_msg) {
             Ok(message) => match self.sig.recover(&message) {
                 Ok(pubkey) => Secp256k1PublicKey::from_bytes(pubkey.serialize().as_slice()),
-                Err(_) => Err(FastCryptoError::GeneralError),
+                Err(_) => Err(FastCryptoError::GeneralOpaqueError),
             },
             Err(_) => Err(FastCryptoError::InvalidInput),
         }

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -213,6 +213,24 @@ pub trait KeyPair:
     fn generate<R: AllowedRng>(rng: &mut R) -> Self;
 }
 
+/// Trait impl'd by public / private keypairs that can generate recoverable signatures
+pub trait RecoverableSigner {
+    type PublicKey;
+    type RecoverableSignature: RecoverableSignature<Signer = Self, PublicKey = Self::PublicKey>;
+
+    /// Sign as a recoverable signature.
+    fn sign_recoverable(&self, msg: &[u8]) -> Self::RecoverableSignature;
+}
+
+/// Trait impl'd by recoverable signatures
+pub trait RecoverableSignature {
+    type PublicKey;
+    type Signer: RecoverableSigner<RecoverableSignature = Self, PublicKey = Self::PublicKey>;
+
+    /// Recover the public key from this signature.
+    fn recover(&self, msg: &[u8]) -> Result<Self::PublicKey, FastCryptoError>;
+}
+
 /// Trait impl'd by aggregated signatures in asymmetric cryptography.
 ///
 /// The trait bounds are implemented to allow the aggregation of multiple signatures,

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -215,20 +215,20 @@ pub trait KeyPair:
 
 /// Trait impl'd by public / private keypairs that can generate recoverable signatures
 pub trait RecoverableSigner {
-    type PublicKey;
-    type RecoverableSignature: RecoverableSignature<Signer = Self, PublicKey = Self::PublicKey>;
+    type PubKey;
+    type Sig: RecoverableSignature<Signer = Self, PubKey = Self::PubKey>;
 
     /// Sign as a recoverable signature.
-    fn sign_recoverable(&self, msg: &[u8]) -> Self::RecoverableSignature;
+    fn sign_recoverable(&self, msg: &[u8]) -> Self::Sig;
 }
 
 /// Trait impl'd by recoverable signatures
 pub trait RecoverableSignature {
-    type PublicKey;
-    type Signer: RecoverableSigner<RecoverableSignature = Self, PublicKey = Self::PublicKey>;
+    type PubKey;
+    type Signer: RecoverableSigner<Sig = Self, PubKey = Self::PubKey>;
 
     /// Recover the public key from this signature.
-    fn recover(&self, msg: &[u8]) -> Result<Self::PublicKey, FastCryptoError>;
+    fn recover(&self, msg: &[u8]) -> Result<Self::PubKey, FastCryptoError>;
 }
 
 /// Trait impl'd by aggregated signatures in asymmetric cryptography.


### PR DESCRIPTION
The recoverable versions of PublicKey, PrivateKey and KeyPair are redundant so they are removed here and two new traits RecoverableSigner and RecoverableSignature are added to enable some modularity between the recoverable schemes.

This keeps all functionality from before, but may require updates to various imports in Sui.

Another PR doing the same for R1 will follow shortly.