### PR TITLE
cli: add sigs and encode cli tool

### DIFF
--- a/fastcrypto-cli/Cargo.toml
+++ b/fastcrypto-cli/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/MystenLabs/fastcrypto"
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
-fastcrypto = { path = "../fastcrypto" }
+fastcrypto = { path = "../fastcrypto", features = ["copy_key"] }
 hex = "0.4.3"
 bincode.workspace = true
 rand.workspace = true
@@ -19,3 +19,11 @@ exitcode = "1.1.2"
 [[bin]]
 name = "ecvrf-cli"
 path = "src/ecvrf.rs"
+
+[[bin]]
+name = "encode-cli"
+path = "src/encode_cli.rs"
+
+[[bin]]
+name = "sigs-cli"
+path = "src/sigs_cli.rs"

--- a/fastcrypto-cli/src/encode_cli.rs
+++ b/fastcrypto-cli/src/encode_cli.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use fastcrypto::encoding::{Base64, Encoding, Hex};
+use std::io::{Error, ErrorKind};
+
+#[derive(Parser)]
+#[command(name = "encode-cli")]
+#[command(about = "Convert between base64 and hex encoding of a string", long_about = None)]
+enum Command {
+    /// Decode a base64 string into hex string.
+    Base64ToHex(Arg),
+
+    /// Decode a hex string into base64 string.
+    HexToBase64(Arg),
+}
+
+#[derive(Parser, Clone)]
+struct Arg {
+    #[clap(short, long)]
+    value: String,
+}
+
+fn main() {
+    match execute(Command::parse()) {
+        Ok(_) => {
+            std::process::exit(exitcode::OK);
+        }
+        Err(e) => {
+            println!("Error: {}", e);
+            std::process::exit(exitcode::DATAERR);
+        }
+    }
+}
+
+fn execute(cmd: Command) -> Result<(), std::io::Error> {
+    match cmd {
+        Command::Base64ToHex(args) => {
+            let val = Base64::decode(&args.value)
+                .map_err(|_| Error::new(ErrorKind::InvalidInput, "Invalid base64 string"))?;
+            println!("Decoded bytes: {:?}", val);
+            println!("Hex: {:?}", Hex::encode(val));
+            Ok(())
+        }
+        Command::HexToBase64(args) => {
+            let val = Hex::decode(&args.value)
+                .map_err(|_| Error::new(ErrorKind::InvalidInput, "Invalid hex string"))?;
+            println!("Decoded bytes: {:?}", val);
+            println!("Base64: {:?}", Base64::encode(val));
+            Ok(())
+        }
+    }
+}

--- a/fastcrypto-cli/src/sigs_cli.rs
+++ b/fastcrypto-cli/src/sigs_cli.rs
@@ -1,0 +1,263 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use fastcrypto::traits::Signer;
+use fastcrypto::{
+    bls12381::min_sig::{
+        BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature,
+    },
+    ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    encoding::{Encoding, Hex},
+    error::FastCryptoError,
+    secp256k1::{
+        recoverable::Secp256k1RecoverableSignature, Secp256k1KeyPair, Secp256k1PrivateKey,
+        Secp256k1PublicKey, Secp256k1Signature,
+    },
+    secp256r1::{
+        recoverable::Secp256r1RecoverableSignature, Secp256r1KeyPair, Secp256r1PrivateKey,
+        Secp256r1PublicKey, Secp256r1Signature,
+    },
+    traits::{KeyPair, RecoverableSigner, ToFromBytes, VerifyRecoverable, VerifyingKey},
+};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::{
+    io::{Error, ErrorKind},
+    str::FromStr,
+};
+#[derive(Parser)]
+#[command(name = "sig-cli")]
+#[command(about = "Sign or verify a signature using a signature scheme", long_about = None)]
+enum Command {
+    /// Generate a keypair using the signature scheme with a deterministic seed.
+    Keygen(KeygenArguments),
+
+    /// Sign a message using a secret key using the signature scheme.
+    Sign(SigningArguments),
+
+    /// Verify the signature against the message and public key using the signature scheme.
+    Verify(VerifiyingArguments),
+}
+
+#[derive(Parser, Clone)]
+struct KeygenArguments {
+    /// Name of the signature scheme.
+    #[clap(long)]
+    scheme: String,
+    /// Hex encoded 32-byte seed for deterministic key generation. e.g. 0000000000000000000000000000000000000000000000000000000000000000.
+    #[clap(long)]
+    seed: String,
+}
+
+enum SignatureScheme {
+    Ed25519,
+    Secp256k1,
+    Secp256k1Recoverable,
+    Secp256r1,
+    Secp256r1Recoverable,
+    BLS12381,
+}
+
+impl FromStr for SignatureScheme {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ed25519" => Ok(SignatureScheme::Ed25519),
+            "secp256k1" => Ok(SignatureScheme::Secp256k1),
+            "secp256k1-rec" => Ok(SignatureScheme::Secp256k1Recoverable),
+            "secp256r1" => Ok(SignatureScheme::Secp256r1),
+            "secp256r1-rec" => Ok(SignatureScheme::Secp256r1Recoverable),
+            "bls12381" => Ok(SignatureScheme::BLS12381),
+            _ => Err(Error::new(ErrorKind::Other, "Invalid signature scheme.")),
+        }
+    }
+}
+#[derive(Parser, Clone)]
+struct SigningArguments {
+    /// The raw message to be signed.
+    #[clap(long)]
+    msg: String,
+
+    /// Hex encoded secret key string used to sign.
+    #[clap(long)]
+    secret_key: String,
+
+    /// Name of the signature scheme.
+    #[clap(long)]
+    scheme: String,
+}
+
+#[derive(Parser, Clone)]
+struct VerifiyingArguments {
+    /// The raw message signed.
+    #[clap(short, long)]
+    msg: String,
+
+    /// Hex encoded signature to be verified.
+    #[clap(long)]
+    signature: String,
+
+    /// Public key to verify the signature.
+    #[clap(short, long)]
+    public_key: String,
+
+    /// Name of the signature scheme.
+    #[clap(long)]
+    scheme: String,
+}
+
+fn main() {
+    match execute(Command::parse()) {
+        Ok(_) => {
+            std::process::exit(exitcode::OK);
+        }
+        Err(e) => {
+            println!("Error: {}", e);
+            std::process::exit(exitcode::DATAERR);
+        }
+    }
+}
+
+fn execute(cmd: Command) -> Result<(), FastCryptoError> {
+    match cmd {
+        Command::Keygen(arg) => {
+            let arr = Hex::decode(&arg.seed).map_err(|_| FastCryptoError::InvalidInput)?;
+            let seed: [u8; 32] = arr.try_into().map_err(|_| FastCryptoError::InvalidInput)?;
+            let rng = &mut StdRng::from_seed(seed);
+
+            let (sk, pk) = match SignatureScheme::from_str(&arg.scheme) {
+                Ok(SignatureScheme::Ed25519) => {
+                    let kp = Ed25519KeyPair::generate(rng);
+                    (
+                        Hex::encode(kp.copy().private().as_ref()),
+                        Hex::encode(kp.public().as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::Secp256k1) | Ok(SignatureScheme::Secp256k1Recoverable) => {
+                    let kp = Secp256k1KeyPair::generate(rng);
+                    (
+                        Hex::encode(kp.copy().private().as_ref()),
+                        Hex::encode(kp.public().as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::Secp256r1) | Ok(SignatureScheme::Secp256r1Recoverable) => {
+                    let kp = Secp256r1KeyPair::generate(rng);
+                    (
+                        Hex::encode(kp.copy().private().as_ref()),
+                        Hex::encode(kp.public().as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::BLS12381) => {
+                    let kp = BLS12381KeyPair::generate(rng);
+                    (
+                        Hex::encode(kp.copy().private().as_ref()),
+                        Hex::encode(kp.public().as_ref()),
+                    )
+                }
+                Err(_) => return Err(FastCryptoError::InvalidInput),
+            };
+            println!("Private key in hex: {:?}", sk);
+            println!("Public key in hex: {:?}", pk);
+
+            Ok(())
+        }
+
+        Command::Sign(arg) => {
+            let sk = Hex::decode(&arg.secret_key).map_err(|_| FastCryptoError::InvalidInput)?;
+            let msg = Hex::decode(&arg.msg).map_err(|_| FastCryptoError::InvalidInput)?;
+
+            let (pk, sig) = match SignatureScheme::from_str(&arg.scheme) {
+                Ok(SignatureScheme::Ed25519) => {
+                    let kp = Ed25519KeyPair::from(Ed25519PrivateKey::from_bytes(&sk)?);
+                    (
+                        Hex::encode(kp.public()),
+                        Hex::encode(kp.sign(&msg).as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::Secp256k1) => {
+                    let kp = Secp256k1KeyPair::from(Secp256k1PrivateKey::from_bytes(&sk)?);
+                    (
+                        Hex::encode(kp.public()),
+                        Hex::encode(kp.sign(&msg).as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::Secp256k1Recoverable) => {
+                    let kp = Secp256k1KeyPair::from(Secp256k1PrivateKey::from_bytes(&sk)?);
+                    (
+                        Hex::encode(kp.public()),
+                        Hex::encode(kp.sign_recoverable(&msg).as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::Secp256r1) => {
+                    let kp = Secp256r1KeyPair::from(Secp256r1PrivateKey::from_bytes(&sk)?);
+                    (
+                        Hex::encode(kp.public()),
+                        Hex::encode(kp.sign(&msg).as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::Secp256r1Recoverable) => {
+                    let kp = Secp256r1KeyPair::from(Secp256r1PrivateKey::from_bytes(&sk)?);
+                    (
+                        Hex::encode(kp.public()),
+                        Hex::encode(kp.sign_recoverable(&msg).as_ref()),
+                    )
+                }
+                Ok(SignatureScheme::BLS12381) => {
+                    let kp = BLS12381KeyPair::from(BLS12381PrivateKey::from_bytes(&sk)?);
+                    (
+                        Hex::encode(kp.public()),
+                        Hex::encode(kp.sign(&msg).as_ref()),
+                    )
+                }
+                Err(_) => return Err(FastCryptoError::InvalidInput),
+            };
+            println!("Signature in hex: {:?}", sig);
+            println!("Public key in hex: {:?}", pk);
+            Ok(())
+        }
+
+        Command::Verify(arg) => {
+            let pk = Hex::decode(&arg.public_key).map_err(|_| FastCryptoError::InvalidInput)?;
+            let msg = Hex::decode(&arg.msg).map_err(|_| FastCryptoError::InvalidInput)?;
+            let sig = Hex::decode(&arg.signature).map_err(|_| FastCryptoError::InvalidInput)?;
+
+            let res = match SignatureScheme::from_str(&arg.scheme) {
+                Ok(SignatureScheme::Ed25519) => {
+                    let pk = Ed25519PublicKey::from_bytes(&pk)
+                        .map_err(|_| FastCryptoError::InvalidInput)?;
+                    pk.verify(&msg, &Ed25519Signature::from_bytes(&sig)?)
+                }
+                Ok(SignatureScheme::Secp256k1) => {
+                    let pk = Secp256k1PublicKey::from_bytes(&pk)
+                        .map_err(|_| FastCryptoError::InvalidInput)?;
+                    pk.verify(&msg, &Secp256k1Signature::from_bytes(&sig)?)
+                }
+                Ok(SignatureScheme::Secp256k1Recoverable) => {
+                    let pk = Secp256k1PublicKey::from_bytes(&pk)
+                        .map_err(|_| FastCryptoError::InvalidInput)?;
+                    pk.verify_recoverable(&msg, &Secp256k1RecoverableSignature::from_bytes(&sig)?)
+                }
+                Ok(SignatureScheme::Secp256r1) => {
+                    let pk = Secp256r1PublicKey::from_bytes(&pk)
+                        .map_err(|_| FastCryptoError::InvalidInput)?;
+                    pk.verify(&msg, &Secp256r1Signature::from_bytes(&sig)?)
+                }
+                Ok(SignatureScheme::Secp256r1Recoverable) => {
+                    let pk = Secp256r1PublicKey::from_bytes(&pk)
+                        .map_err(|_| FastCryptoError::InvalidInput)?;
+                    pk.verify_recoverable(&msg, &Secp256r1RecoverableSignature::from_bytes(&sig)?)
+                }
+                Ok(SignatureScheme::BLS12381) => {
+                    let pk = BLS12381PublicKey::from_bytes(&pk)
+                        .map_err(|_| FastCryptoError::InvalidInput)?;
+                    pk.verify(&msg, &BLS12381Signature::from_bytes(&sig)?)
+                }
+                Err(_) => return Err(FastCryptoError::InvalidInput),
+            };
+            println!("Verify result: {:?}", res);
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Simple cli bin:
1. all sigs keygen/sign/verify
```
cargo build --bin sigs-cli
target/debug/sigs-cli keygen --scheme ed25519 --seed 0000000000000000000000000000000000000000000000000000000000000000
Private key in hex: "9bf49a6a0755f953811fce125f2683d50429c3bb49e074147e0089a52eae155f"
Public key in hex: "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200"

target/debug/sigs-cli verify --scheme ed25519 --msg 68656C6C6F --public-key b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200 --signature 26265ae9acbbce3ab9954589738e1a059d46aaafe6aaa1a5081707bf03e8dddcbfcf5be95b62a4cf2396d1a258417bb0a5a5c5aff3236bce4c5c368443572b08
Verify result: Ok(())

target/debug/sigs-cli sign --scheme ed25519 --msg 68656C6C6F --secret-key 9bf49a6a0755f953811fce125f2683d50429c3bb49e074147e0089a52eae155f                                                                              
Signature in hex: "26265ae9acbbce3ab9954589738e1a059d46aaafe6aaa1a5081707bf03e8dddcbfcf5be95b62a4cf2396d1a258417bb0a5a5c5aff3236bce4c5c368443572b08"
Public key in hex: "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200"

target/debug/sigs-cli sign --secret-key 9bf49a6a0755f953811fce125f2683d50429c3bb49e074147e0089a52eae155f --msg 68656C6C6F --scheme secp256k1-rec                                                                                                                                                          
Signature in hex: "23a1248058d3eaa7f8671424e9117911115b0c4c1654b197a025936a727815ee0f554fe4730ea558502ecb6f78e513bf22a5b08738c7f35340e03c1f5f284a0500"
Public key in hex: "029bef8d556d80e43ae7e0becb3a7e6838b95defe45896ed6075bb9035d06c9964"
target/debug/sigs-cli verify --msg 68656C6C6F --public-key 029bef8d556d80e43ae7e0becb3a7e6838b95defe45896ed6075bb9035d06c9964 --signature 23a1248058d3eaa7f8671424e9117911115b0c4c1654b197a025936a727815ee0f554fe4730ea558502ecb6f78e513bf22a5b08738c7f35340e03c1f5f284a0500 --scheme secp256k1
Error: Expected input of length exactly 64
 target/debug/sigs-cli verify --msg 68656C6C6F --public-key 029bef8d556d80e43ae7e0becb3a7e6838b95defe45896ed6075bb9035d06c9964 --signature 23a1248058d3eaa7f8671424e9117911115b0c4c1654b197a025936a727815ee0f554fe4730ea558502ecb6f78e513bf22a5b08738c7f35340e03c1f5f284a0500 --scheme secp256k1-rec
Verify result: Ok(())

```

3. en/decode
```
cargo build --bin encode-cli
target/debug/encode-cli base64-to-hex --value aGVsbG8=                                                                                                                         
Decoded bytes: [104, 101, 108, 108, 111]
Hex: "68656c6c6f"

target/debug/encode-cli hex-to-base64 --value 68656c6c6f    
Decoded bytes: [104, 101, 108, 108, 111]
Base64: "aGVsbG8="
```
