### PR TITLE
Use a single ECIES encryption for all the shares sent to one party.

### DIFF
--- a/fastcrypto-tbls/benches/dkg.rs
+++ b/fastcrypto-tbls/benches/dkg.rs
@@ -52,7 +52,7 @@ mod dkg_benches {
 
     fn dkg(c: &mut Criterion) {
         const SIZES: [u16; 1] = [100];
-        const WEIGHTS: [u16; 2] = [20, 33];
+        const WEIGHTS: [u16; 3] = [10, 20, 33];
 
         {
             let mut create: BenchmarkGroup<_> = c.benchmark_group("DKG create");

--- a/fastcrypto-tbls/src/dkg.rs
+++ b/fastcrypto-tbls/src/dkg.rs
@@ -213,7 +213,7 @@ where
             return Ok((shares, next_message)); // 1 complaint per message is enough
         }
 
-        shares.insert(message.sender, decrypted_shares.into());
+        shares.insert(message.sender, decrypted_shares);
         Ok((shares, next_message))
     }
 

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -5,7 +5,6 @@ use crate::ecies;
 use crate::types::ShareIndex;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::GroupElement;
-use std::collections::HashSet;
 use std::iter::Map;
 use std::ops::RangeInclusive;
 
@@ -43,6 +42,11 @@ impl<G: GroupElement> Nodes<G> {
         self.n
     }
 
+    /// Number of nodes.
+    pub fn num_nodes(&self) -> usize {
+        self.nodes.len()
+    }
+
     /// Get an iterator on the share ids.
     pub fn share_ids_iter(&self) -> Map<RangeInclusive<u32>, fn(u32) -> ShareIndex> {
         (1..=self.n).map(|i| ShareIndex::new(i).expect("nonzero"))
@@ -63,11 +67,11 @@ impl<G: GroupElement> Nodes<G> {
     }
 
     /// Get the share ids of a node.
-    pub fn share_ids_of(&self, id: PartyId) -> HashSet<ShareIndex> {
+    pub fn share_ids_of(&self, id: PartyId) -> Vec<ShareIndex> {
         // TODO: [perf opt] Cache this
         self.share_ids_iter()
             .filter(|node_id| self.share_id_to_node(node_id).expect("valid ids").id == id)
-            .collect::<HashSet<_>>()
+            .collect::<Vec<_>>()
     }
 
     /// Get an iterator on the nodes.

--- a/fastcrypto-tbls/src/tests/dkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_tests.rs
@@ -37,7 +37,7 @@ fn setup_party(
         .map(|(id, _sk, pk)| Node::<EG> {
             id: *id,
             pk: pk.clone(),
-            weight: 1,
+            weight: 2,
         })
         .collect();
     Party::<G, EG>::new(
@@ -131,13 +131,13 @@ fn test_dkg_e2e_4_parties_threshold_2() {
 
     let r2_all = vec![conf0, conf1, conf3];
     let shares0 = d1
-        .process_confirmations(&r1_all, &r2_all, shares0, 3)
+        .process_confirmations(&r1_all, &r2_all, shares0, 3, &mut thread_rng())
         .unwrap();
     let shares1 = d1
-        .process_confirmations(&r1_all, &r2_all, shares1, 3)
+        .process_confirmations(&r1_all, &r2_all, shares1, 3, &mut thread_rng())
         .unwrap();
     let shares3 = d3
-        .process_confirmations(&r1_all, &r2_all, shares3, 3)
+        .process_confirmations(&r1_all, &r2_all, shares3, 3, &mut thread_rng())
         .unwrap();
 
     // Only the first message of d0 passed all tests -> only one vss is used.


### PR DESCRIPTION
This saves about 30% communication size (only one DDH element per party), and 50% message creation time for weights > 10 (less exps to compute).