### PR TITLE
crypto: Expose Bn254 and useful APIs

### DIFF
--- a/fastcrypto-zkp/examples/blake2s_demo.rs
+++ b/fastcrypto-zkp/examples/blake2s_demo.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::ToConstraintField;
+pub use ark_ff::ToConstraintField;
 
 use ark_crypto_primitives::prf::{PRFGadget, PRF};
 use ark_crypto_primitives::{

--- a/fastcrypto-zkp/src/bn254/api.rs
+++ b/fastcrypto-zkp/src/bn254/api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bn254::verifier::{process_vk_special, PreparedVerifyingKey};
-use ark_bn254::{Bn254, Fr};
+pub use ark_bn254::{Bn254, Fr as Bn254Fr};
 use ark_crypto_primitives::snark::SNARK;
 use ark_groth16::{Groth16, Proof, VerifyingKey};
 use ark_serialize::CanonicalDeserialize;
@@ -11,6 +11,8 @@ use fastcrypto::error::FastCryptoError;
 #[cfg(test)]
 #[path = "unit_tests/api_tests.rs"]
 mod api_tests;
+
+pub use ark_ff::ToConstraintField;
 
 /// Size of scalars in the BN254 construction.
 pub const SCALAR_SIZE: usize = 32;
@@ -40,9 +42,30 @@ pub fn verify_groth16_in_bytes(
     }
     let mut x = Vec::new();
     for chunk in proof_public_inputs_as_bytes.chunks(SCALAR_SIZE) {
-        x.push(Fr::deserialize_compressed(chunk).map_err(|_| FastCryptoError::InvalidInput)?);
+        x.push(Bn254Fr::deserialize_compressed(chunk).map_err(|_| FastCryptoError::InvalidInput)?);
     }
 
+    verify_groth16(
+        vk_gamma_abc_g1_bytes,
+        alpha_g1_beta_g2_bytes,
+        gamma_g2_neg_pc_bytes,
+        delta_g2_neg_pc_bytes,
+        &x,
+        proof_points_as_bytes,
+    )
+}
+
+/// Verify Groth16 proof using the serialized form of the prepared verifying key (see more at
+/// [`crate::bn254::verifier::PreparedVerifyingKey`]), a vector of proof public inputs and
+/// serialized proof points.
+pub fn verify_groth16(
+    vk_gamma_abc_g1_bytes: &[u8],
+    alpha_g1_beta_g2_bytes: &[u8],
+    gamma_g2_neg_pc_bytes: &[u8],
+    delta_g2_neg_pc_bytes: &[u8],
+    proof_public_inputs: &[Bn254Fr],
+    proof_points_as_bytes: &[u8],
+) -> Result<bool, FastCryptoError> {
     let pvk = PreparedVerifyingKey::deserialize(
         vk_gamma_abc_g1_bytes,
         alpha_g1_beta_g2_bytes,
@@ -53,6 +76,6 @@ pub fn verify_groth16_in_bytes(
     let proof = Proof::<Bn254>::deserialize_compressed(proof_points_as_bytes)
         .map_err(|_| FastCryptoError::InvalidInput)?;
 
-    Groth16::<Bn254>::verify_with_processed_vk(&pvk.as_arkworks_pvk(), &x, &proof)
+    Groth16::<Bn254>::verify_with_processed_vk(&pvk.as_arkworks_pvk(), proof_public_inputs, &proof)
         .map_err(|e| FastCryptoError::GeneralError(e.to_string()))
 }


### PR DESCRIPTION
useful for sui to use construct public inputs without deserialization. public inputs such as txid, max_epoch should be converted to field elements and pass directly to fastcrypto without needing to ser/de again