### PR TITLE
BLS12-381 cleanups

### DIFF
--- a/fastcrypto-tbls/src/ecies.rs
+++ b/fastcrypto-tbls/src/ecies.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::random_oracle::RandomOracle;
-use fastcrypto::aes::{Aes256Ctr, AesKey, InitializationVector};
+use fastcrypto::aes::{Aes256Ctr, AesKey, Cipher, InitializationVector};
 use fastcrypto::error::FastCryptoError;
 use fastcrypto::groups::bls12381::G1Element;
 use fastcrypto::groups::{GroupElement, HashToGroupElement, Scalar};
 use fastcrypto::hmac::{hkdf_sha3_256, HkdfIkm};
-use fastcrypto::traits::{AllowedRng, Cipher, ToFromBytes};
+use fastcrypto::traits::{AllowedRng, ToFromBytes};
 use serde::{Deserialize, Serialize};
 use typenum::consts::{U16, U32};
 

--- a/fastcrypto/benches/mskr.rs
+++ b/fastcrypto/benches/mskr.rs
@@ -10,11 +10,11 @@ mod mskr_benches {
     use criterion::BenchmarkGroup;
     use criterion::BenchmarkId;
     use criterion::Criterion;
+    use fastcrypto::bls12381::mskr::HashToScalar;
+    use fastcrypto::bls12381::mskr::Randomize;
     use fastcrypto::bls12381::{min_pk, min_sig};
     use fastcrypto::hash::HashFunction;
     use fastcrypto::hash::Sha256;
-    use fastcrypto::traits::mskr::HashToScalar;
-    use fastcrypto::traits::mskr::Randomize;
     use fastcrypto::traits::{AggregateAuthenticator, KeyPair, Signer, VerifyingKey};
     use rand::thread_rng;
 

--- a/fastcrypto/src/bls12381/min_pk/mskr.rs
+++ b/fastcrypto/src/bls12381/min_pk/mskr.rs
@@ -15,8 +15,8 @@ use once_cell::sync::OnceCell;
 use crate::bls12381::min_pk::{
     BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
 };
+use crate::bls12381::mskr::{HashToScalar, Randomize};
 use crate::hash::{HashFunction, Sha256};
-use crate::traits::mskr::{HashToScalar, Randomize};
 use crate::traits::VerifyingKey;
 
 pub struct BLS12381Hash {}
@@ -146,8 +146,8 @@ impl Randomize<BLS12381PublicKey, blst_fr, BLS12381Hash, { BLS12381PublicKey::LE
 {
     fn randomize_internal(&self, r: &blst_fr) -> Self {
         BLS12381KeyPair {
-            secret: self.secret.randomize_internal(r),
-            name: self.name.randomize_internal(r),
+            private: self.private.randomize_internal(r),
+            public: self.public.randomize_internal(r),
         }
     }
 }

--- a/fastcrypto/src/bls12381/min_sig/mskr.rs
+++ b/fastcrypto/src/bls12381/min_sig/mskr.rs
@@ -15,8 +15,8 @@ use once_cell::sync::OnceCell;
 use crate::bls12381::min_sig::{
     BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
 };
+use crate::bls12381::mskr::{HashToScalar, Randomize};
 use crate::hash::{HashFunction, Sha256};
-use crate::traits::mskr::{HashToScalar, Randomize};
 use crate::traits::VerifyingKey;
 
 pub struct BLS12381Hash {}
@@ -147,8 +147,8 @@ impl Randomize<BLS12381PublicKey, blst_fr, BLS12381Hash, { BLS12381PublicKey::LE
 {
     fn randomize_internal(&self, r: &blst_fr) -> Self {
         BLS12381KeyPair {
-            secret: self.secret.randomize_internal(r),
-            name: self.name.randomize_internal(r),
+            private: self.private.randomize_internal(r),
+            public: self.public.randomize_internal(r),
         }
     }
 }

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -3,7 +3,6 @@
 
 //! This module contains an implementation of the [BLS signature scheme over the BLS 12-381 curve](https://en.wikipedia.org/wiki/BLS_digital_signature).
 //!
-//! Messages can be signed and the signature can be verified again:
 //! ```rust
 //! # use fastcrypto::bls12381::min_sig::*;
 //! # use fastcrypto::traits::{KeyPair, Signer, VerifyingKey};
@@ -16,7 +15,10 @@
 
 use crate::generate_bytes_representation;
 use crate::serde_helpers::BytesRepresentation;
-use crate::traits::InsecureDefault;
+use crate::traits::{
+    AggregateAuthenticator, AllowedRng, Authenticator, EncodeDecodeBase64, InsecureDefault,
+    KeyPair, Signer, SigningKey, ToFromBytes, VerifyingKey,
+};
 use crate::{
     encoding::Base64, encoding::Encoding, error::FastCryptoError,
     serialize_deserialize_with_to_from_bytes,
@@ -33,29 +35,19 @@ use std::{
 };
 use zeroize::Zeroize;
 
-use crate::traits::{
-    AggregateAuthenticator, AllowedRng, Authenticator, EncodeDecodeBase64, KeyPair, Signer,
-    SigningKey, ToFromBytes, VerifyingKey,
-};
-
-// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
-// and of the second using 96 bytes. BLS supports two modes:
-// - Minimal-signature-size (or min-sig) - signatures are in G1 and public keys are in G2.
-// - Minimal-pubkey-size (or min-pk) - signature are in G2 and public keys are in G1.
-//
-// Below we define BLS related objects for each of the modes, separated using modules min_sig and
-// min_pk.
-
+/// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
+/// and of the second using 96 bytes. BLS supports two modes:
+/// - Minimal-signature-size (or min-sig) - signatures are in G1 and public keys are in G2.
+/// - Minimal-pubkey-size (or min-pk) - signature are in G2 and public keys are in G1.
+///
+/// Below we define BLS related objects for each of the modes, see instantiations
+/// [fastcrypto::bls12381::min_sig] and [fastcrypto::bls12381::min_pk].
 macro_rules! define_bls12381 {
 (
     $pk_length:expr,
     $sig_length:expr,
     $dst_string:expr
 ) => {
-
-///
-/// Define Structs
-///
 
 /// BLS 12-381 public key.
 #[readonly::make]
@@ -73,18 +65,11 @@ pub struct BLS12381PrivateKey {
     pub bytes: OnceCell<[u8; BLS_PRIVATE_KEY_LENGTH]>,
 }
 
-impl PartialEq for BLS12381PrivateKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl Eq for BLS12381PrivateKey {}
-
+/// BLS 12-381 key pair.
 #[derive(Debug, PartialEq, Eq)]
 pub struct BLS12381KeyPair {
-    name: BLS12381PublicKey,
-    secret: BLS12381PrivateKey,
+    public: BLS12381PublicKey,
+    private: BLS12381PrivateKey,
 }
 
 /// BLS 12-381 signature.
@@ -95,8 +80,6 @@ pub struct BLS12381Signature {
     pub bytes: OnceCell<[u8; $sig_length]>,
 }
 
-serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
-
 /// Aggregation of multiple BLS 12-381 signatures.
 #[readonly::make]
 #[derive(Debug, Clone)]
@@ -105,31 +88,9 @@ pub struct BLS12381AggregateSignature {
     pub bytes: OnceCell<[u8; $sig_length]>,
 }
 
-serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
-generate_bytes_representation!(BLS12381AggregateSignature, {$sig_length}, BLS12381AggregateSignatureAsBytes);
-
-///
-/// Implement SigningKey
-///
-
-impl AsRef<[u8]> for BLS12381PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_try_init::<_, eyre::Report>(|| Ok(self.pubkey.to_bytes()))
-            .expect("OnceCell invariant violated")
-    }
-}
-
-impl ToFromBytes for BLS12381PublicKey {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        let pubkey =
-            blst::PublicKey::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381PublicKey {
-            pubkey,
-            bytes: OnceCell::new(),
-        })
-    }
-}
+//
+// Boilerplate code for [BLS12381PublicKey].
+//
 
 impl std::hash::Hash for BLS12381PublicKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -150,6 +111,7 @@ impl PartialOrd for BLS12381PublicKey {
         self.as_ref().partial_cmp(other.as_ref())
     }
 }
+
 impl Ord for BLS12381PublicKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.as_ref().cmp(other.as_ref())
@@ -168,6 +130,32 @@ impl Debug for BLS12381PublicKey {
     }
 }
 
+impl AsRef<[u8]> for BLS12381PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_try_init::<_, eyre::Report>(|| Ok(self.pubkey.to_bytes()))
+            .expect("OnceCell invariant violated")
+    }
+}
+
+impl ToFromBytes for BLS12381PublicKey {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // key_validate() validates the public key.
+        let pubkey =
+            blst::PublicKey::key_validate(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381PublicKey {
+            pubkey,
+            bytes: OnceCell::new(),
+        })
+    }
+}
+
+//
+// Custom code for [BLS12381PublicKey].
+//
+
+// Needed since the current NW implementation requires default public keys.
+// Note that deserialize this object will fail as we validate it is a valid public key.
 impl InsecureDefault for BLS12381PublicKey {
     fn insecure_default() -> Self {
         BLS12381PublicKey {
@@ -178,7 +166,6 @@ impl InsecureDefault for BLS12381PublicKey {
 }
 
 serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
-
 generate_bytes_representation!(BLS12381PublicKey, {$pk_length}, BLS12381PublicKeyAsBytes);
 
 impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
@@ -195,22 +182,20 @@ impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
 impl VerifyingKey for BLS12381PublicKey {
     type PrivKey = BLS12381PrivateKey;
     type Sig = BLS12381Signature;
-
     const LENGTH: usize = $pk_length;
 
     fn verify(&self, msg: &[u8], signature: &BLS12381Signature) -> Result<(), FastCryptoError> {
-        // verify() below validates the signature and the public key, thus should be safe with
-        // default values.
+        // verify() does not validate the signature or public key since we already do that during
+        // deserialization.
         let err = signature
             .sig
-            .verify(true, msg, $dst_string, &[], &self.pubkey, true);
+            .verify(false, msg, $dst_string, &[], &self.pubkey, false);
         if err == BLST_ERROR::BLST_SUCCESS {
             Ok(())
         } else {
             Err(FastCryptoError::InvalidSignature)
         }
     }
-
 
     #[cfg(any(test, feature = "experimental"))]
     fn verify_batch_empty_fail(
@@ -316,354 +301,17 @@ fn get_one() -> blst_scalar {
     one
 }
 
-///
-/// Implement Authenticator
-///
+//
+// Boilerplate code for [BLS12381PrivateKey].
+//
 
-impl AsRef<[u8]> for BLS12381Signature {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_try_init::<_, eyre::Report>(|| Ok(self.sig.to_bytes()))
-            .expect("OnceCell invariant violated")
-    }
-}
-
-impl std::hash::Hash for BLS12381Signature {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state);
-    }
-}
-
-impl PartialEq for BLS12381Signature {
+impl PartialEq for BLS12381PrivateKey {
     fn eq(&self, other: &Self) -> bool {
         self.as_ref() == other.as_ref()
     }
 }
 
-impl Eq for BLS12381Signature {}
-
-impl ToFromBytes for BLS12381Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381Signature {
-            sig,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-impl Default for BLS12381Signature {
-    fn default() -> Self {
-        // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
-        // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
-        let mut infinity: [u8; $sig_length] = [0; $sig_length];
-        infinity[0] = 0xc0;
-
-        BLS12381Signature {
-            sig: blst::Signature::from_bytes(&infinity).expect("Should decode infinity signature"),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-impl Display for BLS12381Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl Authenticator for BLS12381Signature {
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-    const LENGTH: usize = $sig_length;
-}
-
-///
-/// Implement SigningKey
-///
-
-impl AsRef<[u8]> for BLS12381PrivateKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_try_init::<_, eyre::Report>(|| Ok(self.privkey.to_bytes()))
-            .expect("OnceCell invariant violated")
-    }
-}
-
-impl ToFromBytes for BLS12381PrivateKey {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        let privkey =
-            blst::SecretKey::from_bytes(bytes).map_err(|_e| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381PrivateKey {
-            privkey,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-// There is a strong requirement for this specific impl. in Fab benchmarks
-serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
-
-impl SigningKey for BLS12381PrivateKey {
-    type PubKey = BLS12381PublicKey;
-    type Sig = BLS12381Signature;
-    const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
-}
-
-impl Signer<BLS12381Signature> for BLS12381PrivateKey {
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        let sig = self.privkey.sign(msg, $dst_string, &[]);
-
-        BLS12381Signature {
-            sig,
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-///
-/// Implement KeyPair
-///
-
-impl From<BLS12381PrivateKey> for BLS12381KeyPair {
-    fn from(secret: BLS12381PrivateKey) -> Self {
-        let name = BLS12381PublicKey::from(&secret);
-        BLS12381KeyPair { name, secret }
-    }
-}
-
-/// The bytes form of the keypair always only contain the private key bytes
-impl ToFromBytes for BLS12381KeyPair {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        BLS12381PrivateKey::from_bytes(bytes).map(|secret| secret.into())
-    }
-}
-
-serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
-
-impl AsRef<[u8]> for BLS12381KeyPair {
-    fn as_ref(&self) -> &[u8] {
-        self.secret.as_ref()
-    }
-}
-
-impl KeyPair for BLS12381KeyPair {
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-    type Sig = BLS12381Signature;
-
-    fn public(&'_ self) -> &'_ Self::PubKey {
-        &self.name
-    }
-
-    fn private(self) -> Self::PrivKey {
-        BLS12381PrivateKey::from_bytes(self.secret.as_ref()).unwrap()
-    }
-
-    #[cfg(feature = "copy_key")]
-    fn copy(&self) -> Self {
-        BLS12381KeyPair {
-            name: self.name.clone(),
-            secret: BLS12381PrivateKey::from_bytes(self.secret.as_ref()).unwrap(),
-        }
-    }
-
-    fn generate<R: AllowedRng>(rng: &mut R) -> Self {
-        let mut ikm = [0u8; 32];
-        rng.fill_bytes(&mut ikm);
-        let privkey = blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
-        let pubkey = privkey.sk_to_pk();
-        BLS12381KeyPair {
-            name: BLS12381PublicKey {
-                pubkey,
-                bytes: OnceCell::new(),
-            },
-            secret: BLS12381PrivateKey {
-                privkey,
-                bytes: OnceCell::new(),
-            },
-        }
-    }
-}
-
-impl Signer<BLS12381Signature> for BLS12381KeyPair {
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        self.secret.sign(msg)
-    }
-}
-
-impl FromStr for BLS12381KeyPair {
-    type Err = eyre::Report;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
-        Ok(kp)
-    }
-}
-
-///
-/// Implement AggregateAuthenticator
-///
-
-// Don't try to use this externally.
-impl AsRef<[u8]> for BLS12381AggregateSignature {
-    fn as_ref(&self) -> &[u8] {
-        self
-                .bytes
-                .get_or_try_init::<_, eyre::Report>(|| Ok(self.sig.to_bytes()))
-                .expect("OnceCell invariant violated")
-
-    }
-}
-
-impl Display for BLS12381AggregateSignature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl From <BLS12381Signature> for BLS12381AggregateSignature {
-    fn from(sig: BLS12381Signature) -> Self {
-        BLS12381AggregateSignature {
-            sig: sig.sig,
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-impl Default for BLS12381AggregateSignature {
-    fn default() -> Self {
-        BLS12381Signature::default().into()
-    }
-}
-
-impl AggregateAuthenticator for BLS12381AggregateSignature {
-    type Sig = BLS12381Signature;
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-
-    /// Parse a key from its byte representation.
-    fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
-        signatures: I,
-    ) -> Result<Self, FastCryptoError> {
-        // aggregate() below does not check the signatures at all.
-        blst::AggregateSignature::aggregate(
-            &signatures
-                .into_iter()
-                .map(|x| &x.borrow().sig)
-                .collect::<Vec<_>>(),
-            false,
-        )
-        .map(|sig| BLS12381AggregateSignature {
-            sig: sig.to_signature(),
-            bytes: OnceCell::new(),
-        })
-        .map_err(|_| FastCryptoError::GeneralOpaqueError)
-    }
-
-    fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
-        // add_signature() only checks the new signature, and only if it's in the group.
-        let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
-        aggr_sig.add_signature(&signature.sig, true).map_err(|_| FastCryptoError::GeneralOpaqueError)?;
-        self.sig = aggr_sig.to_signature();
-        self.bytes.take();
-        Ok(())
-    }
-
-    fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
-        // aggregate() only checks if the signature is in the group.
-        let result = blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], true)
-            .map_err(|_| FastCryptoError::GeneralOpaqueError)?.to_signature();
-        self.sig = result;
-        self.bytes.take();
-        Ok(())
-    }
-
-    fn verify(
-        &self,
-        pks: &[<Self::Sig as Authenticator>::PubKey],
-        message: &[u8],
-    ) -> Result<(), FastCryptoError> {
-        // fast_aggregate_verify() does not check the public keys, but does check that the signature
-        // is in the group.
-        let result = self
-            .sig
-            .fast_aggregate_verify(
-                true,
-                message,
-                $dst_string,
-                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-            );
-        if result != BLST_ERROR::BLST_SUCCESS {
-            return Err(FastCryptoError::GeneralOpaqueError);
-        }
-        Ok(())
-    }
-
-    fn verify_different_msg(
-        &self,
-        pks: &[<Self::Sig as Authenticator>::PubKey],
-        messages: &[&[u8]],
-    ) -> Result<(), FastCryptoError> {
-        // aggregate_verify() checks both the signatures and the public keys.
-        let result = self
-            .sig
-            .aggregate_verify(
-                true,
-                messages,
-                $dst_string,
-                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-                true,
-            );
-        if result != BLST_ERROR::BLST_SUCCESS {
-            return Err(FastCryptoError::GeneralOpaqueError);
-        }
-        Ok(())
-    }
-
-    fn batch_verify<'a>(
-        signatures: &[&Self],
-        pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
-        messages: &[&[u8]],
-    ) -> Result<(), FastCryptoError> {
-        // fast_aggregate_verify() does not check the public keys, but does check that the signature
-        // is in the group.
-        if signatures.len() != pks.len() || signatures.len() != messages.len() {
-            return Err(FastCryptoError::InputLengthWrong(signatures.len()));
-        }
-        let mut pk_iter = pks.into_iter();
-        for i in 0..signatures.len() {
-            let sig = signatures[i].sig;
-            let result = sig
-                .fast_aggregate_verify(
-                    true,
-                    messages[i],
-                    $dst_string,
-                    &pk_iter
-                        .next()
-                        .unwrap()
-                        .map(|x| &x.pubkey)
-                        .collect::<Vec<_>>()[..],
-                );
-            if result != BLST_ERROR::BLST_SUCCESS {
-                return Err(FastCryptoError::GeneralOpaqueError);
-            }
-        }
-        Ok(())
-    }
-}
-
-impl PartialEq for BLS12381AggregateSignature {
-    fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
-    }
-}
-
-impl Eq for BLS12381AggregateSignature {}
-
-///
-/// Implement VerifyingKeyBytes.
-///
+impl Eq for BLS12381PrivateKey {}
 
 impl zeroize::Zeroize for BLS12381PrivateKey {
     fn zeroize(&mut self) {
@@ -680,27 +328,369 @@ impl Drop for BLS12381PrivateKey {
     }
 }
 
-impl zeroize::Zeroize for BLS12381KeyPair {
-    fn zeroize(&mut self) {
-        self.secret.zeroize()
+impl AsRef<[u8]> for BLS12381PrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_try_init::<_, eyre::Report>(|| Ok(self.privkey.to_bytes()))
+            .expect("OnceCell invariant violated")
     }
 }
 
-impl zeroize::ZeroizeOnDrop for BLS12381KeyPair {}
-
-impl Drop for BLS12381KeyPair {
-    fn drop(&mut self) {
-        self.zeroize();
+impl ToFromBytes for BLS12381PrivateKey {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // from_bytes() validates that the key is in the right group.
+        let privkey =
+            blst::SecretKey::from_bytes(bytes).map_err(|_e| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381PrivateKey {
+            privkey,
+            bytes: OnceCell::new(),
+        })
     }
 }
+
+//
+// Custom code for [BLS12381PrivateKey].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
+
+impl SigningKey for BLS12381PrivateKey {
+    type PubKey = BLS12381PublicKey;
+    type Sig = BLS12381Signature;
+    const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
+}
+
+impl Signer<BLS12381Signature> for BLS12381PrivateKey {
+    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+        BLS12381Signature {
+            sig: self.privkey.sign(msg, $dst_string, &[]),
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+//
+// Boilerplate code for [BLS12381Signature].
+//
+
+impl PartialEq for BLS12381Signature {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for BLS12381Signature {}
+
+impl std::hash::Hash for BLS12381Signature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl AsRef<[u8]> for BLS12381Signature {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_try_init::<_, eyre::Report>(|| Ok(self.sig.to_bytes()))
+            .expect("OnceCell invariant violated")
+    }
+}
+
+impl ToFromBytes for BLS12381Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // sig_validate(x, false) checks that signature is in the right group (but allows inf).
+        let sig = blst::Signature::sig_validate(bytes, false).map_err(|_| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381Signature {
+            sig,
+            bytes: OnceCell::new(),
+        })
+    }
+}
+
+impl Display for BLS12381Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", Base64::encode(self.as_ref()))
+    }
+}
+
+//
+// Custom code for [BLS12381Signature].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
+
+impl Default for BLS12381Signature {
+    fn default() -> Self {
+        // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
+        // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
+        let mut infinity: [u8; $sig_length] = [0; $sig_length];
+        infinity[0] = 0xc0;
+
+        BLS12381Signature {
+            sig: blst::Signature::from_bytes(&infinity).expect("Should decode infinity signature"),
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+impl Authenticator for BLS12381Signature {
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
+    const LENGTH: usize = $sig_length;
+}
+
+//
+// Boilerplate code for [BLS12381KeyPair].
+//
+
+impl From<BLS12381PrivateKey> for BLS12381KeyPair {
+    fn from(private: BLS12381PrivateKey) -> Self {
+        let public = BLS12381PublicKey::from(&private);
+        BLS12381KeyPair { public, private }
+    }
+}
+
+/// The bytes form of the keypair only contain the private key bytes
+impl AsRef<[u8]> for BLS12381KeyPair {
+    fn as_ref(&self) -> &[u8] {
+        self.private.as_ref()
+    }
+}
+
+impl ToFromBytes for BLS12381KeyPair {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
+    }
+}
+
+//
+// Custom code for [BLS12381KeyPair].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
+
+impl KeyPair for BLS12381KeyPair {
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
+    type Sig = BLS12381Signature;
+
+    fn public(&'_ self) -> &'_ Self::PubKey {
+        &self.public
+    }
+
+    fn private(self) -> Self::PrivKey {
+        BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
+    }
+
+    #[cfg(feature = "copy_key")]
+    fn copy(&self) -> Self {
+        BLS12381KeyPair {
+            public: self.public.clone(),
+            private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+        }
+    }
+
+    fn generate<R: AllowedRng>(rng: &mut R) -> Self {
+        let mut ikm = [0u8; 32];
+        rng.fill_bytes(&mut ikm);
+        let privkey = blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
+        let pubkey = privkey.sk_to_pk();
+        BLS12381KeyPair {
+            public: BLS12381PublicKey {
+                pubkey,
+                bytes: OnceCell::new(),
+            },
+            private: BLS12381PrivateKey {
+                privkey,
+                bytes: OnceCell::new(),
+            },
+        }
+    }
+}
+
+impl Signer<BLS12381Signature> for BLS12381KeyPair {
+    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+        self.private.sign(msg)
+    }
+}
+
+impl FromStr for BLS12381KeyPair {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
+        Ok(kp)
+    }
+}
+
+//
+// Boilerplate code for [BLS12381AggregateSignature].
+//
+
+impl PartialEq for BLS12381AggregateSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.sig == other.sig
+    }
+}
+
+impl Eq for BLS12381AggregateSignature {}
+
+impl Display for BLS12381AggregateSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", Base64::encode(self.as_ref()))
+    }
+}
+
+impl Default for BLS12381AggregateSignature {
+    fn default() -> Self {
+        BLS12381Signature::default().into()
+    }
+}
+
+impl AsRef<[u8]> for BLS12381AggregateSignature {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_try_init::<_, eyre::Report>(|| Ok(self.sig.to_bytes()))
+            .expect("OnceCell invariant violated")
+    }
+}
+
+impl From <BLS12381Signature> for BLS12381AggregateSignature {
+    fn from(sig: BLS12381Signature) -> Self {
+        BLS12381AggregateSignature {
+            sig: sig.sig,
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+//
+// Custom code for [BLS12381AggregateSignature].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
+generate_bytes_representation!(BLS12381AggregateSignature, {$sig_length}, BLS12381AggregateSignatureAsBytes);
 
 impl ToFromBytes for BLS12381AggregateSignature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
+        // sig_validate(x, false) checks that the signature is in the right group but allows inf.
+        let sig = blst::Signature::sig_validate(bytes, false).map_err(|_| FastCryptoError::InvalidInput)?;
         Ok(BLS12381AggregateSignature {
             sig,
             bytes: OnceCell::new(),
         })
+    }
+}
+
+impl AggregateAuthenticator for BLS12381AggregateSignature {
+    type Sig = BLS12381Signature;
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
+
+    fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
+        signatures: I,
+    ) -> Result<Self, FastCryptoError> {
+        // aggregate() below does not validate signatures (we do that on deserialization).
+        blst::AggregateSignature::aggregate(
+            &signatures
+                .into_iter()
+                .map(|x| &x.borrow().sig)
+                .collect::<Vec<_>>(),
+            false,
+        )
+        .map(|sig| BLS12381AggregateSignature {
+            sig: sig.to_signature(),
+            bytes: OnceCell::new(),
+        })
+        .map_err(|_| FastCryptoError::GeneralOpaqueError)
+    }
+
+    fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
+        let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
+        // add_signature() does not validate the new signature as this is done during deserialization.
+        aggr_sig.add_signature(&signature.sig, false).map_err(|_| FastCryptoError::GeneralOpaqueError)?;
+        self.sig = aggr_sig.to_signature();
+        self.bytes.take();
+        Ok(())
+    }
+
+    fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
+        // aggregate() does not validate the new signature as this is done during deserialization.
+        let result = blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
+            .map_err(|_| FastCryptoError::GeneralOpaqueError)?.to_signature();
+        self.sig = result;
+        self.bytes.take();
+        Ok(())
+    }
+
+    fn verify(
+        &self,
+        pks: &[<Self::Sig as Authenticator>::PubKey],
+        message: &[u8],
+    ) -> Result<(), FastCryptoError> {
+        // No need to validate signatures or public keys as we do that on deserialization.
+        let result = self
+            .sig
+            .fast_aggregate_verify(
+                false,
+                message,
+                $dst_string,
+                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+            );
+        if result != BLST_ERROR::BLST_SUCCESS {
+            return Err(FastCryptoError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    fn verify_different_msg(
+        &self,
+        pks: &[<Self::Sig as Authenticator>::PubKey],
+        messages: &[&[u8]],
+    ) -> Result<(), FastCryptoError> {
+        // aggregate_verify() does not validate keys or signatures.
+        let result = self
+            .sig
+            .aggregate_verify(
+                false,
+                messages,
+                $dst_string,
+                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+                false,
+            );
+        if result != BLST_ERROR::BLST_SUCCESS {
+            return Err(FastCryptoError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    fn batch_verify<'a>(
+        signatures: &[&Self],
+        pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
+        messages: &[&[u8]],
+    ) -> Result<(), FastCryptoError> {
+        // TODO: Consider using verify_multiple_aggregate_signatures() below.
+        if signatures.len() != pks.len() || signatures.len() != messages.len() {
+            return Err(FastCryptoError::InputLengthWrong(signatures.len()));
+        }
+        let mut pk_iter = pks.into_iter();
+        for i in 0..signatures.len() {
+            let sig = signatures[i].sig;
+            let result = sig
+                .fast_aggregate_verify(
+                    false,
+                    messages[i],
+                    $dst_string,
+                    &pk_iter
+                        .next()
+                        .unwrap()
+                        .map(|x| &x.pubkey)
+                        .collect::<Vec<_>>()[..],
+                );
+            if result != BLST_ERROR::BLST_SUCCESS {
+                return Err(FastCryptoError::GeneralOpaqueError);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -719,8 +709,12 @@ pub const BLS_G2_LENGTH: usize = 96;
 
 /// The key pair bytes length used by helper is the same as the private key length. This is because only private key is serialized.
 pub const BLS_KEYPAIR_LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
-/// Module minimizing the size of signatures. See also [min_pk].
+
+/// Module minimizing the size of signatures.
 pub mod min_sig;
 
-/// Module minimizing the size of public keys. See also [min_sig].
+/// Module minimizing the size of public keys.
 pub mod min_pk;
+
+#[cfg(feature = "experimental")]
+pub mod mskr;

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -155,7 +155,7 @@ impl ToFromBytes for BLS12381PublicKey {
 //
 
 // Needed since the current NW implementation requires default public keys.
-// Note that deserialize this object will fail as we validate it is a valid public key.
+// Note that deserialization of this object will fail as we validate it is a valid public key.
 impl InsecureDefault for BLS12381PublicKey {
     fn insecure_default() -> Self {
         BLS12381PublicKey {

--- a/fastcrypto/src/bls12381/mskr.rs
+++ b/fastcrypto/src/bls12381/mskr.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::traits::ToFromBytes;
+
+/// Trait impl'd by keys and signatures for signature schemes supporting the MSKR (Multi-Signature with Key Randomization) scheme.
+pub trait Randomize<
+    PubKey: ToFromBytes,
+    Scalar,
+    H: HashToScalar<Scalar>,
+    const PUBLIC_KEY_LENGTH: usize,
+>: Sized
+{
+    /// Randomize this with the given scalar.
+    fn randomize_internal(&self, r: &Scalar) -> Self;
+
+    /// Randomize this deterministically based on the given public keys.
+    fn randomize(&self, pk: &PubKey, pks: &[PubKey]) -> Self {
+        self.randomize_internal(
+            &randomization_scalar::<PubKey, Scalar, H, PUBLIC_KEY_LENGTH>(pk, pks),
+        )
+    }
+}
+
+pub trait HashToScalar<Scalar> {
+    fn hash_to_scalar(bytes: &[u8]) -> Scalar;
+}
+
+/// Compute as hash of (pk, pks) into a scalar type.
+pub(crate) fn randomization_scalar<
+    PubKey: ToFromBytes,
+    Scalar,
+    H: HashToScalar<Scalar>,
+    const PUBLIC_KEY_LENGTH: usize,
+>(
+    pk: &PubKey,
+    pks: &[PubKey],
+) -> Scalar {
+    let mut seed: Vec<u8> = Vec::with_capacity(PUBLIC_KEY_LENGTH * (pks.len() + 1));
+    seed.extend_from_slice(pk.as_bytes());
+    for pki in pks {
+        seed.extend_from_slice(pki.as_bytes());
+    }
+    H::hash_to_scalar(seed.as_slice())
+}

--- a/fastcrypto/src/tests/aes_tests.rs
+++ b/fastcrypto/src/tests/aes_tests.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::aes::{AuthenticatedCipher, Cipher};
 use crate::{
     aes::{
         Aes128CbcPkcs7, Aes128Ctr, Aes128Gcm, Aes192Ctr, Aes256CbcPkcs7, Aes256Ctr, Aes256Gcm,
         AesKey, GenericByteArray, InitializationVector,
     },
     error::FastCryptoError,
-    traits::{AuthenticatedCipher, Cipher, Generate, ToFromBytes},
+    traits::{Generate, ToFromBytes},
 };
 use core::fmt::Debug;
 use generic_array::ArrayLength;

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -297,14 +297,12 @@ fn verify_batch_missing_keys_in_batch() {
 fn test_serialize_deserialize_standard_sig() {
     let kp = keys().pop().unwrap();
     let pk = kp.public().clone();
-    // let default_pk = BLS12381PublicKey::insecure_default();
     let sk = kp.private();
     let message = b"hello, narwhal";
     let sig = keys().pop().unwrap().sign(message);
     let default_sig = BLS12381Signature::default();
 
     verify_serialization(&pk, Some(pk.as_bytes()));
-    // verify_serialization(&default_pk, Some(default_pk.as_bytes()));
     verify_serialization(&sk, Some(sk.as_bytes()));
     verify_serialization(&sig, Some(sig.as_bytes()));
     verify_serialization(&default_sig, Some(default_sig.as_bytes()));

--- a/fastcrypto/src/tests/bls12381_tests.rs
+++ b/fastcrypto/src/tests/bls12381_tests.rs
@@ -297,14 +297,14 @@ fn verify_batch_missing_keys_in_batch() {
 fn test_serialize_deserialize_standard_sig() {
     let kp = keys().pop().unwrap();
     let pk = kp.public().clone();
-    let default_pk = BLS12381PublicKey::insecure_default();
+    // let default_pk = BLS12381PublicKey::insecure_default();
     let sk = kp.private();
     let message = b"hello, narwhal";
     let sig = keys().pop().unwrap().sign(message);
     let default_sig = BLS12381Signature::default();
 
     verify_serialization(&pk, Some(pk.as_bytes()));
-    verify_serialization(&default_pk, Some(default_pk.as_bytes()));
+    // verify_serialization(&default_pk, Some(default_pk.as_bytes()));
     verify_serialization(&sk, Some(sk.as_bytes()));
     verify_serialization(&sig, Some(sig.as_bytes()));
     verify_serialization(&default_sig, Some(default_sig.as_bytes()));

--- a/fastcrypto/src/tests/mskr_tests.rs
+++ b/fastcrypto/src/tests/mskr_tests.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::bls12381::mskr::Randomize;
 use crate::bls12381::{min_pk, min_sig};
-use crate::traits::mskr::Randomize;
 use crate::traits::Signer;
 use crate::traits::{AggregateAuthenticator, KeyPair, VerifyingKey};
 use rand::thread_rng;


### PR DESCRIPTION
- Moved AES related traits to `aes.rs`
- Moved `mskr` related traits to its own file
- Organized `bls12-381/mod.rs`
- Consistent validation of public keys and signatures - we validates those on during deserialization, and not every time we call `verify()`, for example
