### PR TITLE
Get rid of warnings

### DIFF
--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -14,8 +14,12 @@ use crate::{
     test_helpers,
     traits::{EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
+
+#[cfg(feature = "copy_key")]
 use k256::ecdsa::signature::Signature as ExternalSignature;
+#[cfg(feature = "copy_key")]
 use k256::ecdsa::signature::Signer as ExternalSigner;
+#[cfg(feature = "copy_key")]
 use k256::ecdsa::signature::Verifier as ExternalVerifier;
 #[cfg(feature = "copy_key")]
 use proptest::arbitrary::Arbitrary;

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -1,8 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "copy_key")]
 use k256::ecdsa::signature::Signature as ExternalSignature;
+#[cfg(feature = "copy_key")]
 use k256::ecdsa::signature::Signer as ExternalSigner;
+#[cfg(feature = "copy_key")]
 use k256::ecdsa::signature::Verifier as ExternalVerifier;
 #[cfg(feature = "copy_key")]
 use proptest::arbitrary::Arbitrary;


### PR DESCRIPTION
These imports are only used in a test under the `copy_key`feature, so this gives a warning as being unused when this feature is not set.