### PR TITLE
Code clean-ups in the Groth16 verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "blst",
  "byte-slice-cast",
  "criterion 0.4.0",
+ "derive_more",
  "fastcrypto",
  "hex",
  "num-bigint",

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -24,6 +24,7 @@ ark-serialize = "0.4.1"
 blst = "0.3.10"
 byte-slice-cast = "1.2.2"
 fastcrypto = { path = "../fastcrypto" }
+derive_more = "0.99.16"
 
 [dev-dependencies]
 ark-bls12-377 = "0.4.0"

--- a/fastcrypto-zkp/src/bls12381/api.rs
+++ b/fastcrypto-zkp/src/bls12381/api.rs
@@ -10,7 +10,6 @@ use crate::bls12381::conversions::{BlsFr, SCALAR_SIZE};
 use crate::bls12381::verifier::{
     process_vk_special, verify_with_processed_vk, PreparedVerifyingKey,
 };
-use crate::bls12381::FieldElement;
 
 #[cfg(test)]
 #[path = "unit_tests/api_tests.rs"]
@@ -41,13 +40,16 @@ pub fn verify_groth16_in_bytes(
     }
     let mut x = Vec::new();
     for chunk in proof_public_inputs_as_bytes.chunks(SCALAR_SIZE) {
-        x.push(FieldElement(
-            BlsFr::deserialize_compressed(chunk).map_err(|_| FastCryptoError::InvalidInput)?,
-        ));
+        x.push(
+            BlsFr::deserialize_compressed(chunk)
+                .map_err(|_| FastCryptoError::InvalidInput)?
+                .into(),
+        );
     }
 
     let proof = Proof::<Bls12_381>::deserialize_compressed(proof_points_as_bytes)
-        .map_err(|_| FastCryptoError::InvalidInput)?;
+        .map_err(|_| FastCryptoError::InvalidInput)?
+        .into();
 
     let blst_pvk = PreparedVerifyingKey::deserialize(
         vk_gamma_abc_g1_bytes,
@@ -56,6 +58,6 @@ pub fn verify_groth16_in_bytes(
         delta_g2_neg_pc_bytes,
     )?;
 
-    verify_with_processed_vk(&blst_pvk, &x, &proof.into())
+    verify_with_processed_vk(&blst_pvk, &x, &proof)
         .map_err(|e| FastCryptoError::GeneralError(e.to_string()))
 }

--- a/fastcrypto-zkp/src/bls12381/mod.rs
+++ b/fastcrypto-zkp/src/bls12381/mod.rs
@@ -5,6 +5,8 @@
 
 //! Groth16 verifier over the BLS12-381 elliptic curve construction.
 
+use derive_more::From;
+
 /// Conversions between arkworks <-> blst
 pub mod conversions;
 
@@ -13,3 +15,15 @@ pub mod verifier;
 
 /// API that takes in serialized inputs
 pub mod api;
+
+/// A field element in the BLS12-381 construction. Thin wrapper around `conversions::BlsFr`.
+#[derive(Debug, From, Copy, Clone)]
+pub struct FieldElement(pub(crate) conversions::BlsFr);
+
+/// A Groth16 proof in the BLS12-381 construction. Thin wrapper around `ark_groth16::Proof::<ark_bls12_381::Bls12_381>`.
+#[derive(Debug, From)]
+pub struct Proof(pub(crate) ark_groth16::Proof<ark_bls12_381::Bls12_381>);
+
+/// A Groth16 verifying key in the BLS12-381 construction. Thin wrapper around `ark_groth16::VerifyingKey::<ark_bls12_381::Bls12_381>`.
+#[derive(Debug, From)]
+pub struct VerifyingKey(pub(crate) ark_groth16::VerifyingKey<ark_bls12_381::Bls12_381>);

--- a/fastcrypto-zkp/src/bls12381/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/bls12381/unit_tests/verifier_tests.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     bls12381::verifier::{
         g1_linear_combination, multipairing_with_processed_vk, process_vk_special,
-        verify_with_processed_vk, Proof, BLST_FR_ONE,
+        verify_with_processed_vk, BLST_FR_ONE,
     },
     dummy_circuits::DummyCircuit,
 };

--- a/fastcrypto-zkp/src/bls12381/unit_tests/verifier_tests.rs
+++ b/fastcrypto-zkp/src/bls12381/unit_tests/verifier_tests.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::bls12381::verifier::{ArkProof, BlsFr, PreparedVerifyingKey as CustomPVK};
+use crate::bls12381::verifier::{BlsFr, PreparedVerifyingKey as CustomPVK};
 use ark_bls12_381::{Bls12_381, Fq12, Fr, G1Projective};
 use ark_crypto_primitives::snark::SNARK;
 use ark_ec::bls12::G1Prepared;
@@ -66,7 +66,7 @@ fn ark_process_vk(vk: &ark_groth16::VerifyingKey<Bls12_381>) -> PreparedVerifyin
 // See [`test_multipairing_with_processed_vk`]
 fn ark_multipairing_with_prepared_vk(
     pvk: &PreparedVerifyingKey<Bls12_381>,
-    proof: &ArkProof<Bls12_381>,
+    proof: &ark_groth16::Proof<Bls12_381>,
     public_inputs: &[Fr],
 ) -> Fq12 {
     let mut g_ic = G1Projective::from(pvk.vk.gamma_abc_g1[0]);
@@ -189,7 +189,7 @@ fn test_verify_with_processed_vk() {
     };
 
     let (pk, vk) = Groth16::<Bls12_381>::circuit_specific_setup(c, rng).unwrap();
-    let proof = Proof(Groth16::<Bls12_381>::prove(&pk, c, rng).unwrap());
+    let proof = Groth16::<Bls12_381>::prove(&pk, c, rng).unwrap().into();
     let v = c.a.unwrap().mul(c.b.unwrap());
 
     let blst_pvk = process_vk_special(&vk.into());

--- a/fastcrypto-zkp/src/bls12381/verifier.rs
+++ b/fastcrypto-zkp/src/bls12381/verifier.rs
@@ -131,7 +131,7 @@ impl PreparedVerifyingKey {
 ///
 /// // Prepare the verification key (for proof verification). Ideally, we would like to do this only
 /// // once per circuit.
-/// let pvk = process_vk_special(&params.vk);
+/// let pvk = process_vk_special(&params.vk.into());
 /// ```
 pub fn process_vk_special(vk: &VerifyingKey) -> PreparedVerifyingKey {
     let g1_alpha = bls_g1_affine_to_blst_g1_affine(&vk.0.alpha_g1);
@@ -336,22 +336,22 @@ fn multipairing_with_processed_vk(
 ///     Groth16::<Bls12_381>::generate_random_parameters_with_reduction(circuit, &mut rng).unwrap()
 /// };
 ///
-/// // Prepare the verification key (for proof verification). Ideally, we would like to do this only
-/// // once per circuit.
-/// let pvk = process_vk_special(&params.vk);
-///
 /// let proof = {
 ///     let circuit = Fibonacci::<Fr>::new(42, Fr::one(), Fr::one()); // 42 constraints, initial a = b = 1
 ///     // Create a proof with our parameters, picking a random witness assignment
 ///     Groth16::<Bls12_381>::create_random_proof_with_reduction(circuit, &params, &mut rng).unwrap()
 /// };
 ///
+/// // Prepare the verification key (for proof verification). Ideally, we would like to do this only
+/// // once per circuit.
+/// let pvk = process_vk_special(&params.vk.into());
+///
 /// // We provide the public inputs which we know are used in our circuits
 /// // this must be the same as the inputs used in the proof right above.
-/// let inputs: Vec<_> = [FieldElement(Fr::one()); 2].to_vec();
+/// let inputs: Vec<FieldElement> = [Fr::one().into(); 2].to_vec();
 ///
 /// // Verify the proof
-/// let r = verify_with_processed_vk(&pvk, &inputs, &proof).unwrap();
+/// let r = verify_with_processed_vk(&pvk, &inputs, &proof.into()).unwrap();
 /// ```
 pub fn verify_with_processed_vk(
     pvk: &PreparedVerifyingKey,

--- a/fastcrypto-zkp/src/bls12381/verifier.rs
+++ b/fastcrypto-zkp/src/bls12381/verifier.rs
@@ -3,7 +3,6 @@
 use std::{iter, ops::Neg, ptr};
 
 use ark_bls12_381::{Bls12_381, Fq12, Fr as BlsFr, G1Affine, G2Affine};
-use ark_groth16::Proof as ArkProof;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use blst::{
@@ -284,7 +283,7 @@ pub(crate) const BLST_FR_ONE: blst_fr = blst_fr {
 fn multipairing_with_processed_vk(
     pvk: &PreparedVerifyingKey,
     x: &[BlsFr],
-    proof: &ArkProof<Bls12_381>,
+    proof: &ark_groth16::Proof<Bls12_381>,
 ) -> blst_fp12 {
     // Linear combination: note that the arkworks interface assumes the 1st scalar is an implicit 1
     let pts: Vec<blst_p1_affine> = pvk

--- a/fastcrypto-zkp/src/bn254/api.rs
+++ b/fastcrypto-zkp/src/bn254/api.rs
@@ -56,10 +56,9 @@ pub fn verify_groth16_in_bytes(
         delta_g2_neg_pc_bytes,
     )?;
 
-    let proof = Proof::from(
-        ArkProof::deserialize_compressed(proof_points_as_bytes)
-            .map_err(|_| FastCryptoError::InvalidInput)?,
-    );
+    let proof = ArkProof::deserialize_compressed(proof_points_as_bytes)
+        .map_err(|_| FastCryptoError::InvalidInput)?
+        .into();
 
     verify_with_processed_vk(&pvk, &x, &proof)
 }

--- a/fastcrypto-zkp/src/bn254/mod.rs
+++ b/fastcrypto-zkp/src/bn254/mod.rs
@@ -5,8 +5,22 @@
 
 //! Groth16 verifier over the BN254 elliptic curve construction.
 
+use derive_more::From;
+
 /// API that takes in serialized inputs
 pub mod api;
 
 /// Groth16 SNARK verifier
 pub mod verifier;
+
+/// A field element in the BN254 construction. Thin wrapper around `api::Bn254Fr`.
+#[derive(Debug, From)]
+pub struct FieldElement(pub(crate) api::Bn254Fr);
+
+/// A Groth16 proof in the BN254 construction. Thin wrapper around `ark_groth16::Proof::<ark_bn254::Bn254>`.
+#[derive(Debug, From)]
+pub struct Proof(pub(crate) ark_groth16::Proof<ark_bn254::Bn254>);
+
+/// A Groth16 verifying key in the BN254 construction. Thin wrapper around `ark_groth16::VerifyingKey::<ark_bn254::Bn254>`.
+#[derive(Debug, From)]
+pub struct VerifyingKey(pub(crate) ark_groth16::VerifyingKey<ark_bn254::Bn254>);

--- a/fastcrypto-zkp/src/bn254/unit_tests/api_tests.rs
+++ b/fastcrypto-zkp/src/bn254/unit_tests/api_tests.rs
@@ -3,10 +3,11 @@
 
 use crate::bn254::api::{prepare_pvk_bytes, verify_groth16_in_bytes};
 use crate::bn254::verifier::process_vk_special;
+use crate::bn254::VerifyingKey;
 use crate::dummy_circuits::{DummyCircuit, Fibonacci};
 use ark_bn254::{Bn254, Fr};
 use ark_crypto_primitives::snark::SNARK;
-use ark_groth16::{Groth16, VerifyingKey};
+use ark_groth16::Groth16;
 use ark_serialize::CanonicalSerialize;
 use ark_std::rand::thread_rng;
 use ark_std::UniformRand;
@@ -30,7 +31,7 @@ fn test_verify_groth16_in_bytes_api() {
     let proof = Groth16::<Bn254>::prove(&pk, c, rng).unwrap();
     let v = c.a.unwrap().mul(c.b.unwrap());
 
-    let pvk = process_vk_special(&vk);
+    let pvk = process_vk_special(&VerifyingKey(vk));
 
     let bytes = pvk.as_serialized().unwrap();
     let vk_gamma_abc_g1_bytes = &bytes[0];
@@ -106,12 +107,12 @@ fn test_verify_groth16_in_bytes_multiple_inputs() {
         Groth16::<Bn254>::generate_random_parameters_with_reduction(circuit, &mut rng).unwrap()
     };
 
-    let pvk = process_vk_special(&params.vk);
-
     let proof = {
         let circuit = Fibonacci::<Fr>::new(42, a, b);
         Groth16::<Bn254>::create_random_proof_with_reduction(circuit, &params, &mut rng).unwrap()
     };
+
+    let pvk = process_vk_special(&VerifyingKey(params.vk));
 
     let inputs: Vec<_> = [a, b].to_vec();
     assert!(
@@ -194,7 +195,7 @@ fn test_verify_groth16_elusiv_proof_in_bytes_api() {
         ],
     );
 
-    let vk: VerifyingKey<Bn254> = ark_groth16::VerifyingKey {
+    let vk = VerifyingKey(ark_groth16::VerifyingKey {
         alpha_g1: utils::G1Affine_from_str_projective((
             "8057073471822347335074195152835286348058235024870127707965681971765888348219",
             "14493022634743109860560137600871299171677470588934003383462482807829968516757",
@@ -313,7 +314,7 @@ fn test_verify_groth16_elusiv_proof_in_bytes_api() {
         .into_iter()
         .map(|s| utils::G1Affine_from_str_projective((s[0], s[1], s[2])))
         .collect(),
-    };
+    });
 
     let pvk = process_vk_special(&vk);
 
@@ -408,7 +409,7 @@ fn fail_verify_groth16_invalid_elusiv_proof_in_bytes_api() {
         ],
     );
 
-    let vk: VerifyingKey<Bn254> = ark_groth16::VerifyingKey {
+    let vk = VerifyingKey(ark_groth16::VerifyingKey {
         alpha_g1: utils::G1Affine_from_str_projective((
             "8057073471822347335074195152835286348058235024870127707965681971765888348219",
             "14493022634743109860560137600871299171677470588934003383462482807829968516757",
@@ -527,7 +528,7 @@ fn fail_verify_groth16_invalid_elusiv_proof_in_bytes_api() {
         .into_iter()
         .map(|s| utils::G1Affine_from_str_projective((s[0], s[1], s[2])))
         .collect(),
-    };
+    });
 
     let pvk = process_vk_special(&vk);
 

--- a/fastcrypto-zkp/src/bn254/unit_tests/api_tests.rs
+++ b/fastcrypto-zkp/src/bn254/unit_tests/api_tests.rs
@@ -409,7 +409,7 @@ fn fail_verify_groth16_invalid_elusiv_proof_in_bytes_api() {
         ],
     );
 
-    let vk = VerifyingKey(ark_groth16::VerifyingKey {
+    let vk = ark_groth16::VerifyingKey {
         alpha_g1: utils::G1Affine_from_str_projective((
             "8057073471822347335074195152835286348058235024870127707965681971765888348219",
             "14493022634743109860560137600871299171677470588934003383462482807829968516757",
@@ -528,7 +528,8 @@ fn fail_verify_groth16_invalid_elusiv_proof_in_bytes_api() {
         .into_iter()
         .map(|s| utils::G1Affine_from_str_projective((s[0], s[1], s[2])))
         .collect(),
-    });
+    }
+    .into();
 
     let pvk = process_vk_special(&vk);
 

--- a/fastcrypto-zkp/src/bn254/verifier.rs
+++ b/fastcrypto-zkp/src/bn254/verifier.rs
@@ -153,10 +153,10 @@ pub fn process_vk_special(vk: &VerifyingKey) -> PreparedVerifyingKey {
 /// serialized proof points.
 pub fn verify_with_processed_vk(
     pvk: &PreparedVerifyingKey,
-    public_inputs: &Vec<FieldElement>,
+    public_inputs: &[FieldElement],
     proof: &Proof,
 ) -> Result<bool, FastCryptoError> {
-    let x: Vec<Bn254Fr> = public_inputs.into_iter().map(|x| x.0).collect();
+    let x: Vec<Bn254Fr> = public_inputs.iter().map(|x| x.0).collect();
     Groth16::<Bn254>::verify_with_processed_vk(&pvk.as_arkworks_pvk(), &x, &proof.0)
         .map_err(|e| FastCryptoError::GeneralError(e.to_string()))
 }

--- a/fastcrypto-zkp/src/bn254/verifier.rs
+++ b/fastcrypto-zkp/src/bn254/verifier.rs
@@ -137,7 +137,7 @@ impl PreparedVerifyingKey {
 ///
 /// // Prepare the verification key (for proof verification). Ideally, we would like to do this only
 /// // once per circuit.
-/// let pvk = process_vk_special(&VerifyingKey::from(params.vk));
+/// let pvk = process_vk_special(&params.vk.into());
 /// ```
 pub fn process_vk_special(vk: &VerifyingKey) -> PreparedVerifyingKey {
     PreparedVerifyingKey {

--- a/fastcrypto-zkp/src/bn254/verifier.rs
+++ b/fastcrypto-zkp/src/bn254/verifier.rs
@@ -148,9 +148,9 @@ pub fn process_vk_special(vk: &VerifyingKey) -> PreparedVerifyingKey {
     }
 }
 
-/// Verify Groth16 proof using the serialized form of the prepared verifying key (see more at
-/// [`crate::bn254::verifier::PreparedVerifyingKey`]), a vector of proof public inputs and
-/// serialized proof points.
+/// Verify Groth16 proof using the prepared verifying key (see more at
+/// [`crate::bn254::verifier::PreparedVerifyingKey`]), a vector of public inputs and
+/// the proof.
 pub fn verify_with_processed_vk(
     pvk: &PreparedVerifyingKey,
     public_inputs: &[FieldElement],

--- a/fastcrypto-zkp/src/bn254/verifier.rs
+++ b/fastcrypto-zkp/src/bn254/verifier.rs
@@ -36,6 +36,7 @@ impl PreparedVerifyingKey {
     /// Serialize the prepared verifying key to its vectors form.
     pub fn as_serialized(&self) -> Result<Vec<Vec<u8>>, FastCryptoError> {
         let mut res = Vec::new();
+
         let mut vk_gamma = Vec::new();
         for g1 in &self.vk_gamma_abc_g1 {
             let mut g1_bytes = Vec::new();
@@ -44,6 +45,7 @@ impl PreparedVerifyingKey {
             vk_gamma.append(&mut g1_bytes);
         }
         res.push(vk_gamma);
+
         let mut fq12 = Vec::new();
         self.alpha_g1_beta_g2
             .serialize_compressed(&mut fq12)
@@ -72,6 +74,9 @@ impl PreparedVerifyingKey {
         gamma_g2_neg_pc_bytes: &[u8],
         delta_g2_neg_pc_bytes: &[u8],
     ) -> Result<Self, FastCryptoError> {
+        if vk_gamma_abc_g1_bytes.len() % SCALAR_SIZE != 0 {
+            return Err(FastCryptoError::InvalidInput);
+        }
         let mut vk_gamma_abc_g1: Vec<G1Affine> = Vec::new();
         for g1_bytes in vk_gamma_abc_g1_bytes.chunks(SCALAR_SIZE) {
             let g1 = G1Affine::deserialize_compressed(g1_bytes)


### PR DESCRIPTION
Misc clean-ups in fastcrypto-zkp. The main contribution is that it introduces wrapper types for the types exposed in public api's for both the Bn254 and Bls12381 verifiers. Note that the binary apis which are used in Sui are _not_ changed by this PR.
