### PR TITLE
Ensure that deserialisation of Ristretto scalars only accepts canonical values

### DIFF
--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -198,7 +198,7 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
     ) -> Result<Self, FastCryptoError> {
         Ok(RistrettoScalar(
             ExternalRistrettoScalar::from_canonical_bytes(*bytes)
-                .ok_or_else(FastCryptoError::InvalidInput)?,
+                .ok_or_else(|| FastCryptoError::InvalidInput)?,
         ))
     }
 

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -198,7 +198,7 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
     ) -> Result<Self, FastCryptoError> {
         Ok(RistrettoScalar(
             ExternalRistrettoScalar::from_canonical_bytes(*bytes)
-                .ok_or_else(|| FastCryptoError::InvalidInput)?,
+                .ok_or(FastCryptoError::InvalidInput)?,
         ))
     }
 

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -198,7 +198,7 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
     ) -> Result<Self, FastCryptoError> {
         Ok(RistrettoScalar(
             ExternalRistrettoScalar::from_canonical_bytes(*bytes)
-                .ok_or(FastCryptoError::InvalidInput)?,
+                .ok_or_else(FastCryptoError::InvalidInput)?,
         ))
     }
 

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -137,6 +137,11 @@ impl RistrettoScalar {
     pub fn from_bytes_mod_order_wide(bytes: &[u8; 64]) -> Self {
         RistrettoScalar(ExternalRistrettoScalar::from_bytes_mod_order_wide(bytes))
     }
+
+    /// Construct a [RistrettoScalar] by reducing a 32-byte little-endian integer modulo the group order.
+    pub fn from_bytes_mod_order(bytes: &[u8; 32]) -> Self {
+        RistrettoScalar(ExternalRistrettoScalar::from_bytes_mod_order(*bytes))
+    }
 }
 
 impl From<u64> for RistrettoScalar {
@@ -192,7 +197,8 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
         bytes: &[u8; RISTRETTO_SCALAR_BYTE_LENGTH],
     ) -> Result<Self, FastCryptoError> {
         Ok(RistrettoScalar(
-            ExternalRistrettoScalar::from_bytes_mod_order(*bytes),
+            ExternalRistrettoScalar::from_canonical_bytes(*bytes)
+                .ok_or(FastCryptoError::InvalidInput)?,
         ))
     }
 

--- a/fastcrypto/src/vrf.rs
+++ b/fastcrypto/src/vrf.rs
@@ -176,8 +176,7 @@ pub mod ecvrf {
         fn from(c: &Challenge) -> Self {
             let mut scalar = [0u8; 32];
             scalar[..C_LEN].copy_from_slice(&c.0);
-            // This will call curve25519_dalek_ng::scalar::Scalar::from_bytes_mod_order which cannot fail so it is safe to unwrap.
-            RistrettoScalar::from_byte_array(&scalar).unwrap()
+            RistrettoScalar::from_bytes_mod_order(&scalar)
         }
     }
 


### PR DESCRIPTION
Depends on #555