### PR TITLE
Align arkworks dependencies

### DIFF
--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -16,7 +16,7 @@ harness = false
 ark-bls12-381 = "0.4.0"
 ark-bn254 = "0.4.0"
 ark-crypto-primitives = { version = "0.4.0", features = ["r1cs", "prf"] }
-ark-ec = { version = "0.4.2", features = ["parallel"]}
+ark-ec = { version = "0.4.1", features = ["parallel"]}
 ark-ff = { version = "0.4.1", features = ["asm", "parallel"]}
 ark-groth16 = "0.4.0"
 ark-relations = "0.4.0"

--- a/fastcrypto-zkp/Cargo.toml
+++ b/fastcrypto-zkp/Cargo.toml
@@ -16,7 +16,7 @@ harness = false
 ark-bls12-381 = "0.4.0"
 ark-bn254 = "0.4.0"
 ark-crypto-primitives = { version = "0.4.0", features = ["r1cs", "prf"] }
-ark-ec = { version = "0.4.1", features = ["parallel"]}
+ark-ec = { version = "0.4.2", features = ["parallel"]}
 ark-ff = { version = "0.4.1", features = ["asm", "parallel"]}
 ark-groth16 = "0.4.0"
 ark-relations = "0.4.0"

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -55,7 +55,7 @@ elliptic-curve = {version = "0.13.2", features = ["hash2curve"]}
 rsa = {version = "0.8.2", features = ["sha2"] }
 static_assertions = "1.1.0"
 ark-secp256r1 = "0.4.0"
-ark-ec = "0.4.2"
+ark-ec = "0.4.1"
 ark-ff = "0.4.1"
 ark-serialize = "0.4.2"
 

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -56,7 +56,7 @@ rsa = {version = "0.8.2", features = ["sha2"] }
 static_assertions = "1.1.0"
 ark-secp256r1 = "0.4.0"
 ark-ec = "0.4.2"
-ark-ff = "0.4.0"
+ark-ff = "0.4.1"
 ark-serialize = "0.4.2"
 
 fastcrypto-derive = { path = "../fastcrypto-derive", version = "0.1.2" }


### PR DESCRIPTION
Align the ark-ec and ark-ff versions between fastcrypto and fastcrypto-zkp because it's needed in sui. The ark-bls12-381 crate v0.4.0, which is the most recent, has locked the ark-ec version to v0.4.1, so we need to use that. There is a newer version, ark-ec v0.4.2, but the [only change](https://github.com/arkworks-rs/algebra/blob/master/CHANGELOG.md) was a bug fix to the implementation of the MNT4-298 and MNT6-298 curve constructions which is not used in fastcrypto.