### PR TITLE
Clean up zeroize

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Furthermore, we extend the selected libraries with additional features:
 - Robust testing framework: [Wycheproof tests](https://github.com/google/wycheproof) and [prop tests](https://altsysrq.github.io/proptest-book/intro.html) are added when possible to protect against arbitrary inputs and crafted edge cases.
-- Zeroization: Sensitive private key materials are cleared from memory securely and proactively when it goes out of scope using the [zeroize](https://docs.rs/zeroize/latest/zeroize/) trait.
+- Zeroization: Sensitive private key materials are cleared from memory when it goes out of scope using the [zeroize](https://docs.rs/zeroize/latest/zeroize/) trait. Note that this is *best effort* and does not guarantee that all sensitive data is cleared from memory as data may be copied or moved around by the compiler, FFI, etc. 
 - Serialization: Effective and standardized serialization are required.
 
 This library will be continuously updated with more schemes and faster implementations based on benchmarking results, RFC updates, new research and auditor inputs.

--- a/fastcrypto/src/aes.rs
+++ b/fastcrypto/src/aes.rs
@@ -82,7 +82,7 @@ pub trait AuthenticatedCipher {
 }
 
 /// Struct wrapping an instance of a `generic_array::GenericArray<u8, N>`.
-#[derive(Clone, Serialize, Deserialize, SilentDebug, SilentDisplay)]
+#[derive(Clone, Serialize, Deserialize, SilentDebug, SilentDisplay, ZeroizeOnDrop)]
 #[serde(bound = "N: ArrayLength<u8>")]
 pub struct GenericByteArray<N: ArrayLength<u8>> {
     // We use GenericArrays because they are used by the underlying crates.
@@ -132,17 +132,6 @@ where
         self.bytes.zeroize();
     }
 }
-
-impl<N> Drop for GenericByteArray<N>
-where
-    N: ArrayLength<u8>,
-{
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-impl<N> ZeroizeOnDrop for GenericByteArray<N> where N: ArrayLength<u8> + Debug {}
 
 /// A key of `N` bytes used with AES ciphers.
 pub type AesKey<N> = GenericByteArray<N>;

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -34,7 +34,6 @@ use std::{
     mem::MaybeUninit,
     str::FromStr,
 };
-use zeroize::Zeroize;
 
 /// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
 /// and of the second using 96 bytes. BLS supports two modes:
@@ -330,20 +329,7 @@ impl PartialEq for BLS12381PrivateKey {
 
 impl Eq for BLS12381PrivateKey {}
 
-impl zeroize::Zeroize for BLS12381PrivateKey {
-    fn zeroize(&mut self) {
-        self.bytes.take().zeroize();
-        self.privkey.zeroize();
-    }
-}
-
 impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
-
-impl Drop for BLS12381PrivateKey {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
 
 impl AsRef<[u8]> for BLS12381PrivateKey {
     fn as_ref(&self) -> &[u8] {

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -329,6 +329,8 @@ impl PartialEq for BLS12381PrivateKey {
 
 impl Eq for BLS12381PrivateKey {}
 
+// All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
+// ZeroizeOnDrop).
 impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
 
 impl AsRef<[u8]> for BLS12381PrivateKey {

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -39,7 +39,7 @@ use std::{
     fmt::{self, Debug, Display},
     str::FromStr,
 };
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::ZeroizeOnDrop;
 
 #[cfg(any(test, feature = "experimental"))]
 use crate::traits::AggregateAuthenticator;
@@ -70,7 +70,7 @@ pub const ED25519_KEYPAIR_LENGTH: usize = ED25519_PRIVATE_KEY_LENGTH;
 pub struct Ed25519PublicKey(pub ed25519_consensus::VerificationKey);
 
 /// Ed25519 private key.
-#[derive(SilentDebug, SilentDisplay, AsRef, Zeroize, ZeroizeOnDrop)]
+#[derive(SilentDebug, SilentDisplay, AsRef, ZeroizeOnDrop)]
 #[as_ref(forward)]
 pub struct Ed25519PrivateKey(pub ed25519_consensus::SigningKey);
 

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -22,6 +22,7 @@ use derive_more::{Add, Div, From, Neg, Sub};
 use fastcrypto_derive::GroupOpsExtend;
 use serde::{de, Deserialize};
 use std::ops::{Div, Mul};
+use zeroize::Zeroize;
 
 const RISTRETTO_POINT_BYTE_LENGTH: usize = 32;
 const RISTRETTO_SCALAR_BYTE_LENGTH: usize = 32;
@@ -129,7 +130,7 @@ impl ToFromByteArray<RISTRETTO_POINT_BYTE_LENGTH> for RistrettoPoint {
 serialize_deserialize_with_to_from_byte_array!(RistrettoPoint);
 
 /// Represents a scalar.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, From, Add, Sub, Neg, Div, GroupOpsExtend)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, From, Add, Sub, Neg, Div, GroupOpsExtend, Zeroize)]
 pub struct RistrettoScalar(ExternalRistrettoScalar);
 
 impl RistrettoScalar {

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -41,7 +41,6 @@ use std::{
     fmt::{self, Debug},
     str::FromStr,
 };
-use zeroize::Zeroize;
 
 pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(rust_secp256k1::Secp256k1::new);
 
@@ -211,20 +210,11 @@ impl AsRef<[u8]> for Secp256k1PrivateKey {
     }
 }
 
-impl zeroize::Zeroize for Secp256k1PrivateKey {
-    fn zeroize(&mut self) {
-        // Unwrap is safe here because we are using a constant and it has been tested
-        // (see fastcrypto/src/tests/secp256k1_tests::test_sk_zeroization_on_drop)
-        self.privkey = SecretKey::from_slice(&constants::ONE).unwrap();
-        self.bytes.take().zeroize();
-    }
-}
-
 impl zeroize::ZeroizeOnDrop for Secp256k1PrivateKey {}
 
 impl Drop for Secp256k1PrivateKey {
     fn drop(&mut self) {
-        self.zeroize();
+        self.privkey.non_secure_erase();
     }
 }
 

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -214,6 +214,7 @@ impl zeroize::ZeroizeOnDrop for Secp256k1PrivateKey {}
 
 impl Drop for Secp256k1PrivateKey {
     fn drop(&mut self) {
+        // bytes is zeroized on drop indirectly via OnceCell
         self.privkey.non_secure_erase();
     }
 }

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -40,7 +40,6 @@ use p256::elliptic_curve::scalar::IsHigh;
 use p256::{NistP256, Scalar};
 use std::fmt::{self, Debug};
 use std::str::FromStr;
-use zeroize::Zeroize;
 
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 
@@ -297,21 +296,7 @@ impl AsRef<[u8]> for Secp256r1PrivateKey {
     }
 }
 
-impl zeroize::Zeroize for Secp256r1PrivateKey {
-    fn zeroize(&mut self) {
-        // Unwrap is safe here because we are using a constant and it has been tested
-        // (see fastcrypto/src/tests/secp256r1_tests::test_sk_zeroization_on_drop)
-        self.privkey = ExternalSecretKey::from_bytes(&Scalar::ONE.to_bytes()).unwrap();
-        self.bytes.take().zeroize();
-    }
-}
-
-impl Drop for Secp256r1PrivateKey {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
+// All fields support ZeroizeOnDrop
 impl zeroize::ZeroizeOnDrop for Secp256r1PrivateKey {}
 
 serialize_deserialize_with_to_from_bytes!(Secp256r1Signature, SECP256R1_SIGNATURE_LENTH);

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -296,7 +296,8 @@ impl AsRef<[u8]> for Secp256r1PrivateKey {
     }
 }
 
-// All fields support ZeroizeOnDrop
+// All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
+// ZeroizeOnDrop).
 impl zeroize::ZeroizeOnDrop for Secp256r1PrivateKey {}
 
 serialize_deserialize_with_to_from_bytes!(Secp256r1Signature, SECP256R1_SIGNATURE_LENTH);

--- a/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_recoverable_tests.rs
@@ -308,12 +308,11 @@ fn test_sk_zeroization_on_drop() {
         assert_eq!(sk_memory, &sk_bytes[..]);
     }
 
-    // Check that self.privkey is set to ONE_KEY (workaround to all zero SecretKey considered as invalid)
+    // Check that self.privkey is set to 1 (see DUMMY_KEYPAIR)
     unsafe {
-        for i in 0..constants::SECRET_KEY_SIZE - 1 {
-            assert_eq!(*ptr.add(i), 0);
+        for i in 0..constants::SECRET_KEY_SIZE {
+            assert_eq!(*ptr.add(i), 1);
         }
-        assert_eq!(*ptr.add(constants::SECRET_KEY_SIZE - 1), 1);
     }
 
     // Check that self.bytes is zeroized

--- a/fastcrypto/src/tests/secp256k1_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_tests.rs
@@ -451,12 +451,11 @@ fn test_sk_zeroization_on_drop() {
         assert_eq!(sk_memory, &sk_bytes[..]);
     }
 
-    // Check that self.privkey is set to ONE_KEY (workaround to all zero SecretKey considered as invalid)
+    // Check that self.privkey is set to 1 (see DUMMY_KEYPAIR)
     unsafe {
-        for i in 0..constants::SECRET_KEY_SIZE - 1 {
-            assert_eq!(*ptr.add(i), 0);
+        for i in 0..constants::SECRET_KEY_SIZE {
+            assert_eq!(*ptr.add(i), 1);
         }
-        assert_eq!(*ptr.add(constants::SECRET_KEY_SIZE - 1), 1);
     }
 
     // Check that self.bytes is zeroized

--- a/fastcrypto/src/vrf.rs
+++ b/fastcrypto/src/vrf.rs
@@ -72,6 +72,7 @@ pub mod ecvrf {
     use crate::vrf::{VRFKeyPair, VRFPrivateKey, VRFProof, VRFPublicKey};
     use elliptic_curve::hash2curve::{ExpandMsg, Expander};
     use serde::{Deserialize, Serialize};
+    use zeroize::ZeroizeOnDrop;
 
     /// draft-irtf-cfrg-vrf-15 specifies suites for suite-strings 0x00-0x04 and notes that future
     /// designs should specify a different suite_string constant, so we use "sui_vrf" here.
@@ -125,7 +126,7 @@ pub mod ecvrf {
         }
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, ZeroizeOnDrop)]
     pub struct ECVRFPrivateKey(RistrettoScalar);
 
     impl VRFPrivateKey for ECVRFPrivateKey {


### PR DESCRIPTION
- Use Zeroize only for internal objects
- Use ZeroizeOnDrop for private keys:
   - derive(ZeroizeOnDrop) if all fields are Zeroize
   - just the trait ZeroizeOnDrop if all fields already support ZeroizeOnDrop
   - impl Drop if some fields do not support Zeroize*