### PR TITLE
Bump ecdsa and signature crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,8 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b0a1222f8072619e8a6b667a854020a03d363738303203c09468b3424a420a"
 dependencies = [
  "der 0.7.1",
  "elliptic-curve 0.13.2",
@@ -1486,7 +1488,7 @@ dependencies = [
  "radix64",
  "rand",
  "readonly",
- "rfc6979 0.3.1",
+ "rfc6979 0.4.0",
  "rust-base58",
  "rustc-hex",
  "schemars",
@@ -1499,7 +1501,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "signature 1.6.4",
+ "signature 2.0.0",
  "static_assertions",
  "thiserror",
  "tokio",
@@ -2209,6 +2211,8 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 [[package]]
 name = "p256"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
  "ecdsa 0.16.1",
  "elliptic-curve 0.13.2",
@@ -2297,6 +2301,8 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primeorder"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
 dependencies = [
  "elliptic-curve 0.13.2",
 ]
@@ -2548,6 +2554,8 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1064,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,21 +1285,19 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+version = "0.16.1"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
+ "der 0.7.1",
+ "elliptic-curve 0.13.2",
+ "rfc6979 0.4.0",
  "signature 2.0.0",
 ]
 
@@ -1302,16 +1328,35 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.6",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.1",
+ "digest 0.10.6",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.1",
+ "rand_core",
+ "sec1 0.7.1",
  "subtle",
  "zeroize",
 ]
@@ -1423,9 +1468,9 @@ dependencies = [
  "curve25519-dalek-ng",
  "derive_more",
  "digest 0.10.6",
- "ecdsa 0.15.1",
+ "ecdsa 0.16.1",
  "ed25519-consensus",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "eyre",
  "fastcrypto-derive",
  "faster-hex",
@@ -1441,7 +1486,7 @@ dependencies = [
  "radix64",
  "rand",
  "readonly",
- "rfc6979",
+ "rfc6979 0.3.1",
  "rust-base58",
  "rustc-hex",
  "schemars",
@@ -1554,6 +1599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1623,7 @@ dependencies = [
  "serde",
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1620,7 +1676,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -1838,7 +1905,7 @@ checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa 0.14.8",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.6",
  "sha3 0.10.6",
 ]
@@ -2141,12 +2208,10 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
+version = "0.13.0"
 dependencies = [
- "ecdsa 0.15.1",
- "elliptic-curve",
+ "ecdsa 0.16.1",
+ "elliptic-curve 0.13.2",
  "primeorder",
  "sha2 0.10.6",
 ]
@@ -2169,8 +2234,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der 0.7.1",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -2221,11 +2296,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
+version = "0.13.0"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.2",
 ]
 
 [[package]]
@@ -2467,9 +2540,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -2628,10 +2709,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.1",
+ "generic-array",
+ "pkcs8 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -2865,7 +2960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.1",
 ]
 
 [[package]]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -36,8 +36,8 @@ generic-array = { version = "0.14.6", features = ["serde"] }
 typenum.workspace = true
 auto_ops = "0.3.0"
 derive_more = "0.99.16"
-p256 = { version = "0.12.0", features = ["ecdsa", "arithmetic"] }
-ecdsa = { version = "0.15.1", features = ["rfc6979"] }
+p256 = { path = "../../elliptic-curves/p256", features = ["ecdsa", "arithmetic"] }
+ecdsa = { path = "../../signatures/ecdsa", features = ["rfc6979", "verifying"] }
 rfc6979 = "0.3.1"
 blake2 = "0.10.6"
 blake3 = "1.3.3"

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -22,7 +22,7 @@ serde.workspace = true
 serde_bytes = "0.11.9"
 serde_with = "2.1.0"
 serde-big-array = { version = "0.5.0", optional = true }
-signature = { version = "1.6.4", features = ["rand-preview"] }
+signature = { version = "2.0.0" }
 tokio = { version = "1.24.1", features = ["sync", "rt", "macros"] }
 zeroize.workspace = true
 bulletproofs = "4.0.0"
@@ -36,9 +36,9 @@ generic-array = { version = "0.14.6", features = ["serde"] }
 typenum.workspace = true
 auto_ops = "0.3.0"
 derive_more = "0.99.16"
-p256 = { path = "../../elliptic-curves/p256", features = ["ecdsa", "arithmetic"] }
-ecdsa = { path = "../../signatures/ecdsa", features = ["rfc6979", "verifying"] }
-rfc6979 = "0.3.1"
+p256 = { version = "0.13.0", features = ["ecdsa", "arithmetic"] }
+ecdsa = { version = "0.16.1", features = ["rfc6979", "verifying"] }
+rfc6979 = "0.4.0"
 blake2 = "0.10.6"
 blake3 = "1.3.3"
 blst = { version = "0.3.10", features = ["no-threads"] }

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -8,8 +8,6 @@
     rust_2021_compatibility
 )]
 
-pub use signature::Signature as _;
-
 #[cfg(test)]
 #[path = "tests/ed25519_tests.rs"]
 pub mod ed25519_tests;

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -331,6 +331,7 @@ impl Secp256r1KeyPair {
     pub fn sign_with_hash<H: HashFunction<32>>(&self, msg: &[u8]) -> Secp256r1Signature {
         // Private key as scalar
 
+        // sign_prehash generates the nonce according to rfc6979.
         let sig: Signature = self
             .secret
             .privkey

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -20,21 +20,17 @@ pub mod recoverable;
 
 use crate::serde_helpers::BytesRepresentation;
 use crate::{generate_bytes_representation, serialize_deserialize_with_to_from_bytes};
-use ecdsa::hazmat::SignPrimitive;
-use ecdsa::signature::hazmat::PrehashVerifier;
+use ecdsa::signature::hazmat::{PrehashSigner, PrehashVerifier};
 use elliptic_curve::FieldBytes;
 use once_cell::sync::OnceCell;
-use p256::ecdsa::{
-    Signature as ExternalSignature, SigningKey as ExternalSecretKey,
-    VerifyingKey as ExternalPublicKey,
-};
+use p256::ecdsa::{Signature as ExternalSignature, Signature, SigningKey as ExternalSecretKey, VerifyingKey as ExternalPublicKey};
 use p256::elliptic_curve::group::GroupEncoding;
-use p256::elliptic_curve::IsHigh;
 use p256::NistP256;
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
 };
+use p256::elliptic_curve::scalar::IsHigh;
 use zeroize::Zeroize;
 
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
@@ -333,17 +329,11 @@ impl Secp256r1KeyPair {
     /// Create a new signature using the given hash function to hash the message.
     pub fn sign_with_hash<H: HashFunction<32>>(&self, msg: &[u8]) -> Secp256r1Signature {
         // Private key as scalar
-        let x = self.secret.privkey.as_nonzero_scalar();
 
-        // This can only fail due to internal errors, namely if k = 0 or s = 0 during signing which
-        // happens with negligible probability.
-        let sig = x
-            .try_sign_prehashed_rfc6979::<sha2::Sha256>(
-                *FieldBytes::<NistP256>::from_slice(H::digest(msg).as_ref()),
-                &[],
+        let sig: Signature = self.secret.privkey.sign_prehash(
+                H::digest(msg).as_ref()
             )
-            .unwrap()
-            .0;
+            .unwrap();
 
         let sig_low = sig.normalize_s().unwrap_or(sig);
         Secp256r1Signature {

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -21,16 +21,17 @@ pub mod recoverable;
 use crate::serde_helpers::BytesRepresentation;
 use crate::{generate_bytes_representation, serialize_deserialize_with_to_from_bytes};
 use ecdsa::signature::hazmat::{PrehashSigner, PrehashVerifier};
-use elliptic_curve::FieldBytes;
 use once_cell::sync::OnceCell;
-use p256::ecdsa::{Signature as ExternalSignature, Signature, SigningKey as ExternalSecretKey, VerifyingKey as ExternalPublicKey};
+use p256::ecdsa::{
+    Signature as ExternalSignature, Signature, SigningKey as ExternalSecretKey,
+    VerifyingKey as ExternalPublicKey,
+};
 use p256::elliptic_curve::group::GroupEncoding;
-use p256::NistP256;
+use p256::elliptic_curve::scalar::IsHigh;
 use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
 };
-use p256::elliptic_curve::scalar::IsHigh;
 use zeroize::Zeroize;
 
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
@@ -330,9 +331,10 @@ impl Secp256r1KeyPair {
     pub fn sign_with_hash<H: HashFunction<32>>(&self, msg: &[u8]) -> Secp256r1Signature {
         // Private key as scalar
 
-        let sig: Signature = self.secret.privkey.sign_prehash(
-                H::digest(msg).as_ref()
-            )
+        let sig: Signature = self
+            .secret
+            .privkey
+            .sign_prehash(H::digest(msg).as_ref())
             .unwrap();
 
         let sig_low = sig.normalize_s().unwrap_or(sig);

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -18,7 +18,6 @@
 //! assert_eq!(kp.public(), &signature.recover(message).unwrap());
 //! ```
 
-use std::borrow::Borrow;
 use crate::hash::HashFunction;
 use crate::secp256r1::{
     DefaultHash, Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1Signature,
@@ -42,6 +41,7 @@ use p256::elliptic_curve::point::{AffineCoordinates, DecompressPoint};
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use p256::elliptic_curve::{Curve, FieldBytesEncoding, PrimeField};
 use p256::{AffinePoint, FieldBytes, NistP256, ProjectivePoint, Scalar, U256};
+use std::borrow::Borrow;
 use std::fmt::{self, Debug, Display};
 
 pub const SECP256R1_RECOVERABLE_SIGNATURE_LENGTH: usize = SECP256R1_SIGNATURE_LENTH + 1;

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -18,6 +18,7 @@
 //! assert_eq!(kp.public(), &signature.recover(message).unwrap());
 //! ```
 
+use std::borrow::Borrow;
 use crate::hash::HashFunction;
 use crate::secp256r1::{
     DefaultHash, Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1Signature,
@@ -213,6 +214,16 @@ impl RecoverableSigner for Secp256r1KeyPair {
             recovery_id: recovery_id.to_byte(),
         }
     }
+}
+
+/// Get the y-coordinate from a given affine point.
+fn get_y_coordinate(point: &AffinePoint) -> Scalar {
+    let encoded_point = point.to_encoded_point(false);
+
+    // The encoded point is in uncompressed form, so we can safely get the y-coordinate here
+    let y = encoded_point.y().unwrap();
+
+    Scalar::reduce_bytes(y)
 }
 
 impl RecoverableSignature for Secp256r1RecoverableSignature {

--- a/fastcrypto/src/serde_helpers.rs
+++ b/fastcrypto/src/serde_helpers.rs
@@ -174,7 +174,7 @@ macro_rules! serialize_deserialize_with_to_from_bytes {
 
 // schemars is used for guiding JsonSchema to create a schema with type Base64 and no wrapping
 // type.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, JsonSchema, Hash)]
 #[serde(transparent)]
 pub struct BytesRepresentation<const N: usize>(#[schemars(with = "Base64")] pub [u8; N]);
 

--- a/fastcrypto/src/serde_helpers.rs
+++ b/fastcrypto/src/serde_helpers.rs
@@ -174,7 +174,7 @@ macro_rules! serialize_deserialize_with_to_from_bytes {
 
 // schemars is used for guiding JsonSchema to create a schema with type Base64 and no wrapping
 // type.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, JsonSchema, Hash)]
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, JsonSchema)]
 #[serde(transparent)]
 pub struct BytesRepresentation<const N: usize>(#[schemars(with = "Base64")] pub [u8; N]);
 

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
 use crate::hash::Blake2b256;
 use crate::secp256k1::{
     Secp256k1KeyPair, Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Signature,

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -15,13 +15,14 @@ use crate::{
     test_helpers,
     traits::{EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
+use k256::ecdsa::signature::Signature as ExternalSignature;
+use k256::ecdsa::signature::Signer as ExternalSigner;
+use k256::ecdsa::signature::Verifier as ExternalVerifier;
 #[cfg(feature = "copy_key")]
 use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::Signer as ExternalSigner;
-use signature::Verifier as ExternalVerifier;
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -1,13 +1,14 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use k256::ecdsa::signature::Signature as ExternalSignature;
+use k256::ecdsa::signature::Signer as ExternalSigner;
+use k256::ecdsa::signature::Verifier as ExternalVerifier;
 #[cfg(feature = "copy_key")]
 use proptest::arbitrary::Arbitrary;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::{constants, ecdsa::Signature};
-use signature::Signer as ExternalSigner;
-use signature::Verifier as ExternalVerifier;
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -12,7 +12,6 @@ use rust_secp256k1::{constants, ecdsa::Signature};
 use wycheproof::ecdsa::{TestName::EcdsaSecp256k1Sha256, TestSet};
 use wycheproof::TestResult;
 
-use super::*;
 use crate::hash::{Blake2b256, Keccak256};
 use crate::test_helpers::verify_serialization;
 use crate::traits::Signer;

--- a/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use p256::ecdsa::Signature;
-use p256::elliptic_curve::IsHigh;
+use p256::elliptic_curve::scalar::IsHigh;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::constants::SECRET_KEY_SIZE;

--- a/fastcrypto/src/tests/secp256r1_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_tests.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use elliptic_curve::IsHigh;
 use p256::ecdsa::Signature;
+use p256::elliptic_curve::scalar::IsHigh;
 use proptest::{prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rust_secp256k1::constants::SECRET_KEY_SIZE;


### PR DESCRIPTION
This PR attempts to bump the version of the ecdsa and signature crates.

Note that once the implementation of ecdsa signature recovery is complete in the signatures crate, eg. that [this PR](https://github.com/RustCrypto/signatures/pull/680) (or something equivalent) is merged, we could use their implementation, but until then we'll have to use our own.