### PR TITLE
Remove #[cfg(test)] for from_uncompressed

### DIFF
--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -139,7 +139,6 @@ impl Secp256k1PublicKey {
     }
 
     /// util function to parse wycheproof test key from DER format.
-    #[cfg(test)]
     pub fn from_uncompressed(uncompressed: &[u8]) -> Self {
         let pubkey = PublicKey::from_slice(uncompressed).unwrap();
         Self {


### PR DESCRIPTION
This is to expose `from_uncompressed` so that it can be used in https://github.com/MystenLabs/sui/pull/11283