### PR TITLE
Add benchmarks for hash functions

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -81,6 +81,10 @@ required-features = ["experimental"]
 name = "serialize"
 harness = false
 
+[[bench]]
+name = "hash"
+harness = false
+
 [features]
 default = []
 copy_key = []

--- a/fastcrypto/benches/hash.rs
+++ b/fastcrypto/benches/hash.rs
@@ -34,7 +34,7 @@ mod hash_benches {
         let mut group: BenchmarkGroup<_> = c.benchmark_group("Hash");
 
         for size in INPUT_SIZES.iter() {
-            let input = vec![0u8; *size];
+            let input: Vec<u8> = (0..*size).map(|_| rand::random::<u8>()).collect();
             hash_single::<Sha256, 32, _>("Sha256", &input, &mut group);
             hash_single::<Sha3_256, 32, _>("Sha3_256", &input, &mut group);
             hash_single::<Blake2b256, 32, _>("Blake2b256", &input, &mut group);

--- a/fastcrypto/benches/hash.rs
+++ b/fastcrypto/benches/hash.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate criterion;
+extern crate rand;
+
+mod hash_benches {
+    use super::*;
+    use criterion::*;
+    use fastcrypto::hash::HashFunction;
+    use fastcrypto::hash::*;
+
+    fn hash_single<
+        H: HashFunction<DIGEST_SIZE>,
+        const DIGEST_SIZE: usize,
+        M: measurement::Measurement,
+    >(
+        name: &str,
+        input: &[u8],
+        c: &mut BenchmarkGroup<M>,
+    ) {
+        c.bench_with_input(
+            BenchmarkId::new(name.to_string(), input.len()),
+            &input,
+            |b, input| {
+                b.iter(|| H::digest(input));
+            },
+        );
+    }
+
+    fn hash(c: &mut Criterion) {
+        static INPUT_SIZES: [usize; 5] = [0, 128, 256, 512, 1024];
+
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Hash");
+
+        for size in INPUT_SIZES.iter() {
+            let input = vec![0u8; *size];
+            hash_single::<Sha256, 32, _>("Sha256", &input, &mut group);
+            hash_single::<Sha3_256, 32, _>("Sha3_256", &input, &mut group);
+            hash_single::<Blake2b256, 32, _>("Blake2b256", &input, &mut group);
+            hash_single::<Blake3, 32, _>("Blake3", &input, &mut group);
+            hash_single::<Keccak256, 32, _>("Keccak256", &input, &mut group);
+            hash_single::<Sha512, 64, _>("Sha512", &input, &mut group);
+            hash_single::<Sha3_512, 64, _>("Sha3_512", &input, &mut group);
+        }
+    }
+
+    criterion_group! {
+        name = hash_benches;
+        config = Criterion::default();
+        targets = hash,
+    }
+}
+
+criterion_main!(hash_benches::hash_benches,);


### PR DESCRIPTION
Below are the results for my laptop.
![hash](https://user-images.githubusercontent.com/6288307/223989644-972c4514-c192-4c67-bab1-0e240ef7541b.png)
```
Hash/Sha256/0           time:   [201.96 ns 202.99 ns 204.17 ns]                          
Hash/Sha3_256/0         time:   [244.80 ns 246.35 ns 248.05 ns]                            
Hash/Blake2b256/0       time:   [145.43 ns 146.22 ns 147.12 ns]                              
Hash/Blake3/0           time:   [110.43 ns 111.21 ns 112.04 ns]                          
Hash/Keccak256/0        time:   [241.47 ns 242.59 ns 243.74 ns]                             
Hash/Sha512/0           time:   [264.38 ns 266.25 ns 268.25 ns]                          
Hash/Sha3_512/0         time:   [256.85 ns 258.43 ns 260.19 ns]                            
Hash/Sha256/128         time:   [586.88 ns 590.12 ns 593.80 ns]                             
Hash/Sha3_256/128       time:   [242.14 ns 243.72 ns 245.46 ns]                              
Hash/Blake2b256/128     time:   [145.64 ns 146.31 ns 147.09 ns]                                
Hash/Blake3/128         time:   [176.60 ns 177.63 ns 178.82 ns]                            
Hash/Keccak256/128      time:   [241.41 ns 242.82 ns 244.41 ns]                               
Hash/Sha512/128         time:   [505.34 ns 507.49 ns 509.85 ns]                             
Hash/Sha3_512/128       time:   [482.33 ns 484.77 ns 487.51 ns]                              
Hash/Sha256/256         time:   [961.77 ns 965.09 ns 968.55 ns]                             
Hash/Sha3_256/256       time:   [472.40 ns 474.41 ns 476.67 ns]                              
Hash/Blake2b256/256     time:   [268.07 ns 269.55 ns 271.24 ns]                                
Hash/Blake3/256         time:   [324.37 ns 325.33 ns 326.29 ns]                            
Hash/Keccak256/256      time:   [472.11 ns 473.91 ns 475.99 ns]                               
Hash/Sha512/256         time:   [750.91 ns 755.73 ns 760.71 ns]                             
Hash/Sha3_512/256       time:   [930.39 ns 934.25 ns 938.62 ns]                               
Hash/Sha256/512         time:   [1.7325 µs 1.7400 µs 1.7479 µs]                             
Hash/Sha3_256/512       time:   [920.22 ns 923.94 ns 927.89 ns]                               
Hash/Blake2b256/512     time:   [525.16 ns 528.61 ns 532.17 ns]                                 
Hash/Blake3/512         time:   [622.34 ns 624.49 ns 626.80 ns]                             
Hash/Keccak256/512      time:   [919.61 ns 924.74 ns 930.65 ns]                                
Hash/Sha512/512         time:   [1.2261 µs 1.2332 µs 1.2411 µs]                             
Hash/Sha3_512/512       time:   [1.8358 µs 1.8451 µs 1.8551 µs]                               
Hash/Sha256/1024        time:   [3.2782 µs 3.2982 µs 3.3191 µs]                              
Hash/Sha3_256/1024      time:   [1.8486 µs 1.8555 µs 1.8629 µs]                                
Hash/Blake2b256/1024    time:   [1.0233 µs 1.0273 µs 1.0314 µs]                                  
Hash/Blake3/1024        time:   [1.2403 µs 1.2446 µs 1.2488 µs]                              
Hash/Keccak256/1024     time:   [1.8428 µs 1.8483 µs 1.8540 µs]                                 
Hash/Sha512/1024        time:   [2.1953 µs 2.2024 µs 2.2088 µs]                              
Hash/Sha3_512/1024      time:   [3.3780 µs 3.3869 µs 3.3965 µs]   
```