### PR TITLE
Remove redundant `from_uncompressed` methods

### DIFF
--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -137,16 +137,6 @@ impl Secp256k1PublicKey {
             .verify(&hashed_message, &self.pubkey)
             .map_err(|_| FastCryptoError::InvalidSignature)
     }
-
-    /// util function to parse wycheproof test key from DER format.
-    #[cfg(test)]
-    pub fn from_uncompressed(uncompressed: &[u8]) -> Self {
-        let pubkey = PublicKey::from_slice(uncompressed).unwrap();
-        Self {
-            pubkey,
-            bytes: OnceCell::new(),
-        }
-    }
 }
 
 impl AsRef<[u8]> for Secp256k1PublicKey {

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -342,19 +342,6 @@ impl From<&Secp256r1RecoverableSignature> for Secp256r1Signature {
     }
 }
 
-impl Secp256r1Signature {
-    /// util function to parse wycheproof test key from DER format.
-    #[cfg(test)]
-    pub fn from_uncompressed(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        ExternalSignature::try_from(bytes)
-            .map(|sig| Secp256r1Signature {
-                sig,
-                bytes: OnceCell::new(),
-            })
-            .map_err(|_| FastCryptoError::InvalidInput)
-    }
-}
-
 /// Secp256r1 public/private key pair.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Secp256r1KeyPair {

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -392,7 +392,7 @@ proptest::proptest! {
 fn wycheproof_test() {
     let test_set = TestSet::load(EcdsaSecp256k1Sha256).unwrap();
     for test_group in test_set.test_groups {
-        let pk = Secp256k1PublicKey::from_uncompressed(&test_group.key.key);
+        let pk = Secp256k1PublicKey::from_bytes(&test_group.key.key).unwrap();
         for test in test_group.tests {
             let bytes = match Signature::from_der(&test.sig) {
                 Ok(s) => s.serialize_compact(),

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -494,7 +494,7 @@ proptest::proptest! {
 fn wycheproof_test() {
     let test_set = TestSet::load(EcdsaSecp256k1Sha256).unwrap();
     for test_group in test_set.test_groups {
-        let pk = Secp256k1PublicKey::from_uncompressed(&test_group.key.key);
+        let pk = Secp256k1PublicKey::from_bytes(&test_group.key.key).unwrap();
         for test in test_group.tests {
             let bytes = match Signature::from_der(&test.sig) {
                 Ok(mut s) => {

--- a/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_recoverable_tests.rs
@@ -233,7 +233,7 @@ fn fail_to_verify_if_upper_s() {
         &hex::decode("0227322b3a891a0a280d6bc1fb2cbb23d28f54906fd6407f5f741f6def5762609a").unwrap(),
     )
     .unwrap();
-    let sig = <Secp256r1RecoverableSignature as ToFromBytes>::from_bytes(&hex::decode("63943a01af84b202f80f17b0f567d0ab2e8b8c8b0c971e4b253706d0f4be9120b2963fe63a35b44847a7888db981d1ccf0753a4673b094fed274a6589deb982a00").unwrap()).unwrap();
+    let sig = Secp256r1RecoverableSignature::from_bytes(&hex::decode("63943a01af84b202f80f17b0f567d0ab2e8b8c8b0c971e4b253706d0f4be9120b2963fe63a35b44847a7888db981d1ccf0753a4673b094fed274a6589deb982a00").unwrap()).unwrap();
 
     // Assert that S is in upper half
     assert_ne!(sig.sig.s().is_high().unwrap_u8(), 0);

--- a/fastcrypto/src/tests/secp256r1_tests.rs
+++ b/fastcrypto/src/tests/secp256r1_tests.rs
@@ -388,8 +388,7 @@ fn fail_to_verify_if_upper_s() {
     let normalized = sig.sig.normalize_s().unwrap();
 
     // Normalize S to be less than N/2.
-    let normalized_sig =
-        Secp256r1Signature::from_uncompressed(normalized.to_bytes().as_slice()).unwrap();
+    let normalized_sig = Secp256r1Signature::from_bytes(normalized.to_bytes().as_slice()).unwrap();
 
     // Verify with normalized lower S.
     assert!(pk.verify(&digest.digest, &normalized_sig).is_ok());
@@ -523,7 +522,7 @@ fn wycheproof_test_nonrecoverable() {
         let pk = Secp256r1PublicKey::from_bytes(&test_group.key.key).unwrap();
         for test in test_group.tests {
             let signature = match Signature::from_der(&test.sig) {
-                Ok(s) => Secp256r1Signature::from_uncompressed(
+                Ok(s) => Secp256r1Signature::from_bytes(
                     // Wycheproof tests do not enforce low s but we do, so we need to normalize
                     s.normalize_s().unwrap_or(s).to_bytes().as_slice(),
                 )


### PR DESCRIPTION
For secp256r1 and secp256k1, the existing `from_bytes` methods may be used instead.