### PR TITLE
Hash & HMAC cleanups

### DIFF
--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -234,16 +234,20 @@ pub trait MultisetHash<const DIGEST_LENGTH: usize>: Eq {
     /// Add all the elements of another hash function into this hash function.
     fn union(&mut self, other: &Self);
 
+    // Note that the "remove" operation is safe even if an item has been removed
+    // more times than it has been inserted. To see why, consider the following
+    // example: Suppose an adversary has performed two sets of "insert(x)" and
+    // "remove(x)" operations resulting in the same hash, i.e., the sum of each set
+    // is \sum_x m_x H(x), where m_x is the difference between the number of times
+    // "x" was inserted and removed.
+    // Then, one can create two new sets with the same hash by taking the original
+    // sets and subtracting m_x H(x) from both sets for every item "x" such that m_x
+    // was negative in any of the original sets. Since we "subtract" (or actually
+    // insert) the same elements from both sets, the resulting hash will remain the
+    // same. Moreover, since none of the values of m_x in the new sets are negative,
+    // we can conclude that no item was removed more times than it was inserted in
+    // the new sets.
     /// Remove an element from this hash function.
-    // Note that remove is safe even if an item is removed more time than inserted. To see that,
-    // consider the following example: Say that the adversary has two sets of "insert(x)" and
-    // "remove(x)" operations that result in the same hash, or in other words, the sum of each set is
-    // \sum_x m_x H(x) where m_x is #insert(x) - #remove(x)#. Then, one can create two new sets with
-    // the same hash by taking the original sets and adding -m_x H(x) to both, for every item x such
-    // that m_x was negative in any of the original sets. Since we add exactly the same elements to
-    // both sets, the resulting hash will be the same, and since now none of the values m_x of the
-    // new sets are negative, in the the new sets we know that no item was removed more than
-    // inserted.
     fn remove<Data: AsRef<[u8]>>(&mut self, item: Data);
 
     /// Remove multiple items from this hash function.

--- a/fastcrypto/src/hmac.rs
+++ b/fastcrypto/src/hmac.rs
@@ -58,6 +58,7 @@ use hkdf::hmac::{Hmac, Mac};
 ///     assert_ne!(native_sk.to_bytes(), my_keypair.private().as_bytes());
 /// # }
 /// ```
+#[cfg(any(test, feature = "experimental"))]
 pub fn hkdf_generate_from_ikm<H, K>(
     ikm: &[u8],  // IKM (32 bytes).
     salt: &[u8], // Salt (can be empty).
@@ -99,12 +100,11 @@ const HKDF_KEY_RECOMMENDED_LENGTH: usize = 32;
 
 /// Type for key in [hmac_sha3_256].
 pub type HmacKey = PrivateSeed<HMAC_KEY_RECOMMENDED_LENGTH, false>;
-/// Type for input keying material in [hkdf_sha3_256].
-pub type HkdfIkm = PrivateSeed<HKDF_KEY_RECOMMENDED_LENGTH, false>;
 
 /// [Keyed-Hash Message Authentication Code](https://www.rfc-editor.org/rfc/rfc2104) (HMAC) using SHA3-256.
 pub fn hmac_sha3_256(key: &HmacKey, message: &[u8]) -> Digest<32> {
-    let mut hash = Hmac::<sha3::Sha3_256>::new_from_slice(key.as_bytes()).unwrap();
+    let mut hash = Hmac::<sha3::Sha3_256>::new_from_slice(key.as_bytes())
+        .expect("HMAC can take key of any size");
     hash.update(message);
     let output = hash.finalize();
     Digest {
@@ -112,7 +112,12 @@ pub fn hmac_sha3_256(key: &HmacKey, message: &[u8]) -> Digest<32> {
     }
 }
 
+/// Type for input keying material in [hkdf_sha3_256].
+#[cfg(any(test, feature = "experimental"))]
+pub type HkdfIkm = PrivateSeed<HKDF_KEY_RECOMMENDED_LENGTH, false>;
+
 /// [HMAC-based Extract-and-Expand Key Derivation Function](https://tools.ietf.org/html/rfc5869) (HKDF) using SHA3-256.
+#[cfg(any(test, feature = "experimental"))]
 pub fn hkdf_sha3_256(
     ikm: &HkdfIkm,
     salt: &[u8],

--- a/fastcrypto/src/private_seed.rs
+++ b/fastcrypto/src/private_seed.rs
@@ -30,7 +30,7 @@ impl<const RECOMMENDED_LENGTH: usize, const FIXED_LENGTH_ONLY: bool> ToFromBytes
             return Err(FastCryptoError::InputLengthWrong(RECOMMENDED_LENGTH));
         }
         Ok(Self {
-            bytes: bytes.to_vec(),
+            bytes: bytes.into(),
         })
     }
 

--- a/fastcrypto/src/tests/hash_tests.rs
+++ b/fastcrypto/src/tests/hash_tests.rs
@@ -7,6 +7,20 @@ use crate::hash::{
 };
 
 #[test]
+fn test_new_update_finalize() {
+    let data =
+        hex::decode("301d56460954541aab6dd7ddc0dd08f8cb3ebd884784a0e797905107533cae62").unwrap();
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let digest = hasher.finalize();
+    assert_eq!(
+        digest.as_ref(),
+        hex::decode("2196d60feda3cd3787885c10a905e11fae911c32a0eb67fd290ade5df7eab140").unwrap()
+    );
+    println!("{}", digest);
+}
+
+#[test]
 fn test_sha256() {
     let data =
         hex::decode("301d56460954541aab6dd7ddc0dd08f8cb3ebd884784a0e797905107533cae62").unwrap();
@@ -15,6 +29,7 @@ fn test_sha256() {
         digest.as_ref(),
         hex::decode("2196d60feda3cd3787885c10a905e11fae911c32a0eb67fd290ade5df7eab140").unwrap()
     );
+    println!("{}", digest);
 }
 
 #[test]
@@ -94,6 +109,12 @@ fn test_accumulator() {
     assert_ne!(check1, accumulator);
     assert_ne!(check1.digest(), accumulator.digest());
 
+    // Test regression
+    assert_eq!(
+        check1.digest().as_ref(),
+        hex::decode("0a8b8511c8c985a4530921933ac82b374ca5230b7e25758c43afe699eb1eec60").unwrap()
+    );
+
     // Hashing the same elements should give the same hash
     let mut accumulator2 = EllipticCurveMultisetHash::default();
     accumulator2.insert_all([b"Hello", b"World"]);
@@ -126,4 +147,9 @@ fn test_accumulator() {
     // Removing all added elements will make the hash equal again
     accumulator2.remove_all([b"!", b"!"]);
     assert_eq!(accumulator, accumulator2);
+
+    // Compare with default
+    let accumulator4 = EllipticCurveMultisetHash::default();
+    assert_ne!(accumulator, accumulator4);
+    assert_ne!(accumulator.digest(), accumulator4.digest());
 }

--- a/fastcrypto/src/tests/hash_tests.rs
+++ b/fastcrypto/src/tests/hash_tests.rs
@@ -152,4 +152,9 @@ fn test_accumulator() {
     let accumulator4 = EllipticCurveMultisetHash::default();
     assert_ne!(accumulator, accumulator4);
     assert_ne!(accumulator.digest(), accumulator4.digest());
+    // Test regression of default
+    assert_eq!(
+        accumulator4.digest().as_ref(),
+        hex::decode("66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925").unwrap()
+    );
 }

--- a/fastcrypto/src/tests/hmac_tests.rs
+++ b/fastcrypto/src/tests/hmac_tests.rs
@@ -81,7 +81,7 @@ fn test_regression_of_salt_padding() {
 }
 
 #[test]
-fn test_regression_of_hmac() {
+fn test_hmac_regression() {
     let test1 = HmacTestVector {
         key: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
         message: "4869205468657265",
@@ -108,7 +108,7 @@ fn test_regression_of_hmac() {
 
 #[test]
 fn test_sanity_hmac_key() {
-    // Empty/short keys are be padded.
+    // Empty/short keys are padded.
     let message = [1u8; 30];
     let r = hmac_sha3_256(&HmacKey::from_bytes(&[]).unwrap(), &message);
     assert_eq!(


### PR DESCRIPTION
Note that sui's dependency on `hkdf_generate_from_ikm` is removed in https://github.com/MystenLabs/sui/pull/8657