### PR TITLE
[ecvrf-cli] fix: when the public key is not 32 bytes return error

### DIFF
--- a/fastcrypto-cli/src/ecvrf.rs
+++ b/fastcrypto-cli/src/ecvrf.rs
@@ -114,7 +114,7 @@ fn execute(cmd: Command) -> Result<String, std::io::Error> {
                 .map_err(|_| Error::new(ErrorKind::InvalidInput, "Invalid public key."))?;
             if public_key_bytes.len()!=32
             {
-              return Err(Error::new(ErrorKind::Other, "Public key length must be 32 bytes."));
+              return Err(Error::new(ErrorKind::InvalidInput, "Public key length must be 32 bytes."));
             }
             let alpha_string = hex::decode(arguments.input)
                 .map_err(|_| Error::new(ErrorKind::InvalidInput, "Invalid input string."))?;

--- a/fastcrypto-cli/src/ecvrf.rs
+++ b/fastcrypto-cli/src/ecvrf.rs
@@ -112,6 +112,10 @@ fn execute(cmd: Command) -> Result<String, std::io::Error> {
             // Parse inputs
             let public_key_bytes = hex::decode(arguments.public_key)
                 .map_err(|_| Error::new(ErrorKind::InvalidInput, "Invalid public key."))?;
+            if public_key_bytes.len()!=32
+            {
+              return Err(Error::new(ErrorKind::Other, "Public key length must be 32 bytes."));
+            }
             let alpha_string = hex::decode(arguments.input)
                 .map_err(|_| Error::new(ErrorKind::InvalidInput, "Invalid input string."))?;
             let proof_bytes = hex::decode(arguments.proof)


### PR DESCRIPTION
when run the command
`
cargo run --bin ecvrf-cli verify --output 2b7e45821d80567761e8bb3fc519efe5ad80cdb4423227289f960319bbcf6eea1aef30c023617d73f589f98272b87563c6669f82b51dafbeb5b9cf3b17c73437 --proof 18ccf8bf316f00b387fc6e7b26f2d3ddadbf5e9c66d3a30986f12b208108551f9c6da87793a857d79261338a50430074b1dbc7f8f05e492149c51313381248b4229ebdda367146dbbbf95809c7fb330d --input 48656c6c6f2c20776f726c6421 --public-key 928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015928744da5ffa614d65dd1d5659a8e9dd558e68f8565946ef3d54215d90cba015
`

it will return verify correct. obviously the public key length is invalid, so we should filter the invaild length when the public key length    bigger than 32 bytes