### PR TITLE
Revert "chore(deps): bump serde_bytes from 0.11.8 to 0.11.9"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.9"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
 dependencies = [
  "serde",
 ]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -19,7 +19,7 @@ hkdf = { version = "0.12.3", features = ["std"] }
 rand.workspace = true
 rust_secp256k1 = { version = "0.26.0", package = "secp256k1", features = ["recovery", "rand-std", "bitcoin_hashes", "global-context"] }
 serde.workspace = true
-serde_bytes = "0.11.9"
+serde_bytes = "0.11.8"
 serde_with = "2.1.0"
 serde-big-array = { version = "0.4.1", optional = true }
 signature = { version = "1.6.4", features = ["rand-preview"] }


### PR DESCRIPTION
Reverts MystenLabs/fastcrypto#429

Conflicts with sui/Move