### PR TITLE
Remove untrusted crate which is used redundantly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,6 @@ dependencies = [
  "fastcrypto",
  "hex",
  "proptest",
- "untrusted",
 ]
 
 [[package]]
@@ -2585,12 +2584,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "valuable"

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -21,7 +21,6 @@ ark-relations = "0.3.0"
 ark-serialize = "0.3.0"
 blst = "0.3.10"
 byte-slice-cast = "1.2.2"
-untrusted = "0.9.0"
 fastcrypto = { path = "../fastcrypto" }
 
 [dev-dependencies]

--- a/fastcrypto-zkp/src/api.rs
+++ b/fastcrypto-zkp/src/api.rs
@@ -5,7 +5,6 @@ use ark_bls12_381::Bls12_381;
 use ark_groth16::{Proof, VerifyingKey};
 use ark_serialize::CanonicalDeserialize;
 use fastcrypto::error::FastCryptoError;
-use untrusted::Input;
 
 use crate::conversions::BlsFr;
 use crate::verifier::{process_vk_special, verify_with_processed_vk, PreparedVerifyingKey};
@@ -16,7 +15,7 @@ mod api_tests;
 
 /// Deserialize bytes as an Arkwork representation of a verifying key, and return a vector of the four components of a prepared verified key (see more at [`crate::verifier::PreparedVerifyingKey`]).
 pub fn prepare_pvk_bytes(vk_bytes: &[u8]) -> Result<Vec<Vec<u8>>, FastCryptoError> {
-    let vk = VerifyingKey::<Bls12_381>::deserialize(Input::from(vk_bytes).as_slice_less_safe())
+    let vk = VerifyingKey::<Bls12_381>::deserialize(vk_bytes)
         .map_err(|_| FastCryptoError::InvalidInput)?;
 
     process_vk_special(&vk).as_serialized()
@@ -32,11 +31,11 @@ pub fn verify_groth16_in_bytes(
     proof_public_inputs_as_bytes: &[u8],
     proof_points_as_bytes: &[u8],
 ) -> Result<bool, FastCryptoError> {
-    let x = BlsFr::deserialize(Input::from(proof_public_inputs_as_bytes).as_slice_less_safe())
+    let x = BlsFr::deserialize(proof_public_inputs_as_bytes)
         .map_err(|_| FastCryptoError::InvalidInput)?;
 
     let proof =
-        Proof::<Bls12_381>::deserialize(Input::from(proof_points_as_bytes).as_slice_less_safe())
+        Proof::<Bls12_381>::deserialize(proof_points_as_bytes)
             .map_err(|_| FastCryptoError::InvalidInput)?;
 
     let blst_pvk = PreparedVerifyingKey::deserialize(

--- a/fastcrypto-zkp/src/api.rs
+++ b/fastcrypto-zkp/src/api.rs
@@ -34,9 +34,8 @@ pub fn verify_groth16_in_bytes(
     let x = BlsFr::deserialize(proof_public_inputs_as_bytes)
         .map_err(|_| FastCryptoError::InvalidInput)?;
 
-    let proof =
-        Proof::<Bls12_381>::deserialize(proof_points_as_bytes)
-            .map_err(|_| FastCryptoError::InvalidInput)?;
+    let proof = Proof::<Bls12_381>::deserialize(proof_points_as_bytes)
+        .map_err(|_| FastCryptoError::InvalidInput)?;
 
     let blst_pvk = PreparedVerifyingKey::deserialize(
         vk_gamma_abc_g1_bytes,

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -192,8 +192,7 @@ fn test_verify_with_processed_vk() {
     let mut public_inputs_bytes = Vec::new();
     v.serialize(&mut public_inputs_bytes).unwrap();
 
-    let deserialized_public_inputs =
-        BlsFr::deserialize(public_inputs_bytes.as_slice()).unwrap();
+    let deserialized_public_inputs = BlsFr::deserialize(public_inputs_bytes.as_slice()).unwrap();
 
     // Roundtrip serde of the proof points bytes.
     let mut proof_points_bytes = Vec::new();

--- a/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/unit_tests/verifier_tests.rs
@@ -16,7 +16,6 @@ use std::{
     iter,
     ops::{AddAssign, Mul, Neg},
 };
-use untrusted::Input;
 
 use crate::{
     conversions::{
@@ -193,16 +192,14 @@ fn test_verify_with_processed_vk() {
     let mut public_inputs_bytes = Vec::new();
     v.serialize(&mut public_inputs_bytes).unwrap();
 
-    let inputs_reader = Input::from(&public_inputs_bytes);
     let deserialized_public_inputs =
-        BlsFr::deserialize(inputs_reader.as_slice_less_safe()).unwrap();
+        BlsFr::deserialize(public_inputs_bytes.as_slice()).unwrap();
 
     // Roundtrip serde of the proof points bytes.
     let mut proof_points_bytes = Vec::new();
     proof.serialize(&mut proof_points_bytes).unwrap();
-    let proof_reader = Input::from(&proof_points_bytes);
     let deserialized_proof_points =
-        Proof::<Bls12_381>::deserialize(proof_reader.as_slice_less_safe()).unwrap();
+        Proof::<Bls12_381>::deserialize(proof_points_bytes.as_slice()).unwrap();
 
     // Roundtrip serde of the prepared verifying key.
     let serialized = blst_pvk.as_serialized().unwrap();

--- a/fastcrypto-zkp/src/verifier.rs
+++ b/fastcrypto-zkp/src/verifier.rs
@@ -50,8 +50,7 @@ impl PreparedVerifyingKey {
     ) -> Result<Self, FastCryptoError> {
         let mut vk_gamma_abc_g1: Vec<G1Affine> = Vec::new();
         for g1_bytes in vk_gamma_abc_g1_bytes.chunks(G1_COMPRESSED_SIZE) {
-            let g1 = G1Affine::deserialize(g1_bytes)
-                .map_err(|_| FastCryptoError::InvalidInput)?;
+            let g1 = G1Affine::deserialize(g1_bytes).map_err(|_| FastCryptoError::InvalidInput)?;
             vk_gamma_abc_g1.push(g1);
         }
         let alpha_g1_beta_g2 = bls_fq12_to_blst_fp12(

--- a/fastcrypto-zkp/src/verifier.rs
+++ b/fastcrypto-zkp/src/verifier.rs
@@ -13,7 +13,6 @@ use blst::{
     blst_p1s_mult_pippenger_scratch_sizeof, blst_scalar, blst_scalar_from_fr, limb_t, Pairing,
 };
 use fastcrypto::error::FastCryptoError;
-use untrusted::Input;
 
 use crate::conversions::{
     bls_fq12_to_blst_fp12, bls_fr_to_blst_fr, bls_g1_affine_to_blst_g1_affine,
@@ -51,23 +50,19 @@ impl PreparedVerifyingKey {
     ) -> Result<Self, FastCryptoError> {
         let mut vk_gamma_abc_g1: Vec<G1Affine> = Vec::new();
         for g1_bytes in vk_gamma_abc_g1_bytes.chunks(G1_COMPRESSED_SIZE) {
-            let g1_reader = Input::from(g1_bytes);
-            let g1 = G1Affine::deserialize(g1_reader.as_slice_less_safe())
+            let g1 = G1Affine::deserialize(g1_bytes)
                 .map_err(|_| FastCryptoError::InvalidInput)?;
             vk_gamma_abc_g1.push(g1);
         }
-        let alpha_reader = Input::from(alpha_g1_beta_g2_bytes);
         let alpha_g1_beta_g2 = bls_fq12_to_blst_fp12(
-            &Fq12::deserialize(alpha_reader.as_slice_less_safe())
+            &Fq12::deserialize(alpha_g1_beta_g2_bytes)
                 .map_err(|_| FastCryptoError::InvalidInput)?,
         );
 
-        let g2_reader = Input::from(gamma_g2_neg_pc_bytes);
-        let gamma_g2_neg_pc = G2Affine::deserialize(g2_reader.as_slice_less_safe())
+        let gamma_g2_neg_pc = G2Affine::deserialize(gamma_g2_neg_pc_bytes)
             .map_err(|_| FastCryptoError::InvalidInput)?;
 
-        let g2_reader_2 = Input::from(delta_g2_neg_pc_bytes);
-        let delta_g2_neg_pc = G2Affine::deserialize(g2_reader_2.as_slice_less_safe())
+        let delta_g2_neg_pc = G2Affine::deserialize(delta_g2_neg_pc_bytes)
             .map_err(|_| FastCryptoError::InvalidInput)?;
 
         Ok(PreparedVerifyingKey {


### PR DESCRIPTION
In fastcrypto-zkp, the `untrusted` crate is used to parse binary inputs and in all cases, the inputs are then used by calling `as_slice_less_safe()` on the input immediately after as input to deserialize. As noted in the documentation of the `untrusted` crate, this does not guarantee panic-free code:

> untrusted.rs goes beyond Rust's normal safety guarantees by also guaranteeing that parsing will be panic-free, as long as untrusted::Input::as_slice_less_safe() is not used.

I suggest we rely on the error handling in the deserialisations methods instead to verify the inputs.