### PR TITLE
Remove From<signature::Error>

### DIFF
--- a/fastcrypto/src/error.rs
+++ b/fastcrypto/src/error.rs
@@ -48,9 +48,3 @@ pub enum FastCryptoError {
     #[error("General cryptographic error")]
     GeneralOpaqueError,
 }
-
-impl From<signature::Error> for FastCryptoError {
-    fn from(_: signature::Error) -> Self {
-        FastCryptoError::InvalidSignature
-    }
-}


### PR DESCRIPTION
This is no longer used anywhere. I've also verified that sui is not affected.