### PR TITLE
macro for Display::fmt

### DIFF
--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -13,7 +13,6 @@
 //! assert!(kp.public().verify(message, &signature).is_ok());
 //! ```
 
-use crate::generate_bytes_representation;
 use crate::serde_helpers::BytesRepresentation;
 use crate::traits::{
     AggregateAuthenticator, AllowedRng, Authenticator, EncodeDecodeBase64, InsecureDefault,
@@ -23,6 +22,7 @@ use crate::{
     encoding::Base64, encoding::Encoding, error::FastCryptoError,
     serialize_deserialize_with_to_from_bytes,
 };
+use crate::{generate_bytes_representation, impl_base64_display_fmt};
 use blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
 #[cfg(any(test, feature = "experimental"))]
 use eyre::eyre;
@@ -30,7 +30,7 @@ use fastcrypto_derive::{SilentDebug, SilentDisplay};
 use once_cell::sync::OnceCell;
 use std::{
     borrow::Borrow,
-    fmt::{self, Debug, Display},
+    fmt::{self, Debug},
     mem::MaybeUninit,
     str::FromStr,
 };
@@ -119,11 +119,7 @@ impl Ord for BLS12381PublicKey {
     }
 }
 
-impl Display for BLS12381PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(BLS12381PublicKey);
 
 impl Debug for BLS12381PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -421,11 +417,7 @@ impl ToFromBytes for BLS12381Signature {
     }
 }
 
-impl Display for BLS12381Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(BLS12381Signature);
 
 //
 // Custom code for [BLS12381Signature].
@@ -542,6 +534,8 @@ impl FromStr for BLS12381KeyPair {
 // Boilerplate code for [BLS12381AggregateSignature].
 //
 
+impl_base64_display_fmt!(BLS12381AggregateSignature);
+
 impl PartialEq for BLS12381AggregateSignature {
     fn eq(&self, other: &Self) -> bool {
         self.sig == other.sig
@@ -549,12 +543,6 @@ impl PartialEq for BLS12381AggregateSignature {
 }
 
 impl Eq for BLS12381AggregateSignature {}
-
-impl Display for BLS12381AggregateSignature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
 
 impl Default for BLS12381AggregateSignature {
     fn default() -> Self {

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -18,6 +18,7 @@ use crate::traits::{InsecureDefault, Signer};
 use crate::{
     encoding::Base64,
     error::FastCryptoError,
+    impl_base64_display_fmt,
     traits::{
         AllowedRng, Authenticator, EncodeDecodeBase64, KeyPair, SigningKey, ToFromBytes,
         VerifyingKey,
@@ -256,11 +257,7 @@ impl AsRef<[u8]> for Ed25519Signature {
     }
 }
 
-impl Display for Ed25519Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(Ed25519Signature);
 
 impl Default for Ed25519Signature {
     fn default() -> Self {
@@ -292,11 +289,7 @@ impl InsecureDefault for Ed25519PublicKey {
     }
 }
 
-impl Display for Ed25519PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.0.as_bytes()))
-    }
-}
+impl_base64_display_fmt!(Ed25519PublicKey);
 
 impl Debug for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -76,7 +76,7 @@ impl RistrettoPoint {
     }
 }
 
-impl std::ops::Mul<RistrettoScalar> for RistrettoPoint {
+impl Mul<RistrettoScalar> for RistrettoPoint {
     type Output = RistrettoPoint;
 
     fn mul(self, rhs: RistrettoScalar) -> RistrettoPoint {

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -17,7 +17,6 @@
 
 pub mod recoverable;
 
-use crate::generate_bytes_representation;
 use crate::hash::{HashFunction, Sha256};
 use crate::secp256k1::recoverable::Secp256k1RecoverableSignature;
 use crate::serde_helpers::BytesRepresentation;
@@ -31,6 +30,7 @@ use crate::{
         VerifyingKey,
     },
 };
+use crate::{generate_bytes_representation, impl_base64_display_fmt};
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 use once_cell::sync::{Lazy, OnceCell};
 use rust_secp256k1::{
@@ -38,7 +38,7 @@ use rust_secp256k1::{
     SecretKey,
 };
 use std::{
-    fmt::{self, Debug, Display},
+    fmt::{self, Debug},
     str::FromStr,
 };
 use zeroize::Zeroize;
@@ -169,11 +169,7 @@ impl ToFromBytes for Secp256k1PublicKey {
     }
 }
 
-impl Display for Secp256k1PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(Secp256k1PublicKey);
 
 serialize_deserialize_with_to_from_bytes!(Secp256k1PublicKey, SECP256K1_PUBLIC_KEY_LENGTH);
 
@@ -246,6 +242,8 @@ generate_bytes_representation!(
     Secp256k1SignatureAsBytes
 );
 
+impl_base64_display_fmt!(Secp256k1Signature);
+
 impl ToFromBytes for Secp256k1Signature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         if bytes.len() != SECP256K1_SIGNATURE_LENGTH {
@@ -279,12 +277,6 @@ impl AsRef<[u8]> for Secp256k1Signature {
 impl std::hash::Hash for Secp256k1Signature {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_ref().hash(state);
-    }
-}
-
-impl Display for Secp256k1Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
     }
 }
 

--- a/fastcrypto/src/secp256k1/recoverable.rs
+++ b/fastcrypto/src/secp256k1/recoverable.rs
@@ -23,7 +23,7 @@ use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     encoding::{Base64, Encoding},
     error::FastCryptoError,
-    serialize_deserialize_with_to_from_bytes,
+    impl_base64_display_fmt, serialize_deserialize_with_to_from_bytes,
     traits::{EncodeDecodeBase64, ToFromBytes},
 };
 use once_cell::sync::{Lazy, OnceCell};
@@ -32,7 +32,7 @@ use rust_secp256k1::{
     ecdsa::{RecoverableSignature as ExternalRecoverableSignature, RecoveryId},
     All, Message, Secp256k1,
 };
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 
@@ -100,11 +100,7 @@ impl PartialEq for Secp256k1RecoverableSignature {
 
 impl Eq for Secp256k1RecoverableSignature {}
 
-impl Display for Secp256k1RecoverableSignature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(Secp256k1RecoverableSignature);
 
 impl Secp256k1RecoverableSignature {
     /// Convert a non-recoverable signature into a recoverable signature.

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -21,7 +21,10 @@ pub mod recoverable;
 pub mod conversion;
 
 use crate::serde_helpers::BytesRepresentation;
-use crate::{generate_bytes_representation, serialize_deserialize_with_to_from_bytes};
+use crate::{
+    generate_bytes_representation, impl_base64_display_fmt,
+    serialize_deserialize_with_to_from_bytes,
+};
 use ark_ec::{AffineRepr, CurveGroup, Group};
 use ark_ff::Field;
 use elliptic_curve::{Curve, FieldBytesEncoding, PrimeField};
@@ -33,7 +36,7 @@ use p256::ecdsa::{
 use p256::elliptic_curve::group::GroupEncoding;
 use p256::elliptic_curve::scalar::IsHigh;
 use p256::{FieldBytes, NistP256, Scalar};
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 use std::str::FromStr;
 use zeroize::Zeroize;
 
@@ -198,11 +201,7 @@ impl ToFromBytes for Secp256r1PublicKey {
     }
 }
 
-impl Display for Secp256r1PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(Secp256r1PublicKey);
 
 impl<'a> From<&'a Secp256r1PrivateKey> for Secp256r1PublicKey {
     fn from(secret: &'a Secp256r1PrivateKey) -> Self {
@@ -323,11 +322,7 @@ impl PartialEq for Secp256r1Signature {
 
 impl Eq for Secp256r1Signature {}
 
-impl Display for Secp256r1Signature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(Secp256r1Signature);
 
 impl From<&Secp256r1RecoverableSignature> for Secp256r1Signature {
     fn from(recoverable_sig: &Secp256r1RecoverableSignature) -> Self {

--- a/fastcrypto/src/secp256r1/recoverable.rs
+++ b/fastcrypto/src/secp256r1/recoverable.rs
@@ -27,13 +27,13 @@ use crate::secp256r1::{
     DefaultHash, Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1Signature,
     SECP256R1_SIGNATURE_LENTH,
 };
-use crate::serialize_deserialize_with_to_from_bytes;
 use crate::traits::{RecoverableSignature, RecoverableSigner, VerifyRecoverable};
 use crate::{
     encoding::{Base64, Encoding},
     error::FastCryptoError,
     traits::{EncodeDecodeBase64, ToFromBytes},
 };
+use crate::{impl_base64_display_fmt, serialize_deserialize_with_to_from_bytes};
 use ark_ec::{AffineRepr, CurveGroup, Group};
 use ark_ff::Field;
 use ark_secp256r1::Projective;
@@ -46,7 +46,7 @@ use p256::elliptic_curve::bigint::ArrayEncoding;
 use p256::elliptic_curve::point::DecompressPoint;
 use p256::elliptic_curve::Curve;
 use p256::{AffinePoint, NistP256, U256};
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 
 pub const SECP256R1_RECOVERABLE_SIGNATURE_LENGTH: usize = SECP256R1_SIGNATURE_LENTH + 1;
 
@@ -109,11 +109,7 @@ impl PartialEq for Secp256r1RecoverableSignature {
 
 impl Eq for Secp256r1RecoverableSignature {}
 
-impl Display for Secp256r1RecoverableSignature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
+impl_base64_display_fmt!(Secp256r1RecoverableSignature);
 
 impl Secp256r1RecoverableSignature {
     /// Recover the public key used to create this signature. This assumes the recovery id byte has been set. The hash function `H` is used to hash the message.

--- a/fastcrypto/src/utils.rs
+++ b/fastcrypto/src/utils.rs
@@ -1,6 +1,17 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[macro_export]
+macro_rules! impl_base64_display_fmt {
+    ($type:ty) => {
+        impl fmt::Display for $type {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                write!(f, "{}", Base64::encode(self.as_ref()))
+            }
+        }
+    };
+}
+
 /// Returns the log base 2 of b. There is an exception: for `b == 0`, it returns 0.
 pub fn log2_byte(b: u8) -> usize {
     if b == 0 {


### PR DESCRIPTION
due to being duplicated in many structs (and to avoid accidental inconsistent re-implementation)