### PR TITLE
Add benchmarks for serialization

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -77,6 +77,10 @@ name = "mskr"
 harness = false
 required-features = ["experimental"]
 
+[[bench]]
+name = "serialize"
+harness = false
+
 [features]
 default = ["secure"]
 secure = []

--- a/fastcrypto/benches/serialize.rs
+++ b/fastcrypto/benches/serialize.rs
@@ -1,0 +1,161 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate criterion;
+extern crate ed25519_consensus;
+extern crate rand;
+
+mod serialization_benches {
+    use super::*;
+    use criterion::*;
+    use fastcrypto::secp256k1::Secp256k1KeyPair;
+    use fastcrypto::secp256r1::Secp256r1KeyPair;
+    use fastcrypto::traits::Signer;
+    use fastcrypto::{bls12381, ed25519::*, traits::KeyPair};
+    use rand::{prelude::ThreadRng, thread_rng};
+
+    fn serialize_signature_single<KP: KeyPair, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let msg: &[u8] = b"";
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = KP::generate(&mut csprng);
+        let signature = keypair.sign(msg);
+        c.bench_function(&(name.to_string()), move |b| {
+            b.iter(|| bincode::serialize(&signature))
+        });
+    }
+
+    fn serialize_public_key_single<KP: KeyPair, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = KP::generate(&mut csprng);
+        c.bench_function(&(name.to_string()), move |b| {
+            b.iter(|| bincode::serialize(&keypair.public()))
+        });
+    }
+
+    fn serialize_signature(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Serialize signature");
+        serialize_signature_single::<Ed25519KeyPair, _>("Ed25519", &mut group);
+        serialize_signature_single::<bls12381::min_sig::BLS12381KeyPair, _>(
+            "BLS12381MinSig",
+            &mut group,
+        );
+        serialize_signature_single::<bls12381::min_pk::BLS12381KeyPair, _>(
+            "BLS12381MinPk",
+            &mut group,
+        );
+        serialize_signature_single::<Secp256k1KeyPair, _>("Secp256k1", &mut group);
+        serialize_signature_single::<Secp256r1KeyPair, _>("Secp256r1", &mut group);
+    }
+
+    fn serialize_public_key(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Serialize public key");
+        serialize_public_key_single::<Ed25519KeyPair, _>("Ed25519", &mut group);
+        serialize_public_key_single::<bls12381::min_sig::BLS12381KeyPair, _>(
+            "BLS12381MinSig",
+            &mut group,
+        );
+        serialize_public_key_single::<bls12381::min_pk::BLS12381KeyPair, _>(
+            "BLS12381MinPk",
+            &mut group,
+        );
+        serialize_public_key_single::<Secp256k1KeyPair, _>("Secp256k1", &mut group);
+        serialize_public_key_single::<Secp256r1KeyPair, _>("Secp256r1", &mut group);
+    }
+
+    fn deserialize_signature_single<KP: KeyPair, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let msg: &[u8] = b"";
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = KP::generate(&mut csprng);
+        let signature = keypair.sign(msg);
+        let serialized = bincode::serialize(&signature).unwrap();
+        c.bench_function(&(name.to_string()), move |b| {
+            b.iter(|| bincode::deserialize::<KP::Sig>(&serialized))
+        });
+    }
+
+    fn deserialize_public_key_single<KP: KeyPair, M: measurement::Measurement>(
+        name: &str,
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = KP::generate(&mut csprng);
+        let serialized = bincode::serialize(&keypair.public()).unwrap();
+        c.bench_function(&(name.to_string()), move |b| {
+            b.iter(|| bincode::deserialize::<KP::Sig>(&serialized))
+        });
+    }
+
+    fn deserialize_signature(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Deserialize signature");
+        deserialize_signature_single::<Ed25519KeyPair, _>("Ed25519", &mut group);
+        deserialize_signature_single::<bls12381::min_sig::BLS12381KeyPair, _>(
+            "BLS12381MinSig",
+            &mut group,
+        );
+        deserialize_signature_single::<bls12381::min_pk::BLS12381KeyPair, _>(
+            "BLS12381MinPk",
+            &mut group,
+        );
+        deserialize_signature_single::<Secp256k1KeyPair, _>("Secp256k1", &mut group);
+        deserialize_signature_single::<Secp256r1KeyPair, _>("Secp256r1", &mut group);
+        deserialize_bls_signature_non_compact(&mut group);
+    }
+
+    fn deserialize_public_key(c: &mut Criterion) {
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Deserialize public key");
+        deserialize_public_key_single::<Ed25519KeyPair, _>("Ed25519", &mut group);
+        deserialize_public_key_single::<bls12381::min_sig::BLS12381KeyPair, _>(
+            "BLS12381MinSig",
+            &mut group,
+        );
+        deserialize_public_key_single::<bls12381::min_pk::BLS12381KeyPair, _>(
+            "BLS12381MinPk",
+            &mut group,
+        );
+        deserialize_public_key_single::<Secp256k1KeyPair, _>("Secp256k1", &mut group);
+        deserialize_public_key_single::<Secp256r1KeyPair, _>("Secp256r1", &mut group);
+    }
+
+    fn deserialize_bls_signature_non_compact<M: measurement::Measurement>(
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        let msg: &[u8] = b"";
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = bls12381::min_pk::BLS12381KeyPair::generate(&mut csprng);
+        let signature = keypair.sign(msg);
+        let serialized = signature.sig.serialize();
+        c.bench_function("BLS12381MinPk non-compact", move |b| {
+            b.iter(|| bincode::deserialize::<bls12381::min_pk::BLS12381Signature>(&serialized))
+        });
+
+        let msg: &[u8] = b"";
+        let mut csprng: ThreadRng = thread_rng();
+        let keypair = bls12381::min_sig::BLS12381KeyPair::generate(&mut csprng);
+        let signature = keypair.sign(msg);
+        let serialized = signature.sig.serialize();
+        c.bench_function("BLS12381MinSig non-compact", move |b| {
+            b.iter(|| bincode::deserialize::<bls12381::min_sig::BLS12381Signature>(&serialized))
+        });
+    }
+
+    criterion_group! {
+        name = serialization_benches;
+        config = Criterion::default().sample_size(100);
+        targets =
+           deserialize_signature,
+           deserialize_public_key,
+           serialize_signature,
+           serialize_public_key,
+    }
+}
+
+criterion_main!(serialization_benches::serialization_benches);


### PR DESCRIPTION
It has been reported that deserialization of BLS signatures is a bottleneck in Sui, so I suggest we add benchmarks of serialization and deserialization to be able to qualify this discussion.

Deserialisation of a BLS12381MinSig signature is 160x times slower for a compact vs a non compact serialization (13µs vs 81 ns):

```
Deserialize signature/Ed25519
                        time:   [56.252 ns 56.639 ns 57.114 ns]
                        change: [-0.2512% +0.4025% +1.0745%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Deserialize signature/BLS12381MinSig
                        time:   [12.665 µs 12.716 µs 12.774 µs]
                        change: [-1.2967% -0.7740% -0.2812%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
Deserialize signature/BLS12381MinPk
                        time:   [25.864 µs 26.005 µs 26.154 µs]
                        change: [-0.5716% +0.0108% +0.6253%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
Deserialize signature/Secp256k1
                        time:   [62.497 ns 62.726 ns 62.975 ns]
                        change: [-2.6372% -2.0325% -1.4718%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  10 (10.00%) high mild
  1 (1.00%) high severe
Deserialize signature/Secp256r1
                        time:   [81.924 ns 82.353 ns 82.827 ns]
                        change: [+0.9635% +1.5500% +2.1307%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Deserialize signature/BLS12381MinPk non-compact
                        time:   [117.49 ns 117.92 ns 118.35 ns]
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
Deserialize signature/BLS12381MinSig non-compact
                        time:   [80.872 ns 81.278 ns 81.717 ns]
                        change: [+0.8536% +1.5292% +2.1975%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Deserialize public key/Ed25519
                        time:   [39.848 ns 40.006 ns 40.176 ns]
                        change: [-0.5279% +0.1121% +0.7380%] (p = 0.73 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
Deserialize public key/BLS12381MinSig
                        time:   [12.598 µs 12.641 µs 12.687 µs]
                        change: [-2.1518% -0.9876% +0.0001%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Deserialize public key/BLS12381MinPk
                        time:   [55.259 ns 55.559 ns 55.904 ns]
                        change: [-1.5148% -0.5400% +0.2801%] (p = 0.26 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

```