### PR TITLE
Expose secp256k1 Signature

### DIFF
--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -18,7 +18,7 @@
 //! ```
 
 use crate::hash::HashFunction;
-pub use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
+use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     encoding::{Base64, Encoding},
@@ -33,7 +33,7 @@ use rust_secp256k1::{
     All, Message, Secp256k1,
 };
 use std::fmt::{self, Debug, Display};
-pub use rust_secp256k1::ecdsa::Signature;
+pub use rust_secp256k1::ecdsa::Signature as secpSig;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -27,12 +27,12 @@ use crate::{
     traits::{EncodeDecodeBase64, ToFromBytes},
 };
 use once_cell::sync::{Lazy, OnceCell};
+pub use rust_secp256k1::ecdsa::Signature as Secp256k1Sig;
 use rust_secp256k1::{
     constants,
     ecdsa::{RecoverableSignature as ExternalRecoverableSignature, RecoveryId},
     All, Message, Secp256k1,
 };
-pub use rust_secp256k1::ecdsa::Signature as Secp256k1Sig;
 use std::fmt::{self, Debug};
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -18,7 +18,7 @@
 //! ```
 
 use crate::hash::HashFunction;
-use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey};
+pub use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     encoding::{Base64, Encoding},
@@ -33,7 +33,7 @@ use rust_secp256k1::{
     All, Message, Secp256k1,
 };
 use std::fmt::{self, Debug, Display};
-pub use crate::secp256k1::ecdsa::Signature;
+pub use rust_secp256k1::ecdsa::Signature;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -18,7 +18,7 @@
 //! ```
 
 use crate::hash::HashFunction;
-pub use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
+use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey};
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     encoding::{Base64, Encoding},
@@ -33,7 +33,7 @@ use rust_secp256k1::{
     All, Message, Secp256k1,
 };
 use std::fmt::{self, Debug, Display};
-//pub use secp256k1::Secp256k1Signature;
+pub use crate::secp256k1::Secp256k1Signature;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -33,7 +33,7 @@ use rust_secp256k1::{
     All, Message, Secp256k1,
 };
 use std::fmt::{self, Debug, Display};
-pub use rust_secp256k1::ecdsa::Signature as secpSig;
+pub use rust_secp256k1::ecdsa::Signature as Secp256k1Sig;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -18,7 +18,7 @@
 //! ```
 
 use crate::hash::HashFunction;
-use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
+pub use crate::secp256k1::{DefaultHash, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1Signature};
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     encoding::{Base64, Encoding},
@@ -33,6 +33,7 @@ use rust_secp256k1::{
     All, Message, Secp256k1,
 };
 use std::fmt::{self, Debug, Display};
+//pub use secp256k1::Secp256k1Signature;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -33,7 +33,7 @@ use rust_secp256k1::{
     All, Message, Secp256k1,
 };
 use std::fmt::{self, Debug, Display};
-pub use crate::secp256k1::Secp256k1Signature;
+pub use crate::secp256k1::ecdsa::Signature;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 


### PR DESCRIPTION
This is for re-use in sui repo where we use AWS KMS as a signer for secp256k1