### PR TITLE
log2 of u8 cleanup

### DIFF
--- a/fastcrypto-zkp/src/bls12381/verifier.rs
+++ b/fastcrypto-zkp/src/bls12381/verifier.rs
@@ -10,10 +10,7 @@ use blst::{
     blst_p1_affine, blst_p1_from_affine, blst_p1_mult, blst_p1_to_affine, blst_p1s_mult_pippenger,
     blst_p1s_mult_pippenger_scratch_sizeof, blst_scalar, blst_scalar_from_fr, limb_t, Pairing,
 };
-use fastcrypto::{
-    error::FastCryptoError,
-    utils::log2_byte,
-};
+use fastcrypto::{error::FastCryptoError, utils::log2_byte};
 
 use crate::bls12381::conversions::{
     bls_fq12_to_blst_fp12, bls_fr_to_blst_fr, bls_g1_affine_to_blst_g1_affine,

--- a/fastcrypto-zkp/src/bls12381/verifier.rs
+++ b/fastcrypto-zkp/src/bls12381/verifier.rs
@@ -10,7 +10,10 @@ use blst::{
     blst_p1_affine, blst_p1_from_affine, blst_p1_mult, blst_p1_to_affine, blst_p1s_mult_pippenger,
     blst_p1s_mult_pippenger_scratch_sizeof, blst_scalar, blst_scalar_from_fr, limb_t, Pairing,
 };
-use fastcrypto::error::FastCryptoError;
+use fastcrypto::{
+    error::FastCryptoError,
+    utils::log2_byte,
+};
 
 use crate::bls12381::conversions::{
     bls_fq12_to_blst_fp12, bls_fr_to_blst_fr, bls_g1_affine_to_blst_g1_affine,
@@ -158,16 +161,6 @@ const G1_IDENTITY: blst_p1 = blst_p1 {
     z: blst_fp { l: [0; 6] },
 };
 
-/// Returns the log base 2 of b in O(lg(N)) time.
-fn log_2_byte(b: u8) -> usize {
-    let mut r = u8::from(b > 0xF) << 2;
-    let mut b = b >> r;
-    let shift = u8::from(b > 0x3) << 1;
-    b >>= shift + 1;
-    r |= shift | b;
-    r.into()
-}
-
 /// Returns a single scalar multiplication of `pt` by `b`.
 fn mul(pt: &blst_p1, b: &blst_fr) -> blst_p1 {
     let mut scalar: blst_scalar = blst_scalar::default();
@@ -193,7 +186,7 @@ fn mul(pt: &blst_p1, b: &blst_fr) -> blst_p1 {
                 &mut result,
                 pt,
                 &(scalar.b[0]),
-                8 * i - 7 + log_2_byte(scalar.b[i - 1]),
+                8 * i - 7 + log2_byte(scalar.b[i - 1]),
             );
         }
     }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -8,6 +8,7 @@ use crate::groups::{GroupElement, HashToGroupElement, Pairing, Scalar as ScalarT
 use crate::serde_helpers::BytesRepresentation;
 use crate::serde_helpers::ToFromByteArray;
 use crate::traits::AllowedRng;
+use crate::utils::log2_byte;
 use crate::{generate_bytes_representation, serialize_deserialize_with_to_from_byte_array};
 use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fp12_inverse, blst_fp12_mul,
@@ -92,7 +93,7 @@ fn size_in_bytes(scalar: &blst_scalar) -> usize {
 /// Given a scalar and its size in bytes (computed using [size_in_bytes], this method returns the size
 /// of the scalar in bits.
 fn size_in_bits(scalar: &blst_scalar, size_in_bytes: usize) -> usize {
-    8 * size_in_bytes - 7 + log_2_byte(scalar.b[size_in_bytes - 1])
+    8 * size_in_bytes - 7 + log2_byte(scalar.b[size_in_bytes - 1])
 }
 
 impl Mul<Scalar> for G1Element {
@@ -577,13 +578,3 @@ const BLST_FR_ONE: blst_fr = blst_fr {
         1739710354780652911,
     ],
 };
-
-/// Returns the log base 2 of b in O(lg(N)) time.
-fn log_2_byte(b: u8) -> usize {
-    let mut r = u8::from(b > 0xF) << 2;
-    let mut b = b >> r;
-    let shift = u8::from(b > 0x3) << 1;
-    b >>= shift + 1;
-    r |= shift | b;
-    r.into()
-}

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -77,6 +77,10 @@ pub mod signature_service_tests;
 #[path = "tests/test_helpers.rs"]
 pub mod test_helpers;
 
+#[cfg(test)]
+#[path = "tests/utils_tests.rs"]
+pub mod utils_tests;
+
 pub mod traits;
 
 #[cfg(any(test, feature = "experimental"))]
@@ -96,6 +100,7 @@ pub mod secp256k1;
 pub mod secp256r1;
 pub mod serde_helpers;
 pub mod signature_service;
+pub mod utils;
 pub mod vrf;
 
 /// This module contains unsecure cryptographic primitives. The purpose of this library is to allow seamless

--- a/fastcrypto/src/tests/utils_tests.rs
+++ b/fastcrypto/src/tests/utils_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::utils::log2_byte;
 
 // log2 using shift operations.

--- a/fastcrypto/src/tests/utils_tests.rs
+++ b/fastcrypto/src/tests/utils_tests.rs
@@ -1,0 +1,20 @@
+use crate::utils::log2_byte;
+
+// log2 using shift operations.
+fn log2_byte_shift(b: u8) -> usize {
+    let mut r = u8::from(b > 0xF) << 2;
+    let mut b = b >> r;
+    let shift = u8::from(b > 0x3) << 1;
+    b >>= shift + 1;
+    r |= shift | b;
+    r.into()
+}
+
+#[test]
+fn test_log2_byte() {
+    for b in 0..=u8::MAX {
+        let result_shift = log2_byte_shift(b);
+        let result_lz = log2_byte(b);
+        assert_eq!(result_shift, result_lz, "Mismatch for input {}", b);
+    }
+}

--- a/fastcrypto/src/utils.rs
+++ b/fastcrypto/src/utils.rs
@@ -1,0 +1,8 @@
+/// Returns the log base 2 of b. There is an exception: for `b == 0`, it returns 0.
+pub fn log2_byte(b: u8) -> usize {
+    if b == 0 {
+        return 0;
+    } else {
+        7 - b.leading_zeros() as usize
+    }
+}

--- a/fastcrypto/src/utils.rs
+++ b/fastcrypto/src/utils.rs
@@ -1,7 +1,10 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Returns the log base 2 of b. There is an exception: for `b == 0`, it returns 0.
 pub fn log2_byte(b: u8) -> usize {
     if b == 0 {
-        return 0;
+        0
     } else {
         7 - b.leading_zeros() as usize
     }


### PR DESCRIPTION
- Cleanup of duplicated implementations of log2 of a byte.
- We also have an assumption that log2(0) = 0, while in math log2(0) is undefined, added a comment around that.
- changed the implementation to use leading_zeros(), as it's easier to read, and probably slightly faster (added related unit_test to ensure same behavior with the old implementation). Didn't change behavior.

Implemented a benchmark for the old and new method, but decided to remove it from our repo as it's exhaustive (wanted it to be exhaustive to ensure comparisons in case they are not constant time. leading zeros is some picosecs faster. Attaching the benchmark FYI.

**A sample output:**
```
Utils/log2_shift/16     time:   [314.59 ps 315.55 ps 316.51 ps]
Utils/log2_leading_zeros/16    time:   [311.77 ps 312.57 ps 313.56 ps]
```

**Bench Code:**
```
// Copyright (c) 2022, Mysten Labs, Inc.
// SPDX-License-Identifier: Apache-2.0
#[macro_use]
extern crate criterion;

mod utils_benches {
    use super::*;
    use criterion::*;

    fn log2_single_shift<M: measurement::Measurement, >(
        name: &str,
        input: &u8,
        c: &mut BenchmarkGroup<M>,
    ) {
        c.bench_with_input(
            BenchmarkId::new(name.to_string(), input),
            &input,
            |b, &&input| {
                b.iter(|| log_2_byte_shift(input));
            },
        );
    }

    fn log2_single_leading_zeros<M: measurement::Measurement, >(
        name: &str,
        input: &u8,
        c: &mut BenchmarkGroup<M>,
    ) {
        c.bench_with_input(
            BenchmarkId::new(name.to_string(), input),
            &input,
            |b, &&input| {
                b.iter(|| log_2_byte_leading_zeros(input));
            },
        );
    }

    // log_2 using shift operations.
    fn log_2_byte_shift(b: u8) -> usize {
        let mut r = u8::from(b > 0xF) << 2;
        let mut b = b >> r;
        let shift = u8::from(b > 0x3) << 1;
        b >>= shift + 1;
        r |= shift | b;
        r.into()
    }

    // log_2 using leading_zeros.
    fn log_2_byte_leading_zeros(b: u8) -> usize {
        if b == 0 {
            return 0;
        } else {
            7 - b.leading_zeros() as usize
        }
    }

    fn log2(c: &mut Criterion) {
        // Some of the functions are not constant time, so we exhaustively test all possible inputs.
        let inputs: [u8; 256] = {
            let mut arr = [0u8; 256];
            for i in 0..=255 {
                arr[i as usize] = i;
            }
            arr
        };

        let mut group: BenchmarkGroup<_> = c.benchmark_group("Utils");

        for input in inputs.iter() {
            log2_single_shift::<_>("log2_shift", &input, &mut group);
            log2_single_leading_zeros::<_>("log2_leading_zeros", &input, &mut group);
        }
    }

    criterion_group! {
        name = utils_benches;
        config = Criterion::default();
        targets = log2,
    }
}

criterion_main!(utils_benches::utils_benches,);
```
