### PR TITLE
Use blst single threaded

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install criterion
         run: cargo install cargo-criterion
       - name: Run benchmarks
-        run: cd fastcrypto; cargo criterion --message-format=json --no-default-features --features no-threads-blst > ../${{ github.sha }}.json; cd ..
+        run: cd fastcrypto; cargo criterion --message-format=json --no-default-features > ../${{ github.sha }}.json; cd ..
       - name: Deploy latest benchmark report
         uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 # pin@v3
         with:

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -41,7 +41,7 @@ ecdsa = { version = "0.15.1", features = ["rfc6979"] }
 rfc6979 = "0.3.1"
 blake2 = "0.10.6"
 blake3 = "1.3.3"
-blst = "0.3.10"
+blst = { version = "0.3.10", features = ["no-threads"] }
 digest.workspace = true
 once_cell = "1.17.0"
 readonly = "0.2.3"
@@ -82,7 +82,6 @@ default = ["secure"]
 secure = []
 copy_key = []
 unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]
-no-threads-blst = ["blst/no-threads"]
 experimental = []
 
 [dev-dependencies]


### PR DESCRIPTION
Parallelisation in sui has been made complicated by blst spawning threads, so I suggest we disable it altogether. Ideally, we should be able to enable multi-threading by setting a feature flag, but since the feature in blst is "negative" (`no-threads`) this is not possible. If there's a need for multithreaded verification later we should be able to come up with a solution.

Benchmarking shows that using multiple threads in blst may speed-up verification ~25% but this comes at the cost of using multiple threads.