### PR TITLE
Code improvements

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -106,3 +106,7 @@ radix64 = "0.6.2"
 base58 = "0.2.0"
 rust-base58 = "0.0.4"
 bcs.workspace = true
+
+
+[profile.bench]
+debug = true

--- a/fastcrypto/benches/ecvrf_ristretto.rs
+++ b/fastcrypto/benches/ecvrf_ristretto.rs
@@ -10,7 +10,7 @@ mod ecvrf_ristretto_benches {
     use fastcrypto::vrf::VRFKeyPair;
     use fastcrypto::vrf::VRFProof;
     use rand::rngs::ThreadRng;
-    use rand::thread_rng;
+    use rand::{rngs::StdRng, thread_rng, SeedableRng};
 
     fn keygen(c: &mut Criterion) {
         let mut csprng: ThreadRng = thread_rng();
@@ -28,7 +28,8 @@ mod ecvrf_ristretto_benches {
     }
 
     fn verify(c: &mut Criterion) {
-        let kp = ECVRFKeyPair::generate(&mut thread_rng());
+        let mut rng = StdRng::seed_from_u64(1337);
+        let kp = ECVRFKeyPair::generate(&mut rng);
         let input = b"Hello, world!";
         let proof = kp.prove(input);
         c.bench_function("ECVRF Ristretto verification", move |b| {

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -28,7 +28,7 @@ const RISTRETTO_SCALAR_BYTE_LENGTH: usize = 32;
 
 /// Represents a point in the Ristretto group for Curve25519.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, From, Add, Sub, Neg, GroupOpsExtend)]
-pub struct RistrettoPoint(ExternalRistrettoPoint);
+pub struct RistrettoPoint(pub ExternalRistrettoPoint);
 
 impl RistrettoPoint {
     /// Construct a RistrettoPoint from the given data using an Ristretto-flavoured Elligator 2 map.
@@ -153,7 +153,7 @@ serialize_deserialize_with_to_from_byte_array!(RistrettoPoint);
 
 /// Represents a scalar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, From, Add, Sub, Neg, Div, GroupOpsExtend)]
-pub struct RistrettoScalar(ExternalRistrettoScalar);
+pub struct RistrettoScalar(pub ExternalRistrettoScalar);
 
 impl RistrettoScalar {
     /// The order of the base point.

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -193,9 +193,9 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
     fn from_byte_array(
         bytes: &[u8; RISTRETTO_SCALAR_BYTE_LENGTH],
     ) -> Result<Self, FastCryptoError> {
-        Ok(RistrettoScalar(
-            ExternalRistrettoScalar::from_bytes_mod_order(*bytes),
-        ))
+        let canonical_scalar = ExternalRistrettoScalar::from_canonical_bytes(*bytes)
+            .ok_or(FastCryptoError::InvalidInput)?;
+        Ok(RistrettoScalar(canonical_scalar))
     }
 
     fn to_byte_array(&self) -> [u8; RISTRETTO_SCALAR_BYTE_LENGTH] {

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -16,6 +16,7 @@ use curve25519_dalek_ng::constants::{BASEPOINT_ORDER, RISTRETTO_BASEPOINT_POINT}
 use curve25519_dalek_ng::ristretto::CompressedRistretto as ExternalCompressedRistrettoPoint;
 use curve25519_dalek_ng::ristretto::RistrettoPoint as ExternalRistrettoPoint;
 use curve25519_dalek_ng::scalar::Scalar as ExternalRistrettoScalar;
+use curve25519_dalek_ng::traits::VartimeMultiscalarMul;
 use curve25519_dalek_ng::traits::{Identity, MultiscalarMul};
 use derive_more::{Add, Div, From, Neg, Sub};
 use fastcrypto_derive::GroupOpsExtend;
@@ -73,6 +74,31 @@ impl RistrettoPoint {
             scalars_iter.map(|s| s.into().0),
             points_iter.map(|g| g.0),
         )))
+    }
+
+    /// Compute the linear combination of the given scalars and points. An error will be returned if
+    /// the sizes do not match.
+    pub fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> Result<Self, FastCryptoError>
+    where
+        I: IntoIterator,
+        I::IntoIter: ExactSizeIterator,
+        I::Item: Into<RistrettoScalar>,
+        J: IntoIterator<Item = Self>,
+        J::IntoIter: ExactSizeIterator,
+    {
+        let scalars_iter = scalars.into_iter();
+        let points_iter = points.into_iter();
+
+        if scalars_iter.size_hint() != points_iter.size_hint() {
+            return Err(FastCryptoError::InvalidInput);
+        }
+
+        Ok(RistrettoPoint(
+            ExternalRistrettoPoint::vartime_multiscalar_mul(
+                scalars_iter.map(|s| s.into().0),
+                points_iter.map(|g| g.0),
+            ),
+        ))
     }
 }
 

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -57,8 +57,10 @@ impl RistrettoPoint {
     pub fn multiscalar_mul<I, J>(scalars: I, points: J) -> Result<Self, FastCryptoError>
     where
         I: IntoIterator,
+        I::IntoIter: ExactSizeIterator,
         I::Item: Into<RistrettoScalar>,
         J: IntoIterator<Item = Self>,
+        J::IntoIter: ExactSizeIterator,
     {
         let scalars_iter = scalars.into_iter();
         let points_iter = points.into_iter();

--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -115,7 +115,7 @@ pub trait Hash<const DIGEST_LEN: usize> {
 }
 
 /// This wraps a [digest::Digest] as a [HashFunction].
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct HashFunctionWrapper<Variant: digest::Digest + 'static, const DIGEST_LEN: usize>(Variant);
 
 /// This trait allows using a [HashFunctionWrapper] where a [digest::Digest] was expected.

--- a/fastcrypto/src/vrf.rs
+++ b/fastcrypto/src/vrf.rs
@@ -113,7 +113,7 @@ pub mod ecvrf {
 
             let mut bytes = [0u8; H::OUTPUT_SIZE];
             expanded_message.fill_bytes(&mut bytes);
-            RistrettoPoint::map_to_point::<H>(&bytes)
+            RistrettoPoint::from_uniform_bytes(&bytes)
         }
 
         /// Implements ECVRF_validate_key which checks the validity of a public key. See section 5.4.5

--- a/fastcrypto/src/vrf.rs
+++ b/fastcrypto/src/vrf.rs
@@ -244,11 +244,11 @@ pub mod ecvrf {
             let h = public_key.ecvrf_encode_to_curve(alpha_string);
 
             let challenge = RistrettoScalar::from(&self.c);
-            let u = RistrettoPoint::multiscalar_mul(
+            let u = RistrettoPoint::vartime_multiscalar_mul(
                 [self.s, -challenge],
                 [RistrettoPoint::generator(), public_key.0],
             )?;
-            let v = RistrettoPoint::multiscalar_mul([self.s, -challenge], [h, self.gamma])?;
+            let v = RistrettoPoint::vartime_multiscalar_mul([self.s, -challenge], [h, self.gamma])?;
 
             let c_prime = ecvrf_challenge_generation([&public_key.0, &h, &self.gamma, &u, &v]);
 


### PR DESCRIPTION
This PR is split into multiple commits so that part of it can be merged individually if needed. The last commit which adds the precomputed multiplication needs a bit more work to nicely integrate into the `ristretto` module as in its current form it exposes the internals to the rest o the codebase. This was done for benchmarking purposes.

The performance optimizations yield a speedup of ~27% on the verification benchmark. That gain is primarly attributed to the variable time multiscalar multiplication, which applies to any setting, and secondarily to the caching of the compressed public key which applies to the setting where repeated verifications of proofs with the same public key are performed.