### PR TITLE
Remove more external traits

### DIFF
--- a/fastcrypto/benches/crypto.rs
+++ b/fastcrypto/benches/crypto.rs
@@ -10,6 +10,7 @@ mod signature_benches {
     use criterion::*;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use fastcrypto::secp256r1::Secp256r1KeyPair;
+    use fastcrypto::traits::Signer;
     use fastcrypto::traits::{RecoverableSignature, RecoverableSigner};
     use fastcrypto::{
         bls12381,
@@ -18,7 +19,6 @@ mod signature_benches {
         traits::{AggregateAuthenticator, KeyPair, VerifyingKey},
     };
     use rand::{prelude::ThreadRng, thread_rng};
-    use signature::Signer;
 
     fn sign_single<KP: KeyPair, M: measurement::Measurement>(
         name: &str,

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -335,9 +335,9 @@ impl PartialEq for BLS12381Signature {
 
 impl Eq for BLS12381Signature {}
 
-impl ToFromBytes for BLS12381Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_e| FastCryptoError::InvalidSignature)?;
+impl Signature for BLS12381Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
+        let sig = blst::Signature::from_bytes(bytes).map_err(|_e| signature::Error::new())?;
         Ok(BLS12381Signature {
             sig,
             bytes: OnceCell::new(),
@@ -403,14 +403,14 @@ impl SigningKey for BLS12381PrivateKey {
     const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
 }
 
-impl BLS12381PrivateKey {
-    pub fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+impl Signer<BLS12381Signature> for BLS12381PrivateKey {
+    fn try_sign(&self, msg: &[u8]) -> Result<BLS12381Signature, signature::Error> {
         let sig = self.privkey.sign(msg, $dst_string, &[]);
 
-        BLS12381Signature {
+        Ok(BLS12381Signature {
             sig,
             bytes: OnceCell::new(),
-        }
+        })
     }
 }
 
@@ -445,16 +445,6 @@ impl KeyPair for BLS12381KeyPair {
     type PrivKey = BLS12381PrivateKey;
     type Sig = BLS12381Signature;
 
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        let blst_priv: &blst::SecretKey = &self.secret.privkey;
-        let sig = blst_priv.sign(msg, $dst_string, &[]);
-
-        BLS12381Signature {
-            sig,
-            bytes: OnceCell::new(),
-        }
-    }
-
     fn public(&'_ self) -> &'_ Self::PubKey {
         &self.name
     }
@@ -486,6 +476,18 @@ impl KeyPair for BLS12381KeyPair {
                 bytes: OnceCell::new(),
             },
         }
+    }
+}
+
+impl Signer<BLS12381Signature> for BLS12381KeyPair {
+    fn try_sign(&self, msg: &[u8]) -> Result<BLS12381Signature, signature::Error> {
+        let blst_priv: &blst::SecretKey = &self.secret.privkey;
+        let sig = blst_priv.sign(msg, $dst_string, &[]);
+
+        Ok(BLS12381Signature {
+            sig,
+            bytes: OnceCell::new(),
+        })
     }
 }
 

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -26,7 +26,7 @@ use serde::{
 };
 use serde_bytes::{ByteBuf, Bytes};
 use serde_with::serde_as;
-use signature::{rand_core::OsRng, Signature, Signer};
+use signature::rand_core::OsRng;
 use std::{
     borrow::Borrow,
     fmt::{self, Debug, Display},
@@ -34,6 +34,7 @@ use std::{
 };
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+use crate::traits::Signer;
 use crate::{
     encoding::Base64,
     error::FastCryptoError,
@@ -272,14 +273,14 @@ impl AsRef<[u8]> for Ed25519PrivateKey {
     }
 }
 
-impl Signature for Ed25519Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
+impl ToFromBytes for Ed25519Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         ed25519_consensus::Signature::try_from(bytes)
             .map(|sig| Ed25519Signature {
                 sig,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 
@@ -299,7 +300,7 @@ impl Display for Ed25519Signature {
 
 impl Default for Ed25519Signature {
     fn default() -> Self {
-        <Ed25519Signature as Signature>::from_bytes(&[1u8; ED25519_SIGNATURE_LENGTH]).unwrap()
+        Ed25519Signature::from_bytes(&[1u8; ED25519_SIGNATURE_LENGTH]).unwrap()
     }
 }
 
@@ -359,8 +360,7 @@ impl<'de> Deserialize<'de> for Ed25519Signature {
                     let b = seq
                         .next_element::<ByteBuf>()?
                         .ok_or_else(|| de::Error::missing_field(RAW_FIELD_NAME))?;
-                    <Ed25519Signature as Signature>::from_bytes(&b)
-                        .map_err(|e| de::Error::custom(e.to_string()))
+                    Ed25519Signature::from_bytes(&b).map_err(|e| de::Error::custom(e.to_string()))
                 }
             }
 
@@ -384,7 +384,7 @@ impl<'de> Deserialize<'de> for Ed25519Signature {
                     if entry.0 != RAW_FIELD_NAME {
                         return Err(de::Error::unknown_field(entry.0, &[RAW_FIELD_NAME]));
                     }
-                    <Ed25519Signature as Signature>::from_bytes(entry.1)
+                    Ed25519Signature::from_bytes(entry.1)
                         .map_err(|e| de::Error::custom(e.to_string()))
                 }
             }
@@ -618,11 +618,11 @@ impl From<ed25519_consensus::SigningKey> for Ed25519KeyPair {
 }
 
 impl Signer<Ed25519Signature> for Ed25519KeyPair {
-    fn try_sign(&self, msg: &[u8]) -> Result<Ed25519Signature, signature::Error> {
-        Ok(Ed25519Signature {
+    fn sign(&self, msg: &[u8]) -> Ed25519Signature {
+        Ed25519Signature {
             sig: self.secret.0.sign(msg),
             bytes: OnceCell::new(),
-        })
+        }
     }
 }
 

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -266,20 +266,20 @@ impl Authenticator for Ed25519Signature {
     const LENGTH: usize = ED25519_SIGNATURE_LENGTH;
 }
 
-impl ToFromBytes for Ed25519Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+impl AsRef<[u8]> for Ed25519PrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Signature for Ed25519Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
         ed25519_consensus::Signature::try_from(bytes)
             .map(|sig| Ed25519Signature {
                 sig,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| FastCryptoError::InvalidSignature)
-    }
-}
-
-impl AsRef<[u8]> for Ed25519PrivateKey {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
+            .map_err(|_| signature::Error::new())
     }
 }
 
@@ -299,7 +299,7 @@ impl Display for Ed25519Signature {
 
 impl Default for Ed25519Signature {
     fn default() -> Self {
-        Ed25519Signature::from_bytes(&[1u8; ED25519_SIGNATURE_LENGTH]).unwrap()
+        <Ed25519Signature as Signature>::from_bytes(&[1u8; ED25519_SIGNATURE_LENGTH]).unwrap()
     }
 }
 
@@ -359,7 +359,8 @@ impl<'de> Deserialize<'de> for Ed25519Signature {
                     let b = seq
                         .next_element::<ByteBuf>()?
                         .ok_or_else(|| de::Error::missing_field(RAW_FIELD_NAME))?;
-                    Ed25519Signature::from_bytes(&b).map_err(|e| de::Error::custom(e.to_string()))
+                    <Ed25519Signature as Signature>::from_bytes(&b)
+                        .map_err(|e| de::Error::custom(e.to_string()))
                 }
             }
 
@@ -383,7 +384,7 @@ impl<'de> Deserialize<'de> for Ed25519Signature {
                     if entry.0 != RAW_FIELD_NAME {
                         return Err(de::Error::unknown_field(entry.0, &[RAW_FIELD_NAME]));
                     }
-                    Ed25519Signature::from_bytes(entry.1)
+                    <Ed25519Signature as Signature>::from_bytes(entry.1)
                         .map_err(|e| de::Error::custom(e.to_string()))
                 }
             }
@@ -573,13 +574,6 @@ impl KeyPair for Ed25519KeyPair {
     type PrivKey = Ed25519PrivateKey;
     type Sig = Ed25519Signature;
 
-    fn sign(&self, msg: &[u8]) -> Ed25519Signature {
-        Ed25519Signature {
-            sig: self.secret.0.sign(msg),
-            bytes: OnceCell::new(),
-        }
-    }
-
     fn public(&'_ self) -> &'_ Self::PubKey {
         &self.name
     }
@@ -620,6 +614,15 @@ impl From<ed25519_consensus::SigningKey> for Ed25519KeyPair {
             name: Ed25519PublicKey(kp.verification_key()),
             secret: Ed25519PrivateKey(kp),
         }
+    }
+}
+
+impl Signer<Ed25519Signature> for Ed25519KeyPair {
+    fn try_sign(&self, msg: &[u8]) -> Result<Ed25519Signature, signature::Error> {
+        Ok(Ed25519Signature {
+            sig: self.secret.0.sign(msg),
+            bytes: OnceCell::new(),
+        })
     }
 }
 

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -34,6 +34,7 @@ use rust_secp256k1::{
     constants, ecdsa::Signature as NonrecoverableSignature, All, Message, PublicKey, Secp256k1,
     SecretKey,
 };
+use signature::{Signature, Signer};
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
@@ -225,19 +226,17 @@ impl Drop for Secp256k1PrivateKey {
 
 serialize_deserialize_with_to_from_bytes!(Secp256k1Signature, SECP256K1_SIGNATURE_LENGTH);
 
-impl ToFromBytes for Secp256k1Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+impl Signature for Secp256k1Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
         if bytes.len() != SECP256K1_SIGNATURE_LENGTH {
-            return Err(FastCryptoError::InputLengthWrong(
-                SECP256K1_SIGNATURE_LENGTH,
-            ));
+            return Err(signature::Error::new());
         }
         NonrecoverableSignature::from_compact(bytes)
             .map(|sig| Secp256k1Signature {
                 sig,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| FastCryptoError::InvalidSignature)
+            .map_err(|_| signature::Error::new())
     }
 }
 
@@ -311,18 +310,6 @@ impl KeyPair for Secp256k1KeyPair {
     type PrivKey = Secp256k1PrivateKey;
     type Sig = Secp256k1Signature;
 
-    fn sign(&self, msg: &[u8]) -> Secp256k1Signature {
-        // Sha256 is used by default
-        let message = Message::from_hashed_data::<sha256::Hash>(msg);
-
-        // Creates a 64-bytes signature of shape [r, s].
-        // Pseudo-random deterministic nonce generation is used according to RFC6979.
-        Secp256k1Signature {
-            sig: Secp256k1::signing_only().sign_ecdsa(&message, &self.secret.privkey),
-            bytes: OnceCell::new(),
-        }
-    }
-
     fn public(&'_ self) -> &'_ Self::PubKey {
         &self.name
     }
@@ -361,6 +348,20 @@ impl FromStr for Secp256k1KeyPair {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
         Ok(kp)
+    }
+}
+
+impl Signer<Secp256k1Signature> for Secp256k1KeyPair {
+    fn try_sign(&self, msg: &[u8]) -> Result<Secp256k1Signature, signature::Error> {
+        // Sha256 is used by default
+        let message = Message::from_hashed_data::<sha256::Hash>(msg);
+
+        // Creates a 64-bytes signature of shape [r, s].
+        // Pseudo-random deterministic nonce generation is used according to RFC6979.
+        Ok(Secp256k1Signature {
+            sig: Secp256k1::signing_only().sign_ecdsa(&message, &self.secret.privkey),
+            bytes: OnceCell::new(),
+        })
     }
 }
 

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -123,12 +123,12 @@ impl Secp256k1PublicKey {
         &self,
         hashed_msg: &[u8],
         signature: &Secp256k1Signature,
-    ) -> Result<(), signature::Error> {
-        let message = Message::from_slice(hashed_msg).map_err(|_| signature::Error::new())?;
+    ) -> Result<(), FastCryptoError> {
+        let message = Message::from_slice(hashed_msg).map_err(|_| FastCryptoError::InvalidInput)?;
         signature
             .sig
             .verify(&message, &self.pubkey)
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidSignature)
     }
 
     /// util function to parse wycheproof test key from DER format.

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -18,6 +18,7 @@
 pub mod recoverable;
 
 use crate::secp256k1::recoverable::Secp256k1RecoverableSignature;
+use crate::traits::Signer;
 use crate::{
     encoding::{Base64, Encoding},
     error::FastCryptoError,
@@ -34,7 +35,6 @@ use rust_secp256k1::{
     constants, ecdsa::Signature as NonrecoverableSignature, All, Message, PublicKey, Secp256k1,
     SecretKey,
 };
-use signature::{Signature, Signer};
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
@@ -226,17 +226,19 @@ impl Drop for Secp256k1PrivateKey {
 
 serialize_deserialize_with_to_from_bytes!(Secp256k1Signature, SECP256K1_SIGNATURE_LENGTH);
 
-impl Signature for Secp256k1Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
+impl ToFromBytes for Secp256k1Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         if bytes.len() != SECP256K1_SIGNATURE_LENGTH {
-            return Err(signature::Error::new());
+            return Err(FastCryptoError::InputLengthWrong(
+                SECP256K1_SIGNATURE_LENGTH,
+            ));
         }
         NonrecoverableSignature::from_compact(bytes)
             .map(|sig| Secp256k1Signature {
                 sig,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 
@@ -352,16 +354,16 @@ impl FromStr for Secp256k1KeyPair {
 }
 
 impl Signer<Secp256k1Signature> for Secp256k1KeyPair {
-    fn try_sign(&self, msg: &[u8]) -> Result<Secp256k1Signature, signature::Error> {
+    fn sign(&self, msg: &[u8]) -> Secp256k1Signature {
         // Sha256 is used by default
         let message = Message::from_hashed_data::<sha256::Hash>(msg);
 
         // Creates a 64-bytes signature of shape [r, s].
         // Pseudo-random deterministic nonce generation is used according to RFC6979.
-        Ok(Secp256k1Signature {
+        Secp256k1Signature {
             sig: Secp256k1::signing_only().sign_ecdsa(&message, &self.secret.privkey),
             bytes: OnceCell::new(),
-        })
+        }
     }
 }
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -31,7 +31,6 @@ use rust_secp256k1::{
     ecdsa::{RecoverableSignature, RecoveryId},
     All, Message, Secp256k1,
 };
-use signature::Signature;
 use std::fmt::{self, Debug, Display};
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
@@ -52,10 +51,12 @@ serialize_deserialize_with_to_from_bytes!(
     SECP256K1_RECOVERABLE_SIGNATURE_SIZE
 );
 
-impl Signature for Secp256k1RecoverableSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
-        if bytes.len() != 65 {
-            return Err(signature::Error::new());
+impl ToFromBytes for Secp256k1RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        if bytes.len() != SECP256K1_RECOVERABLE_SIGNATURE_SIZE {
+            return Err(FastCryptoError::InputLengthWrong(
+                SECP256K1_RECOVERABLE_SIGNATURE_SIZE,
+            ));
         }
         RecoveryId::from_i32(bytes[64] as i32)
             .and_then(|rec_id| {
@@ -66,7 +67,7 @@ impl Signature for Secp256k1RecoverableSignature {
                     }
                 })
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -52,10 +52,12 @@ serialize_deserialize_with_to_from_bytes!(
     SECP256K1_RECOVERABLE_SIGNATURE_SIZE
 );
 
-impl Signature for Secp256k1RecoverableSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
-        if bytes.len() != 65 {
-            return Err(signature::Error::new());
+impl ToFromBytes for Secp256k1RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        if bytes.len() != SECP256K1_RECOVERABLE_SIGNATURE_SIZE {
+            return Err(FastCryptoError::InputLengthWrong(
+                SECP256K1_RECOVERABLE_SIGNATURE_SIZE,
+            ));
         }
         RecoveryId::from_i32(bytes[64] as i32)
             .and_then(|rec_id| {
@@ -66,7 +68,7 @@ impl Signature for Secp256k1RecoverableSignature {
                     }
                 })
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidSignature)
     }
 }
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -52,12 +52,10 @@ serialize_deserialize_with_to_from_bytes!(
     SECP256K1_RECOVERABLE_SIGNATURE_SIZE
 );
 
-impl ToFromBytes for Secp256k1RecoverableSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        if bytes.len() != SECP256K1_RECOVERABLE_SIGNATURE_SIZE {
-            return Err(FastCryptoError::InputLengthWrong(
-                SECP256K1_RECOVERABLE_SIGNATURE_SIZE,
-            ));
+impl Signature for Secp256k1RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
+        if bytes.len() != 65 {
+            return Err(signature::Error::new());
         }
         RecoveryId::from_i32(bytes[64] as i32)
             .and_then(|rec_id| {
@@ -68,7 +66,7 @@ impl ToFromBytes for Secp256k1RecoverableSignature {
                     }
                 })
             })
-            .map_err(|_| FastCryptoError::InvalidSignature)
+            .map_err(|_| signature::Error::new())
     }
 }
 

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -28,7 +28,6 @@ use p256::ecdsa::{
 use p256::elliptic_curve::group::GroupEncoding;
 use p256::elliptic_curve::IsHigh;
 use p256::NistP256;
-use signature::{Error, Signature, Signer};
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
@@ -38,6 +37,7 @@ use zeroize::Zeroize;
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 
 use crate::secp256r1::recoverable::Secp256r1RecoverableSignature;
+use crate::traits::Signer;
 use crate::{
     encoding::{Base64, Encoding},
     error::FastCryptoError,
@@ -218,13 +218,13 @@ impl zeroize::ZeroizeOnDrop for Secp256r1PrivateKey {}
 
 serialize_deserialize_with_to_from_bytes!(Secp256r1Signature, SECP256R1_SIGNATURE_LENTH);
 
-impl Signature for Secp256r1Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+impl ToFromBytes for Secp256r1Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         if bytes.len() != SECP256R1_SIGNATURE_LENTH {
-            return Err(Error::new());
+            return Err(FastCryptoError::InputLengthWrong(SECP256R1_SIGNATURE_LENTH));
         }
 
-        let sig = ExternalSignature::try_from(bytes).map_err(|_| Error::new())?;
+        let sig = ExternalSignature::try_from(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
 
         Ok(Secp256r1Signature {
             sig,
@@ -357,13 +357,13 @@ impl FromStr for Secp256r1KeyPair {
 }
 
 impl Signer<Secp256r1Signature> for Secp256r1KeyPair {
-    fn try_sign(&self, msg: &[u8]) -> Result<Secp256r1Signature, Error> {
+    fn sign(&self, msg: &[u8]) -> Secp256r1Signature {
         let sig: ecdsa::Signature<NistP256> = self.secret.privkey.sign(msg);
         let sig_low = sig.normalize_s().unwrap_or(sig);
-        Ok(Secp256r1Signature {
+        Secp256r1Signature {
             sig: sig_low,
             bytes: OnceCell::new(),
-        })
+        }
     }
 }
 

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -284,13 +284,13 @@ impl From<&Secp256r1RecoverableSignature> for Secp256r1Signature {
 impl Secp256r1Signature {
     /// util function to parse wycheproof test key from DER format.
     #[cfg(test)]
-    pub fn from_uncompressed(bytes: &[u8]) -> Result<Self, signature::Error> {
+    pub fn from_uncompressed(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         ExternalSignature::try_from(bytes)
             .map(|sig| Secp256r1Signature {
                 sig,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -28,7 +28,6 @@ use p256::ecdsa::{
 use p256::elliptic_curve::group::GroupEncoding;
 use p256::elliptic_curve::IsHigh;
 use p256::NistP256;
-use signature::{Error, Signature, Signer};
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
@@ -218,13 +217,14 @@ impl zeroize::ZeroizeOnDrop for Secp256r1PrivateKey {}
 
 serialize_deserialize_with_to_from_bytes!(Secp256r1Signature, SECP256R1_SIGNATURE_LENTH);
 
-impl Signature for Secp256r1Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+impl ToFromBytes for Secp256r1Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         if bytes.len() != SECP256R1_SIGNATURE_LENTH {
-            return Err(Error::new());
+            return Err(FastCryptoError::InputLengthWrong(SECP256R1_SIGNATURE_LENTH));
         }
 
-        let sig = ExternalSignature::try_from(bytes).map_err(|_| Error::new())?;
+        let sig =
+            ExternalSignature::try_from(bytes).map_err(|_| FastCryptoError::InvalidSignature)?;
 
         Ok(Secp256r1Signature {
             sig,
@@ -321,6 +321,15 @@ impl KeyPair for Secp256r1KeyPair {
     type PrivKey = Secp256r1PrivateKey;
     type Sig = Secp256r1Signature;
 
+    fn sign(&self, msg: &[u8]) -> Secp256r1Signature {
+        let sig: ecdsa::Signature<NistP256> = self.secret.privkey.sign(msg);
+        let sig_low = sig.normalize_s().unwrap_or(sig);
+        Secp256r1Signature {
+            sig: sig_low,
+            bytes: OnceCell::new(),
+        }
+    }
+
     fn public(&'_ self) -> &'_ Self::PubKey {
         &self.name
     }
@@ -353,17 +362,6 @@ impl FromStr for Secp256r1KeyPair {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
         Ok(kp)
-    }
-}
-
-impl Signer<Secp256r1Signature> for Secp256r1KeyPair {
-    fn try_sign(&self, msg: &[u8]) -> Result<Secp256r1Signature, Error> {
-        let sig: ecdsa::Signature<NistP256> = self.secret.privkey.sign(msg);
-        let sig_low = sig.normalize_s().unwrap_or(sig);
-        Ok(Secp256r1Signature {
-            sig: sig_low,
-            bytes: OnceCell::new(),
-        })
     }
 }
 

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -28,6 +28,7 @@ use p256::ecdsa::{
 use p256::elliptic_curve::group::GroupEncoding;
 use p256::elliptic_curve::IsHigh;
 use p256::NistP256;
+use signature::{Error, Signature, Signer};
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
@@ -217,14 +218,13 @@ impl zeroize::ZeroizeOnDrop for Secp256r1PrivateKey {}
 
 serialize_deserialize_with_to_from_bytes!(Secp256r1Signature, SECP256R1_SIGNATURE_LENTH);
 
-impl ToFromBytes for Secp256r1Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+impl Signature for Secp256r1Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != SECP256R1_SIGNATURE_LENTH {
-            return Err(FastCryptoError::InputLengthWrong(SECP256R1_SIGNATURE_LENTH));
+            return Err(Error::new());
         }
 
-        let sig =
-            ExternalSignature::try_from(bytes).map_err(|_| FastCryptoError::InvalidSignature)?;
+        let sig = ExternalSignature::try_from(bytes).map_err(|_| Error::new())?;
 
         Ok(Secp256r1Signature {
             sig,
@@ -321,15 +321,6 @@ impl KeyPair for Secp256r1KeyPair {
     type PrivKey = Secp256r1PrivateKey;
     type Sig = Secp256r1Signature;
 
-    fn sign(&self, msg: &[u8]) -> Secp256r1Signature {
-        let sig: ecdsa::Signature<NistP256> = self.secret.privkey.sign(msg);
-        let sig_low = sig.normalize_s().unwrap_or(sig);
-        Secp256r1Signature {
-            sig: sig_low,
-            bytes: OnceCell::new(),
-        }
-    }
-
     fn public(&'_ self) -> &'_ Self::PubKey {
         &self.name
     }
@@ -362,6 +353,17 @@ impl FromStr for Secp256r1KeyPair {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
         Ok(kp)
+    }
+}
+
+impl Signer<Secp256r1Signature> for Secp256r1KeyPair {
+    fn try_sign(&self, msg: &[u8]) -> Result<Secp256r1Signature, Error> {
+        let sig: ecdsa::Signature<NistP256> = self.secret.privkey.sign(msg);
+        let sig_low = sig.normalize_s().unwrap_or(sig);
+        Ok(Secp256r1Signature {
+            sig: sig_low,
+            bytes: OnceCell::new(),
+        })
     }
 }
 

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -62,11 +62,12 @@ serialize_deserialize_with_to_from_bytes!(
     SECP256R1_RECOVERABLE_SIGNATURE_LENGTH
 );
 
-impl Signature for Secp256r1RecoverableSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
-        // TODO: Compatibility with signatures without recovery id
+impl ToFromBytes for Secp256r1RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         if bytes.len() != SECP256R1_RECOVERABLE_SIGNATURE_LENGTH {
-            return Err(signature::Error::new());
+            return Err(FastCryptoError::InputLengthWrong(
+                SECP256R1_RECOVERABLE_SIGNATURE_LENGTH,
+            ));
         }
         ExternalSignature::try_from(&bytes[..SECP256R1_RECOVERABLE_SIGNATURE_LENGTH - 1])
             .map(|sig| Secp256r1RecoverableSignature {
@@ -74,7 +75,7 @@ impl Signature for Secp256r1RecoverableSignature {
                 recovery_id: bytes[SECP256R1_RECOVERABLE_SIGNATURE_LENGTH - 1],
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidSignature)
     }
 }
 

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -42,7 +42,6 @@ use p256::elliptic_curve::sec1::ToEncodedPoint;
 use p256::elliptic_curve::IsHigh;
 use p256::elliptic_curve::{AffineXCoordinate, Curve, DecompressPoint};
 use p256::{AffinePoint, FieldBytes, NistP256, ProjectivePoint, Scalar, U256};
-use signature::Signature;
 use std::borrow::Borrow;
 use std::fmt::{self, Debug, Display};
 
@@ -62,11 +61,12 @@ serialize_deserialize_with_to_from_bytes!(
     SECP256R1_RECOVERABLE_SIGNATURE_LENGTH
 );
 
-impl Signature for Secp256r1RecoverableSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
-        // TODO: Compatibility with signatures without recovery id
+impl ToFromBytes for Secp256r1RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         if bytes.len() != SECP256R1_RECOVERABLE_SIGNATURE_LENGTH {
-            return Err(signature::Error::new());
+            return Err(FastCryptoError::InputLengthWrong(
+                SECP256R1_RECOVERABLE_SIGNATURE_LENGTH,
+            ));
         }
         ExternalSignature::try_from(&bytes[..SECP256R1_RECOVERABLE_SIGNATURE_LENGTH - 1])
             .map(|sig| Secp256r1RecoverableSignature {
@@ -74,7 +74,7 @@ impl Signature for Secp256r1RecoverableSignature {
                 recovery_id: bytes[SECP256R1_RECOVERABLE_SIGNATURE_LENGTH - 1],
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -138,14 +138,14 @@ impl Secp256r1RecoverableSignature {
 
     /// util function to parse wycheproof test key from DER format.
     #[cfg(test)]
-    pub(crate) fn from_uncompressed(bytes: &[u8]) -> Result<Self, signature::Error> {
+    pub(crate) fn from_uncompressed(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         ExternalSignature::try_from(bytes)
             .map(|sig| Secp256r1RecoverableSignature {
                 sig,
                 recovery_id: 0u8,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| signature::Error::new())
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -62,12 +62,11 @@ serialize_deserialize_with_to_from_bytes!(
     SECP256R1_RECOVERABLE_SIGNATURE_LENGTH
 );
 
-impl ToFromBytes for Secp256r1RecoverableSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+impl Signature for Secp256r1RecoverableSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
+        // TODO: Compatibility with signatures without recovery id
         if bytes.len() != SECP256R1_RECOVERABLE_SIGNATURE_LENGTH {
-            return Err(FastCryptoError::InputLengthWrong(
-                SECP256R1_RECOVERABLE_SIGNATURE_LENGTH,
-            ));
+            return Err(signature::Error::new());
         }
         ExternalSignature::try_from(&bytes[..SECP256R1_RECOVERABLE_SIGNATURE_LENGTH - 1])
             .map(|sig| Secp256r1RecoverableSignature {
@@ -75,7 +74,7 @@ impl ToFromBytes for Secp256r1RecoverableSignature {
                 recovery_id: bytes[SECP256R1_RECOVERABLE_SIGNATURE_LENGTH - 1],
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| FastCryptoError::InvalidSignature)
+            .map_err(|_| signature::Error::new())
     }
 }
 

--- a/fastcrypto/src/signature_service.rs
+++ b/fastcrypto/src/signature_service.rs
@@ -3,6 +3,7 @@
 
 use crate::hash::Digest;
 use crate::traits;
+use crate::traits::Signer;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::oneshot;
 
@@ -18,7 +19,7 @@ impl<Signature: traits::Authenticator, const DIGEST_LEN: usize>
 {
     pub fn new<S>(signer: S) -> Self
     where
-        S: signature::Signer<Signature> + Send + 'static,
+        S: Signer<Signature> + Send + 'static,
     {
         let (tx, mut rx): (Sender<(Digest<DIGEST_LEN>, oneshot::Sender<_>)>, _) = channel(100);
         tokio::spawn(async move {

--- a/fastcrypto/src/signature_service.rs
+++ b/fastcrypto/src/signature_service.rs
@@ -3,6 +3,7 @@
 
 use crate::hash::Digest;
 use crate::traits;
+use crate::traits::KeyPair;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::oneshot;
 
@@ -18,7 +19,7 @@ impl<Signature: traits::Authenticator, const DIGEST_LEN: usize>
 {
     pub fn new<S>(signer: S) -> Self
     where
-        S: signature::Signer<Signature> + Send + 'static,
+        S: KeyPair<Sig = Signature> + Send + 'static,
     {
         let (tx, mut rx): (Sender<(Digest<DIGEST_LEN>, oneshot::Sender<_>)>, _) = channel(100);
         tokio::spawn(async move {

--- a/fastcrypto/src/signature_service.rs
+++ b/fastcrypto/src/signature_service.rs
@@ -3,7 +3,6 @@
 
 use crate::hash::Digest;
 use crate::traits;
-use crate::traits::KeyPair;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::oneshot;
 
@@ -19,7 +18,7 @@ impl<Signature: traits::Authenticator, const DIGEST_LEN: usize>
 {
     pub fn new<S>(signer: S) -> Self
     where
-        S: KeyPair<Sig = Signature> + Send + 'static,
+        S: signature::Signer<Signature> + Send + 'static,
     {
         let (tx, mut rx): (Sender<(Digest<DIGEST_LEN>, oneshot::Sender<_>)>, _) = channel(100);
         tokio::spawn(async move {

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -6,10 +6,10 @@ use crate::groups::bls12381::{
     G1Element, G2Element, GTElement, Scalar, G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH,
 };
 use crate::groups::{GroupElement, HashToGroupElement, Pairing};
+use crate::traits::Signer;
 use crate::traits::VerifyingKey;
 use crate::traits::{KeyPair, ToFromBytes};
 use rand::{rngs::StdRng, SeedableRng as _};
-use signature::Signer;
 
 const MSG: &[u8] = b"test message";
 

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::encoding::Encoding;
+use crate::traits::Signer;
 use crate::{
     bls12381::{BLS_G1_LENGTH, BLS_G2_LENGTH, BLS_PRIVATE_KEY_LENGTH},
     encoding::Base64,
@@ -14,7 +15,6 @@ use crate::{
 };
 use proptest::{collection, prelude::*};
 use rand::{rngs::StdRng, SeedableRng as _};
-use signature::{Signature, Signer};
 
 // We use the following macro in order to run all tests for both min_sig and min_pk.
 macro_rules! define_tests { () => {
@@ -638,7 +638,6 @@ proptest! {
 
     #[test]
     fn test_basic_deser_signature(bits in collection::vec(any::<u8>(), BLS_G1_LENGTH..=BLS_G1_LENGTH)) {
-        let _ = <BLS12381Signature as Signature>::from_bytes(&bits);
         let _ = <BLS12381Signature as ToFromBytes>::from_bytes(&bits);
     }
 

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -638,8 +638,8 @@ proptest! {
 
     #[test]
     fn test_basic_deser_signature(bits in collection::vec(any::<u8>(), BLS_G1_LENGTH..=BLS_G1_LENGTH)) {
-        let _ = <BLS12381Signature as Signature>::from_bytes(&bits);
-        let _ = <BLS12381Signature as ToFromBytes>::from_bytes(&bits);
+        let _ = BLS12381Signature::from_bytes(&bits);
+        let _ = BLS12381Signature::from_bytes(&bits);
     }
 
     #[test]

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -638,8 +638,8 @@ proptest! {
 
     #[test]
     fn test_basic_deser_signature(bits in collection::vec(any::<u8>(), BLS_G1_LENGTH..=BLS_G1_LENGTH)) {
-        let _ = BLS12381Signature::from_bytes(&bits);
-        let _ = BLS12381Signature::from_bytes(&bits);
+        let _ = <BLS12381Signature as Signature>::from_bytes(&bits);
+        let _ = <BLS12381Signature as ToFromBytes>::from_bytes(&bits);
     }
 
     #[test]

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use crate::encoding::Encoding;
+use crate::traits::Signer;
 use crate::{
     ed25519::{
         Ed25519AggregateSignature, Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey,
@@ -18,7 +19,6 @@ use crate::{
 use proptest::prelude::*;
 use proptest::strategy::Strategy;
 use rand::{rngs::StdRng, SeedableRng as _};
-use signature::Signer;
 use wycheproof::{eddsa::TestSet, TestResult};
 
 pub fn keys() -> Vec<Ed25519KeyPair> {

--- a/fastcrypto/src/tests/mskr_tests.rs
+++ b/fastcrypto/src/tests/mskr_tests.rs
@@ -3,9 +3,9 @@
 
 use crate::bls12381::{min_pk, min_sig};
 use crate::traits::mskr::Randomize;
+use crate::traits::Signer;
 use crate::traits::{AggregateAuthenticator, KeyPair, VerifyingKey};
 use rand::thread_rng;
-use signature::Signer;
 
 #[test]
 fn verify_randomized_signature_bls12381_min_pk() {

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -346,7 +346,7 @@ proptest::proptest! {
         } else {
             flipped_bytes[64] = 0;
         }
-        let malleated_signature: Secp256k1RecoverableSignature = <Secp256k1RecoverableSignature as signature::Signature>::from_bytes(&flipped_bytes).unwrap();
+        let malleated_signature: Secp256k1RecoverableSignature = Secp256k1RecoverableSignature::from_bytes(&flipped_bytes).unwrap();
 
         // malleable(altered) signature with opposite sign fails to verify
         assert!(key_pair.public().verify_recoverable(message, &malleated_signature).is_err());

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -18,7 +18,7 @@ use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::Signer;
+use signature::{Signer, Verifier};
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -346,7 +346,7 @@ proptest::proptest! {
         } else {
             flipped_bytes[64] = 0;
         }
-        let malleated_signature: Secp256k1RecoverableSignature = Secp256k1RecoverableSignature::from_bytes(&flipped_bytes).unwrap();
+        let malleated_signature: Secp256k1RecoverableSignature = <Secp256k1RecoverableSignature as signature::Signature>::from_bytes(&flipped_bytes).unwrap();
 
         // malleable(altered) signature with opposite sign fails to verify
         assert!(key_pair.public().verify_recoverable(message, &malleated_signature).is_err());

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -18,7 +18,7 @@ use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::{Signer, Verifier};
+use signature::Signer;
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -14,7 +14,7 @@ use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::Signer;
+use signature::{Signer, Verifier};
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::traits::Signer;
 use crate::{
     encoding::{Encoding, Hex},
     hash::{HashFunction, Sha256},
@@ -14,7 +15,8 @@ use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::{Signer, Verifier};
+use signature::Signer as ExternalSigner;
+use signature::Verifier as ExternalVerifier;
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 
@@ -350,7 +352,7 @@ proptest::proptest! {
         let key_pair_copied_2 = key_pair.copy();
         let key_pair_copied_3 = key_pair.copy();
 
-        let signature: Secp256k1Signature = key_pair.try_sign(message).unwrap();
+        let signature: Secp256k1Signature = key_pair.sign(message);
         assert!(key_pair.public().verify(message, &signature).is_ok());
 
         // Use k256 to construct private key with the same bytes and sign the same message
@@ -369,7 +371,7 @@ proptest::proptest! {
         );
 
         // Same signatures produced from both implementations
-        assert_eq!(signature.as_ref(), ToFromBytes::as_bytes(&signature_1));
+        assert_eq!(signature.as_ref(), signature_1.as_bytes());
 
         // Use fastcrypto keypair to verify a signature constructed by k256
         let secp_sig1 = bincode::deserialize::<Secp256k1Signature>(signature_1.as_ref()).unwrap();

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -14,7 +14,7 @@ use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::{Signer, Verifier};
+use signature::Signer;
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 

--- a/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
@@ -4,7 +4,7 @@ use crate::secp256r1::recoverable::SECP256R1_RECOVERABLE_SIGNATURE_LENGTH;
 use crate::secp256r1::{
     Secp256r1KeyPair, Secp256r1PrivateKey, Secp256r1PublicKey, Secp256r1Signature,
 };
-use crate::traits::Signer;
+
 use crate::traits::VerifyingKey;
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{

--- a/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
@@ -1,18 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::traits::VerifyingKey;
-use p256::ecdsa::Signature;
-use p256::elliptic_curve::IsHigh;
-use proptest::{prelude::*, strategy::Strategy};
-use rand::{rngs::StdRng, SeedableRng as _};
-use rust_secp256k1::constants::SECRET_KEY_SIZE;
-use wycheproof::ecdsa::{TestName::EcdsaSecp256r1Sha256, TestSet};
-use wycheproof::TestResult;
-
 use crate::secp256r1::recoverable::SECP256R1_RECOVERABLE_SIGNATURE_LENGTH;
 use crate::secp256r1::{
     Secp256r1KeyPair, Secp256r1PrivateKey, Secp256r1PublicKey, Secp256r1Signature,
 };
+use crate::traits::Signer;
+use crate::traits::VerifyingKey;
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     hash::{HashFunction, Sha256},
@@ -20,6 +13,13 @@ use crate::{
     signature_service::SignatureService,
     traits::{EncodeDecodeBase64, KeyPair, ToFromBytes},
 };
+use p256::ecdsa::Signature;
+use p256::elliptic_curve::IsHigh;
+use proptest::{prelude::*, strategy::Strategy};
+use rand::{rngs::StdRng, SeedableRng as _};
+use rust_secp256k1::constants::SECRET_KEY_SIZE;
+use wycheproof::ecdsa::{TestName::EcdsaSecp256r1Sha256, TestSet};
+use wycheproof::TestResult;
 
 const MSG: &[u8] = b"Hello, world!";
 

--- a/fastcrypto/src/tests/secp256r1_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_tests.rs
@@ -1,22 +1,21 @@
 use elliptic_curve::IsHigh;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use p256::ecdsa::Signature;
-use proptest::{prelude::*, strategy::Strategy};
-use rand::{rngs::StdRng, SeedableRng as _};
-use rust_secp256k1::constants::SECRET_KEY_SIZE;
-use signature::Signer;
-use wycheproof::ecdsa::{TestName::EcdsaSecp256r1Sha256, TestSet};
-use wycheproof::TestResult;
-
 use super::*;
 use crate::secp256r1::recoverable::SECP256R1_RECOVERABLE_SIGNATURE_LENGTH;
+use crate::traits::Signer;
 use crate::{
     hash::{HashFunction, Sha256},
     secp256r1::{Secp256r1KeyPair, Secp256r1PrivateKey, Secp256r1PublicKey, Secp256r1Signature},
     signature_service::SignatureService,
     traits::{EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
+use p256::ecdsa::Signature;
+use proptest::{prelude::*, strategy::Strategy};
+use rand::{rngs::StdRng, SeedableRng as _};
+use rust_secp256k1::constants::SECRET_KEY_SIZE;
+use wycheproof::ecdsa::{TestName::EcdsaSecp256r1Sha256, TestSet};
+use wycheproof::TestResult;
 
 const MSG: &[u8] = b"Hello, world!";
 

--- a/fastcrypto/src/tests/signature_tests.rs
+++ b/fastcrypto/src/tests/signature_tests.rs
@@ -3,7 +3,6 @@
 
 use rand::{rngs::StdRng, SeedableRng};
 
-use crate::traits::Signer;
 use crate::{
     hash::{HashFunction, Sha256},
     traits::KeyPair,

--- a/fastcrypto/src/tests/signature_tests.rs
+++ b/fastcrypto/src/tests/signature_tests.rs
@@ -3,6 +3,7 @@
 
 use rand::{rngs::StdRng, SeedableRng};
 
+use crate::traits::Signer;
 use crate::{
     hash::{HashFunction, Sha256},
     traits::KeyPair,

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -190,6 +190,7 @@ pub trait Authenticator:
 /// Trait impl'd by a key/keypair that can create signatures.
 ///
 pub trait Signer<Sig: Authenticator> {
+    /// Create a new signature over a message.
     fn sign(&self, msg: &[u8]) -> Sig;
 }
 

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -6,6 +6,7 @@ use eyre::eyre;
 use rand::rngs::{StdRng, ThreadRng};
 use rand::{CryptoRng, RngCore};
 use serde::{de::DeserializeOwned, Serialize};
+pub use signature::Signer;
 use std::{
     borrow::Borrow,
     fmt::{Debug, Display},
@@ -18,7 +19,7 @@ use crate::{
 };
 
 /// Trait impl'd by concrete types that represent digital cryptographic material
-/// (keys).
+/// (keys). For signatures, we rely on `signature::Signature`, which may be more widely implemented.
 ///
 /// Key types *must* (as mandated by the `AsRef<[u8]>` bound) be a thin
 /// wrapper around the "bag-of-bytes" serialized form of a key which can
@@ -44,6 +45,13 @@ pub trait ToFromBytes: AsRef<[u8]> + Debug + Sized {
     /// Borrow a byte slice representing the serialized form of this key
     fn as_bytes(&self) -> &[u8] {
         self.as_ref()
+    }
+}
+
+impl<T: signature::Signature> ToFromBytes for T {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        <Self as signature::Signature>::from_bytes(bytes)
+            .map_err(|_| FastCryptoError::GeneralOpaqueError)
     }
 }
 
@@ -180,7 +188,7 @@ pub trait SigningKey: ToFromBytes + Serialize + DeserializeOwned + Send + Sync +
 /// to the ones on its associated types for private key and public key material.
 ///
 pub trait Authenticator:
-    ToFromBytes + Display + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
+    signature::Signature + Display + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
 {
     type PubKey: VerifyingKey<Sig = Self>;
     type PrivKey: SigningKey<Sig = Self>;
@@ -189,12 +197,12 @@ pub trait Authenticator:
 
 /// Trait impl'd by a public / private key pair in asymmetric cryptography.
 ///
-pub trait KeyPair: Sized + From<Self::PrivKey> + EncodeDecodeBase64 + FromStr {
+pub trait KeyPair:
+    Sized + From<Self::PrivKey> + Signer<Self::Sig> + EncodeDecodeBase64 + FromStr
+{
     type PubKey: VerifyingKey<PrivKey = Self::PrivKey, Sig = Self::Sig>;
     type PrivKey: SigningKey<PubKey = Self::PubKey, Sig = Self::Sig>;
     type Sig: Authenticator<PubKey = Self::PubKey, PrivKey = Self::PrivKey>;
-
-    fn sign(&self, msg: &[u8]) -> Self::Sig;
 
     /// Get the public key.
     fn public(&'_ self) -> &'_ Self::PubKey;

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -6,7 +6,6 @@ use eyre::eyre;
 use rand::rngs::{StdRng, ThreadRng};
 use rand::{CryptoRng, RngCore};
 use serde::{de::DeserializeOwned, Serialize};
-pub use signature::Signer;
 use std::{
     borrow::Borrow,
     fmt::{Debug, Display},
@@ -19,7 +18,7 @@ use crate::{
 };
 
 /// Trait impl'd by concrete types that represent digital cryptographic material
-/// (keys). For signatures, we rely on `signature::Signature`, which may be more widely implemented.
+/// (keys).
 ///
 /// Key types *must* (as mandated by the `AsRef<[u8]>` bound) be a thin
 /// wrapper around the "bag-of-bytes" serialized form of a key which can
@@ -45,13 +44,6 @@ pub trait ToFromBytes: AsRef<[u8]> + Debug + Sized {
     /// Borrow a byte slice representing the serialized form of this key
     fn as_bytes(&self) -> &[u8] {
         self.as_ref()
-    }
-}
-
-impl<T: signature::Signature> ToFromBytes for T {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        <Self as signature::Signature>::from_bytes(bytes)
-            .map_err(|_| FastCryptoError::GeneralOpaqueError)
     }
 }
 
@@ -188,11 +180,17 @@ pub trait SigningKey: ToFromBytes + Serialize + DeserializeOwned + Send + Sync +
 /// to the ones on its associated types for private key and public key material.
 ///
 pub trait Authenticator:
-    signature::Signature + Display + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
+    ToFromBytes + Display + Serialize + DeserializeOwned + Send + Sync + 'static + Clone
 {
     type PubKey: VerifyingKey<Sig = Self>;
     type PrivKey: SigningKey<Sig = Self>;
     const LENGTH: usize;
+}
+
+/// Trait impl'd by a key/keypair that can create signatures.
+///
+pub trait Signer<Sig: Authenticator> {
+    fn sign(&self, msg: &[u8]) -> Sig;
 }
 
 /// Trait impl'd by a public / private key pair in asymmetric cryptography.

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -187,10 +187,11 @@ impl std::hash::Hash for UnsecureSignature {
     }
 }
 
-impl Signature for UnsecureSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, signature::Error> {
-        let bytes_fixed: [u8; SIGNATURE_LENGTH] =
-            bytes.try_into().map_err(|_| signature::Error::new())?;
+impl ToFromBytes for UnsecureSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        let bytes_fixed: [u8; SIGNATURE_LENGTH] = bytes
+            .try_into()
+            .map_err(|_| FastCryptoError::InputLengthWrong(SIGNATURE_LENGTH))?;
         Ok(Self(bytes_fixed))
     }
 }
@@ -298,9 +299,9 @@ impl KeyPair for UnsecureKeyPair {
 }
 
 impl Signer<UnsecureSignature> for UnsecureKeyPair {
-    fn try_sign(&self, msg: &[u8]) -> Result<UnsecureSignature, signature::Error> {
+    fn sign(&self, msg: &[u8]) -> Result<UnsecureSignature, FastCryptoError> {
         // A signature for msg is equal to H(pk || msg)
-        Ok(sign(self.name.0, msg))
+        sign(self.name.0, msg)
     }
 }
 


### PR DESCRIPTION
This removes the external `signature::Signer` and `signature::Signature` traits. The `Signer` trait is replaced with a local trait with the same name, and the `Signature` trait is incorporated into the `Authenticator` trait.

Besides some refactoring, the only change is that the `sign` and `try_sign` functions in `signature::Signer` is replaced with just a `sign` function. However, `sign` in the `signature::Signer` trait defaults to calling `try_sign` and panic on fail and none of our signature schemes can error during signing anyway, so this is doesn't really change anything.

This also gets rid of `signature::Error` for all signature schemes. It is still used in the bulletproofs though.