### PR TITLE
Update benchmarking.yml

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install criterion
         run: cargo install cargo-criterion
       - name: Run benchmarks
-        run: cd fastcrypto; cargo criterion --message-format=json --no-default-features > ../${{ github.sha }}.json; cd ..
+        run: cd fastcrypto; cargo criterion --message-format=json --no-default-features --features experimental > ../${{ github.sha }}.json; cd ..
       - name: Deploy latest benchmark report
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # pin@v3
         with:


### PR DESCRIPTION
BLS12381 group ops, which are part of the benchmarks, are now under the experimental feature, so we need to run the benchmarks with that feature set.