### PR TITLE
Update unsecure schemes

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -78,8 +78,7 @@ harness = false
 required-features = ["experimental"]
 
 [features]
-default = ["secure"]
-secure = []
+default = []
 copy_key = []
 unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]
 no-threads-blst = ["blst/no-threads"]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -23,7 +23,7 @@ serde_bytes = "0.11.9"
 serde_with = "2.1.0"
 serde-big-array = { version = "0.4.1", optional = true }
 signature = { version = "1.6.4", features = ["rand-preview"] }
-tokio = { version = "1.25.0", features = ["sync", "rt", "macros"] }
+tokio = { version = "1.24.1", features = ["sync", "rt", "macros"] }
 zeroize.workspace = true
 bulletproofs = "4.0.0"
 curve25519-dalek-ng = "4.1.1"

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -103,9 +103,5 @@ pub mod vrf;
 /// away.
 ///
 /// Warning: All schemes in this file are completely unsafe to use in production.
-#[cfg(all(
-    feature = "unsecure_schemes",
-    not(feature = "secure"),
-    debug_assertions
-))]
+#[cfg(feature = "unsecure_schemes")]
 pub mod unsecure;

--- a/fastcrypto/src/unsecure/hash.rs
+++ b/fastcrypto/src/unsecure/hash.rs
@@ -28,9 +28,7 @@ impl HashFunction<8> for XXH3Unsecure {
 
     fn finalize(self) -> Digest<8> {
         let hash: [u8; 8] = self.instance.finish().to_le_bytes();
-        Digest {
-            digest: hash.into(),
-        }
+        Digest { digest: hash }
     }
 }
 
@@ -54,9 +52,7 @@ impl HashFunction<16> for XXH128Unsecure {
 
     fn finalize(self) -> Digest<16> {
         let hash: [u8; 16] = self.instance.finish_ext().to_be_bytes();
-        Digest {
-            digest: hash.into(),
-        }
+        Digest { digest: hash }
     }
 }
 
@@ -85,6 +81,6 @@ impl HashFunction<32> for Fast256HashUnsecure {
         let mut digest = [0; 32];
         digest[..16].copy_from_slice(&short_digest);
         digest[16..32].copy_from_slice(&short_digest);
-        Digest { digest: digest }
+        Digest { digest }
     }
 }

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -163,8 +163,8 @@ impl VerifyingKey for UnsecurePublicKey {
 /// Implement Authenticator
 ///
 
-impl InsecureDefault for UnsecureSignature {
-    fn insecure_default() -> Self {
+impl Default for UnsecureSignature {
+    fn default() -> Self {
         Self([0; SIGNATURE_LENGTH])
     }
 }
@@ -327,8 +327,8 @@ fn xor<const N: usize>(x: [u8; N], y: [u8; N]) -> [u8; N] {
     v.try_into().unwrap()
 }
 
-impl InsecureDefault for UnsecureAggregateSignature {
-    fn insecure_default() -> Self {
+impl Default for UnsecureAggregateSignature {
+    fn default() -> Self {
         Self([0; SIGNATURE_LENGTH])
     }
 }

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -51,7 +51,7 @@ pub struct UnsecureKeyPair {
     secret: UnsecurePrivateKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnsecureSignature(pub [u8; SIGNATURE_LENGTH]);
 
 impl<const DIGEST_LEN: usize> From<Digest<DIGEST_LEN>> for UnsecureSignature {

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use crate::traits::{
-    AggregateAuthenticator, Authenticator, EncodeDecodeBase64, KeyPair, Signer, SigningKey,
-    ToFromBytes, VerifyingKey,
+    AggregateAuthenticator, Authenticator, EncodeDecodeBase64, InsecureDefault, KeyPair, Signer,
+    SigningKey, ToFromBytes, VerifyingKey,
 };
 
 use super::hash::Fast256HashUnsecure;
@@ -87,8 +87,8 @@ fn sign(pk: [u8; PUBLIC_KEY_LENGTH], msg: &[u8]) -> UnsecureSignature {
 /// Implement SigningKey
 ///
 
-impl Default for UnsecurePublicKey {
-    fn default() -> Self {
+impl InsecureDefault for UnsecurePublicKey {
+    fn insecure_default() -> Self {
         Self([0; PUBLIC_KEY_LENGTH])
     }
 }
@@ -163,8 +163,8 @@ impl VerifyingKey for UnsecurePublicKey {
 /// Implement Authenticator
 ///
 
-impl Default for UnsecureSignature {
-    fn default() -> Self {
+impl InsecureDefault for UnsecureSignature {
+    fn insecure_default() -> Self {
         Self([0; SIGNATURE_LENGTH])
     }
 }
@@ -327,8 +327,8 @@ fn xor<const N: usize>(x: [u8; N], y: [u8; N]) -> [u8; N] {
     v.try_into().unwrap()
 }
 
-impl Default for UnsecureAggregateSignature {
-    fn default() -> Self {
+impl InsecureDefault for UnsecureAggregateSignature {
+    fn insecure_default() -> Self {
         Self([0; SIGNATURE_LENGTH])
     }
 }

--- a/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
+++ b/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::signature_service::SignatureService;
+use crate::traits::InsecureDefault;
 use crate::{
     hash::{Blake2b256, HashFunction},
     hmac::hkdf_generate_from_ikm,
@@ -256,7 +257,7 @@ fn verify_batch_aggregate_signature() {
 #[test]
 fn test_serialize_deserialize_aggregate_signatures() {
     // Test empty aggregate signature
-    let sig = UnsecureAggregateSignature::default();
+    let sig = UnsecureAggregateSignature::insecure_default();
     let serialized = bincode::serialize(&sig).unwrap();
     let _deserialized: UnsecureAggregateSignature = bincode::deserialize(&serialized).unwrap();
 
@@ -287,7 +288,7 @@ fn test_add_signatures_to_aggregate() {
     let message = b"hello, narwhal";
 
     // Test 'add signature'
-    let mut sig1 = UnsecureAggregateSignature::default();
+    let mut sig1 = UnsecureAggregateSignature::insecure_default();
     // Test populated aggregate signature
     kps.clone().into_iter().for_each(|kp| {
         let sig = kp.sign(message);
@@ -297,7 +298,7 @@ fn test_add_signatures_to_aggregate() {
     assert!(sig1.verify(&pks, message).is_ok());
 
     // Test 'add aggregate signature'
-    let mut sig2 = UnsecureAggregateSignature::default();
+    let mut sig2 = UnsecureAggregateSignature::insecure_default();
 
     let kp = &kps[0];
     let sig = UnsecureAggregateSignature::aggregate(&vec![kp.sign(message)]).unwrap();
@@ -327,7 +328,7 @@ fn test_add_signatures_to_aggregate_different_messages() {
     let messages: Vec<&[u8]> = vec![b"hello", b"world", b"!!!!!"];
 
     // Test 'add signature'
-    let mut sig1 = UnsecureAggregateSignature::default();
+    let mut sig1 = UnsecureAggregateSignature::insecure_default();
     // Test populated aggregate signature
     for (i, kp) in kps.iter().take(3).enumerate() {
         let sig = kp.sign(messages[i]);
@@ -337,7 +338,7 @@ fn test_add_signatures_to_aggregate_different_messages() {
     assert!(sig1.verify_different_msg(&pks, &messages).is_ok());
 
     // Test 'add aggregate signature'
-    let mut sig2 = UnsecureAggregateSignature::default();
+    let mut sig2 = UnsecureAggregateSignature::insecure_default();
 
     let kp = &kps[0];
     let sig = UnsecureAggregateSignature::aggregate(&[kp.sign(messages[0])]).unwrap();

--- a/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
+++ b/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::signature_service::SignatureService;
-use crate::traits::InsecureDefault;
 use crate::{
     hash::{Blake2b256, HashFunction},
     hmac::hkdf_generate_from_ikm,
@@ -257,7 +256,7 @@ fn verify_batch_aggregate_signature() {
 #[test]
 fn test_serialize_deserialize_aggregate_signatures() {
     // Test empty aggregate signature
-    let sig = UnsecureAggregateSignature::insecure_default();
+    let sig = UnsecureAggregateSignature::default();
     let serialized = bincode::serialize(&sig).unwrap();
     let _deserialized: UnsecureAggregateSignature = bincode::deserialize(&serialized).unwrap();
 
@@ -288,7 +287,7 @@ fn test_add_signatures_to_aggregate() {
     let message = b"hello, narwhal";
 
     // Test 'add signature'
-    let mut sig1 = UnsecureAggregateSignature::insecure_default();
+    let mut sig1 = UnsecureAggregateSignature::default();
     // Test populated aggregate signature
     kps.clone().into_iter().for_each(|kp| {
         let sig = kp.sign(message);
@@ -298,7 +297,7 @@ fn test_add_signatures_to_aggregate() {
     assert!(sig1.verify(&pks, message).is_ok());
 
     // Test 'add aggregate signature'
-    let mut sig2 = UnsecureAggregateSignature::insecure_default();
+    let mut sig2 = UnsecureAggregateSignature::default();
 
     let kp = &kps[0];
     let sig = UnsecureAggregateSignature::aggregate(&vec![kp.sign(message)]).unwrap();
@@ -328,7 +327,7 @@ fn test_add_signatures_to_aggregate_different_messages() {
     let messages: Vec<&[u8]> = vec![b"hello", b"world", b"!!!!!"];
 
     // Test 'add signature'
-    let mut sig1 = UnsecureAggregateSignature::insecure_default();
+    let mut sig1 = UnsecureAggregateSignature::default();
     // Test populated aggregate signature
     for (i, kp) in kps.iter().take(3).enumerate() {
         let sig = kp.sign(messages[i]);
@@ -338,7 +337,7 @@ fn test_add_signatures_to_aggregate_different_messages() {
     assert!(sig1.verify_different_msg(&pks, &messages).is_ok());
 
     // Test 'add aggregate signature'
-    let mut sig2 = UnsecureAggregateSignature::insecure_default();
+    let mut sig2 = UnsecureAggregateSignature::default();
 
     let kp = &kps[0];
     let sig = UnsecureAggregateSignature::aggregate(&[kp.sign(messages[0])]).unwrap();

--- a/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
+++ b/fastcrypto/src/unsecure/tests/unsecure_signature_tests.rs
@@ -6,15 +6,15 @@ use crate::signature_service::SignatureService;
 use crate::{
     hash::{Blake2b256, HashFunction},
     hmac::hkdf_generate_from_ikm,
-    traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
+    traits::{
+        AggregateAuthenticator, EncodeDecodeBase64, KeyPair, Signer, ToFromBytes, VerifyingKey,
+    },
     unsecure::signature::{
         UnsecureAggregateSignature, UnsecureKeyPair, UnsecurePrivateKey, UnsecurePublicKey,
         UnsecureSignature,
     },
 };
-use ::signature::Verifier;
 use rand::{rngs::StdRng, SeedableRng as _};
-use signature::Signer;
 
 pub fn keys() -> Vec<UnsecureKeyPair> {
     let mut rng = StdRng::from_seed([0; 32]);
@@ -398,7 +398,7 @@ async fn signature_service() {
     // Request signature from the service.
     let message: &[u8] = b"Hello, world!";
     let digest = Blake2b256::digest(message);
-    let signature = service.request_signature(digest.clone()).await;
+    let signature = service.request_signature(digest).await;
 
     // Verify the signature we received.
     assert!(pk.verify(digest.digest.as_slice(), &signature).is_ok());


### PR DESCRIPTION
We have to relax the restriction on the unsecure code because the workspace in sui doesn't propagate the `no-default-features` parameter and we also cannot restrict the usage to the debug profile because we want to use it for benchmarking. This means that the unsecure signatures are available by simply setting the `unsecure_schemes` feature.