### PR TITLE
Allow larger discriminants and strong fiat-shamir

### DIFF
--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -95,6 +95,10 @@ harness = false
 name = "hash"
 harness = false
 
+[[bench]]
+name = "vdf"
+harness = false
+
 [features]
 default = []
 copy_key = []

--- a/fastcrypto/benches/groups.rs
+++ b/fastcrypto/benches/groups.rs
@@ -208,6 +208,17 @@ mod group_benches {
         group.bench_function("Double (1024 bit discriminant)", move |b| {
             b.iter(|| z.double())
         });
+
+        let d = Discriminant::try_from(BigInt::from_str_radix("-af0806241ecbc630fbbfd0c9d61c257c40a185e8cab313041cf029d6f070d58ecbc6c906df53ecf0dd4497b0753ccdbce2ebd9c80ae0032acce89096af642dd8c008403dd989ee5c1262545004fdcd7acf47908b983bc5fed17889030f0138e10787a8493e95ca86649ae8208e4a70c05772e25f9ac901a399529de12910a7a2c3376292be9dba600fd89910aeccc14432b6e45c0456f41c177bb736915cad3332a74e25b3993f3e44728dc2bd13180132c5fb88f0490aeb96b2afca655c13dd9ab8874035e26dab16b6aad2d584a2d35ae0eaf00df4e94ab39fe8a3d5837dcab204c46d7a7b97b0c702d8be98c50e1bf8b649b5b6194fc3bae6180d2dd24d9f", 16).unwrap()).unwrap();
+        let x = QuadraticForm::generator(&d).mul(&BigInt::from(1234));
+        let y = QuadraticForm::generator(&d).mul(&BigInt::from(4321));
+        let z = y.clone();
+        group.bench_function("Compose (2048 bit discriminant)", move |b| {
+            b.iter(|| x.compose(&y))
+        });
+        group.bench_function("Double (2048 bit discriminant)", move |b| {
+            b.iter(|| z.double())
+        });
     }
 
     criterion_group! {

--- a/fastcrypto/benches/vdf.rs
+++ b/fastcrypto/benches/vdf.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#[macro_use]
+extern crate criterion;
+
+mod vdf_benches {
+
+    use criterion::measurement::Measurement;
+    use criterion::{BenchmarkGroup, Criterion};
+    use fastcrypto::groups::class_group::{Discriminant, QuadraticForm};
+    use fastcrypto::vdf::wesolowski::ClassGroupVDF;
+    use fastcrypto::vdf::VDF;
+    use num_bigint::BigInt;
+    use num_traits::Num;
+
+    struct BenchmarkInputs {
+        iterations: u64,
+        discriminant: String,
+        result: String,
+        proof: String,
+    }
+
+    fn verify_single<M: Measurement>(parameters: BenchmarkInputs, c: &mut BenchmarkGroup<M>) {
+        let discriminant =
+            Discriminant::try_from(-BigInt::from_str_radix(&parameters.discriminant, 16).unwrap())
+                .unwrap();
+        let discriminant_size = discriminant.bits();
+
+        let result_bytes = hex::decode(parameters.result).unwrap();
+        let result = QuadraticForm::from_bytes(&result_bytes, &discriminant).unwrap();
+
+        let proof_bytes = hex::decode(parameters.proof).unwrap();
+        let proof = QuadraticForm::from_bytes(&proof_bytes, &discriminant).unwrap();
+
+        let input = QuadraticForm::generator(&discriminant);
+
+        let vdf = ClassGroupVDF::new(discriminant, parameters.iterations);
+        c.bench_function(discriminant_size.to_string(), move |b| {
+            b.iter(|| vdf.verify(&input, &result, &proof))
+        });
+    }
+
+    fn verify(c: &mut Criterion) {
+        let mut group = c.benchmark_group("VDF verify");
+
+        // Note that the number of iterations are quite low, but this has very little influence on the benchmark results.
+
+        //1024 bits
+        verify_single(BenchmarkInputs {
+            iterations: 1000,
+            discriminant: "cd711f181153e08e08e5ba156db0c4e9469de76f2bd6b64f068f5007918727f5eaa5f6a0e090f82682a4ebf87befdea8f1253265d700ee3ca6b0fdb2677c633c7f37b62f0e0c13b402def0ba9abaf15e4c53bfb6bda0c7a0cad4439864af3eb9af6d6c4b10286eb8ff5e2de5b009196bc60c3000fde8d4b89b7674e61bc2d23f".to_string(),
+            result: "030039c78c39cff6c29052bfc1453616ec7a47251509b9dbc33d1036bebd4d12e6711a51deb327120310f96be04c90fd4c3b1dab9617c3133132b827abe7bb2348707da8164b964e1b95cd6a8eaf36ffb80bab1f750410e793daec8228b222bd00370100".to_string(),
+            proof: "000075d043db5f619f5cb4e8ef7729c7cac154434c33d6e52dd086b90a52c7b1231890eda9d1365100e88993e332f0a99bb7763f215de2fb6b632445beeeff22b657dc90d4e110ed03eac10ec445117d211208c79dd4933ba58b8e17b4c54ef1824c0100".to_string(),
+        }, &mut group);
+
+        // 2048 bits
+        verify_single(BenchmarkInputs {
+            iterations: 1000,
+            discriminant: "f6901cd003679e2f451cda55b032fb49222a9b595b9e5948b793d2d7338d4da01937c637739e7f980d481b742c0fdc5255847ccc848359db822ed6ca7f33bdd54a207e24679c9f1f7e64be59e1bed7afbaa999770743984ed997c2c8187b5a80a0df200c040ac152dd6bb3bfdf3a7f151f2ddbd9debf6c841cebdc9f450cb42f51529ba04e6bda874b43461ed104b39257559bed53200d093f8e6c48f2b1c91e15e37ce695924eafd78fa4ba11e519f9a885399264d1a885d353ce128f1e044ef2feda125167e38ad5db7931b752847388c900868bc6bff2d83f7a6e055c618d3abc0ae104520df25508f40323c35d2d992303e12f1ae7bc44ffd5861d9f768f".to_string(),
+            result: "02001222c470df6df6e1321aa1c28279d0c64663c7f066888ff6cd854dcd5deb71f63dfe0b867675180fada390e0d7b1ff735b55fea2b88123a32d1e1239126b275578ea26a4a89e5ef290e2b7b8d072ab819d5b9422770339dc87fd4dc4ebf6add3e391067a557be4be5436355ab11035609d5a3dc71e95cf2a0dcbb228b85d9750a1dc670ac51822d7eff49b5cacd4a8cc485e53bbf7e44f95e7fd5ec55fca44eb91c4831b1e839d8b4c8453dce8be69698bc5cb8fa45120d201057e4d72a6746b0100".to_string(),
+            proof: "03008b91b20ab570b701d394aa095d8c670d95a8a3b26af966e979a27acf417421360ea54014668a121139ab11fe92cc0a8d192a8a675f244f3016ed23a7a82d9dd70de089d5bcb5bb0c9535923b2656b19c8cf0cc6e0e4c800c44fc17e16a1b96572f6e0e0967709af259b854a51bec270e5cf73cc4efa93791ac6a84dc2ab77f02d0234ac60b2a04740644ac845204c67f9063ab139e9a0eb25c4417c892ca52299202d3854243d7eb58cc46a837745a1eb92699eb89138eec89467f7226380b040600".to_string(),
+        }, &mut group);
+    }
+
+    criterion_group! {
+        name = vdf_benches;
+        config = Criterion::default().sample_size(100);
+        targets = verify,
+    }
+}
+
+criterion_main!(vdf_benches::vdf_benches,);

--- a/fastcrypto/src/groups/class_group/compressed.rs
+++ b/fastcrypto/src/groups/class_group/compressed.rs
@@ -203,12 +203,12 @@ impl CompressedQuadraticForm {
         // This implementation follows https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L222-L245.
         match self {
             Zero(d) => {
-                let mut bytes = vec![0x00; QuadraticForm::serialized_length(d.0.bits() as usize)];
+                let mut bytes = vec![0x00; QuadraticForm::serialized_length(d.bits())];
                 bytes[0] = 0x04;
                 bytes
             }
             Generator(d) => {
-                let mut bytes = vec![0x00; QuadraticForm::serialized_length(d.0.bits() as usize)];
+                let mut bytes = vec![0x00; QuadraticForm::serialized_length(d.bits())];
                 bytes[0] = 0x08;
                 bytes
             }
@@ -219,7 +219,7 @@ impl CompressedQuadraticForm {
 
                 // The bit length of the discriminant, which is rounded up to the next multiple of 32.
                 // Serialization of special forms (identity or generator) takes only 1 byte.
-                let d_bits = (form.discriminant.0.bits() as usize + 31) & !31;
+                let d_bits = (form.discriminant.bits() + 31) & !31;
 
                 // Size of g in bytes minus 1 (g_size)
                 let g_size = (form.g.bits() as usize + 7) / 8 - 1;
@@ -249,7 +249,7 @@ impl CompressedQuadraticForm {
                 bytes.extend_from_slice(&vec![
                     0u8;
                     QuadraticForm::serialized_length(
-                        form.discriminant.0.bits() as usize
+                        form.discriminant.bits()
                     ) - bytes.len()
                 ]);
                 bytes
@@ -259,7 +259,7 @@ impl CompressedQuadraticForm {
 
     /// Deserialize a compressed binary form according to the format defined in the chiavdf library.
     fn deserialize(bytes: &[u8], discriminant: &Discriminant) -> FastCryptoResult<Self> {
-        if bytes.len() != QuadraticForm::serialized_length(discriminant.0.bits() as usize) {
+        if bytes.len() != QuadraticForm::serialized_length(discriminant.bits()) {
             return Err(FastCryptoError::InvalidInput);
         }
 
@@ -276,7 +276,7 @@ impl CompressedQuadraticForm {
 
         // The bit length of the discriminant, which is rounded up to the next multiple of 32.
         // Serialization of special forms (identity or generator) takes only 1 byte.
-        let d_bits = (discriminant.0.bits() as usize + 31) & !31;
+        let d_bits = (discriminant.bits() + 31) & !31;
 
         // Size of g in bytes minus 1 (g_size)
         let g_size = bytes[1] as usize;
@@ -442,7 +442,7 @@ mod tests {
         let serialized = compressed.serialize();
         assert_eq!(serialized.to_vec(), compressed_bytes);
 
-        let length = QuadraticForm::serialized_length(discriminant.0.bits() as usize);
+        let length = QuadraticForm::serialized_length(discriminant.bits());
 
         let mut generator_serialized = vec![0x08];
         generator_serialized.extend_from_slice(&vec![0u8; length - 1]);

--- a/fastcrypto/src/groups/class_group/compressed.rs
+++ b/fastcrypto/src/groups/class_group/compressed.rs
@@ -7,7 +7,7 @@ use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::groups::class_group::compressed::CompressedQuadraticForm::{
     Generator, Nontrivial, Zero,
 };
-use crate::groups::class_group::{Discriminant, QuadraticForm, QUADRATIC_FORM_SIZE_IN_BYTES};
+use crate::groups::class_group::{Discriminant, QuadraticForm};
 use crate::groups::ParameterizedGroupElement;
 use num_bigint::{BigInt, Sign};
 use num_integer::{ExtendedGcd, Integer};
@@ -34,15 +34,39 @@ struct CompressedFormat {
 }
 
 impl QuadraticForm {
-    /// Serialize a quadratic form. The format follows that of chiavdf (see https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L222-L245)
-    /// and the result will be exactly [`QUADRATIC_FORM_SIZE_IN_BYTES`] bytes long.
-    pub(super) fn serialize(&self) -> [u8; QUADRATIC_FORM_SIZE_IN_BYTES] {
+
+    /// Return the length of the serialization in bytes of a quadratic form with a given discriminant
+    /// length in bits.
+    pub fn serialized_length(discriminant_in_bits: usize) -> usize {
+        // The number of 32 bit words needed to represent the discriminant rounded up,
+        ((discriminant_in_bits + 31) / 32
+            * 3 // a' is two words and t' is one word. Both is divided by g, so the length of g is subtracted from both.
+            + 1 // Flags for special forms (identity or generator) and the sign of b and t'.
+            + 1 // The size of g - 1 = g_size.
+            // Two extra bytes for g and b0 (which has the same length). Note that 2 * g_size was already counted.
+            + 2) as usize
+    }
+
+    /// Serialize a quadratic form. The length of the serialization in bytes depends on the bit-length
+    /// of the discriminant and may be computed using [QuadraticForm::serialized_length].
+    ///
+    /// The format follows that of chiavdf (see
+    /// https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L222-L245)
+    /// if the discriminant is 1024 bits.
+    pub(super) fn serialize(&self) -> Vec<u8> {
         self.compress().serialize()
     }
 
-    /// Deserialize bytes into a quadratic form. The format follows that of chiavdf (see https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L258-L287)
-    /// and the bytes array must be exactly [`QUADRATIC_FORM_SIZE_IN_BYTES`] bytes long.
+    /// Deserialize bytes into a quadratic form. The expected length of the serialization in bytes
+    /// depends on the bit-length of the discriminant and may be computed using [CompressedQuadraticForm::serialized_length].
+    ///
+    /// The format follows that of chiavdf (see https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L258-L287)
+    /// if the discriminant is 1024 bits.
     pub fn from_bytes(bytes: &[u8], discriminant: &Discriminant) -> FastCryptoResult<Self> {
+        if bytes.len() != QuadraticForm::serialized_length(discriminant.0.bits() as usize)
+        {
+            return Err(FastCryptoError::InvalidInput);
+        }
         CompressedQuadraticForm::deserialize(bytes, discriminant)?.decompress()
     }
 
@@ -109,6 +133,7 @@ impl QuadraticForm {
 }
 
 impl CompressedQuadraticForm {
+
     /// Return this as an uncompressed QuadraticForm. See https://eprint.iacr.org/2020/196.pdf for a definition of the compression.
     fn decompress(&self) -> FastCryptoResult<QuadraticForm> {
         // This implementation follows https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L52-L116.
@@ -180,16 +205,18 @@ impl CompressedQuadraticForm {
     }
 
     /// Serialize a compressed binary form according to the format defined in the chiavdf library.
-    fn serialize(&self) -> [u8; QUADRATIC_FORM_SIZE_IN_BYTES] {
+    fn serialize(&self) -> Vec<u8> {
         // This implementation follows https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L222-L245.
         match self {
-            Zero(_) => {
-                let mut bytes = [0u8; QUADRATIC_FORM_SIZE_IN_BYTES];
+            Zero(d) => {
+                let mut bytes =
+                    vec![0x00; QuadraticForm::serialized_length(d.0.bits() as usize)];
                 bytes[0] = 0x04;
                 bytes
             }
-            Generator(_) => {
-                let mut bytes = [0u8; QUADRATIC_FORM_SIZE_IN_BYTES];
+            Generator(d) => {
+                let mut bytes =
+                    vec![0x00; QuadraticForm::serialized_length(d.0.bits() as usize)];
                 bytes[0] = 0x08;
                 bytes
             }
@@ -227,11 +254,13 @@ impl CompressedQuadraticForm {
                     &export_to_size(&form.b0, b0_length)
                         .expect("The size bound on the discriminant ensures that this is true"),
                 );
-                bytes.extend_from_slice(&vec![0u8; QUADRATIC_FORM_SIZE_IN_BYTES - bytes.len()]);
-
+                bytes.extend_from_slice(&vec![
+                    0u8;
+                    QuadraticForm::serialized_length(
+                        form.discriminant.0.bits() as usize
+                    ) - bytes.len()
+                ]);
                 bytes
-                    .try_into()
-                    .expect("The size bound on the discriminant ensures that this is true")
             }
         }
     }
@@ -239,12 +268,6 @@ impl CompressedQuadraticForm {
     /// Deserialize a compressed binary form according to the format defined in the chiavdf library.
     fn deserialize(bytes: &[u8], discriminant: &Discriminant) -> FastCryptoResult<Self> {
         // This implementation follows https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L258-L287.
-        if bytes.len() != QUADRATIC_FORM_SIZE_IN_BYTES {
-            return Err(FastCryptoError::InputLengthWrong(
-                QUADRATIC_FORM_SIZE_IN_BYTES,
-            ));
-        }
-
         let is_identity = bytes[0] & 0x04 != 0;
         if is_identity {
             return Ok(Zero(discriminant.clone()));
@@ -374,12 +397,13 @@ fn partial_xgcd(a: &BigInt, b: &BigInt) -> FastCryptoResult<(BigInt, BigInt)> {
 #[cfg(test)]
 mod tests {
     use crate::groups::class_group::compressed::{
-        bigint_from_bytes, bigint_to_bytes, CompressedQuadraticForm, QUADRATIC_FORM_SIZE_IN_BYTES,
+        bigint_from_bytes, bigint_to_bytes, CompressedQuadraticForm,
     };
     use crate::groups::class_group::{Discriminant, QuadraticForm};
     use crate::groups::ParameterizedGroupElement;
     use num_bigint::BigInt;
     use num_traits::Num;
+    use std::str::FromStr;
 
     #[test]
     fn test_bigint_import() {
@@ -415,15 +439,17 @@ mod tests {
         let discriminant_hex = "d2b4bc45525b1c2b59e1ad7f81a1003f2f0efdcbc734bf711ebf5599a73577a282af5e8959ffcf3ec8601b601bcd2fa54915823d73130e90cb90fe1c6c7c10bf";
         let discriminant =
             Discriminant::try_from(-BigInt::from_str_radix(discriminant_hex, 16).unwrap()).unwrap();
-        let compressed_hex = "010083b82ff747c385b0e2ff91ef1bea77d3d70b74322db1cd405e457aefece6ff23961c1243f1ed69e15efd232397e467200100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let compressed_hex = "010083b82ff747c385b0e2ff91ef1bea77d3d70b74322db1cd405e457aefece6ff23961c1243f1ed69e15efd232397e467200100";
         let compressed_bytes = hex::decode(compressed_hex).unwrap();
         let compressed =
             CompressedQuadraticForm::deserialize(&compressed_bytes, &discriminant).unwrap();
         let serialized = compressed.serialize();
         assert_eq!(serialized.to_vec(), compressed_bytes);
 
-        let mut generator_serialized = [0u8; QUADRATIC_FORM_SIZE_IN_BYTES];
-        generator_serialized[0] = 0x08;
+        let length = QuadraticForm::serialized_length(discriminant.0.bits() as usize);
+
+        let mut generator_serialized = vec![0x08];
+        generator_serialized.extend_from_slice(&vec![0u8; length - 1]);
         assert_eq!(
             QuadraticForm::generator(&discriminant)
                 .compress()
@@ -432,24 +458,38 @@ mod tests {
         );
         assert_eq!(
             QuadraticForm::generator(&discriminant),
-            CompressedQuadraticForm::deserialize(&generator_serialized, &discriminant)
-                .unwrap()
-                .decompress()
-                .unwrap()
+            QuadraticForm::from_bytes(&generator_serialized, &discriminant).unwrap()
         );
 
-        let mut identity_serialized = [0u8; QUADRATIC_FORM_SIZE_IN_BYTES];
-        identity_serialized[0] = 0x04;
+        let mut identity_serialized = vec![0x04];
+        identity_serialized.extend_from_slice(&vec![0u8; length - 1]);
         assert_eq!(
             QuadraticForm::zero(&discriminant).compress().serialize(),
             identity_serialized
         );
         assert_eq!(
             QuadraticForm::zero(&discriminant),
-            CompressedQuadraticForm::deserialize(&identity_serialized, &discriminant)
-                .unwrap()
-                .decompress()
-                .unwrap()
+            QuadraticForm::from_bytes(&identity_serialized, &discriminant).unwrap()
         );
+    }
+
+    #[test]
+    fn test_serialize_roundtrip() {
+        // 512, 1024, 2048 and 4096 bits
+        let discriminants = [
+            "-9349344414767291113687223839476811112057517254984004685948091483948469540163634423565760143454771869645957446839582874595782298614481082568123251157411687",
+            "-133945061969889266637985327980602701669957743979382571436531763623415706276402737192009754195707000763534826528470478732951439968182253841713707751680514914997731717008973123373160242352119122869810833826423629802461890931457718412113596718805448770307254626415119526466550394593324563882174686655718775270447",
+            "-29502142669795498170664913925261110998320411268548537483129113540779280561083683352182517520690699478273319868447448049966824511039919308043747877951680827633851250876773921459982042061851444137132714948181860869206531105248168224678068701295818400875143336452362204697641282000514554237783258014492731972413087647918643222949297880308212892726925365719811319120311399853900323484711428931751287527191097875770471316418233180621991992577566395542854095151545112408782988736372758594134766939199932173978149654618994408144132349550563062288824293800449098318712711815821352232797398061624841110469260018248562843766511",
+            "-1007406630399371166205680828506843661949414311260040967856089339951193128060006822186578417382690035289449410666011850863693848919000628846349158715617084456083709831037163606319682672637324840187988607127103283149127943287978050624989555034830938436492975275987366038909474637467450001207425286269651430287955788923542179414542154414299977476302876585624737430226443723554486671958211612001960238001471273685967498771059733513459006129260882122390792571950782612040307833174744553353810400760504366039499327516985390664823589969989307911300950073410116630825901270255248406423708217095849457069056140995525605401875876118373137298999494339171538428290676256719705881706431651985194776829197614940001195992054408265445358913742096341471054976467547938020859817598310858507427495592930840526330743650698223650223475256616630888604670277950241581755495006259849435974983398554883297788462241826616412920690989472098631426747304873946834232860439878253783060639505051324901511090179582728174169603085475715057689175073017095753308275310776520002427239928789097518771962660619070493257590325261876957495417502288636882538000005279327607258660706478536265303230535024676764883243771806618176424548574077467727598718632427911394987209476759",
+        ].map(|s| BigInt::from_str(s).unwrap()).map(|p| Discriminant::try_from(p).unwrap());
+
+        for discriminant in discriminants {
+            let form = QuadraticForm::generator(&discriminant).mul(&BigInt::from(1234));
+            let serialized = form.serialize();
+            assert_eq!(
+                form,
+                QuadraticForm::from_bytes(&serialized, &discriminant).unwrap()
+            );
+        }
     }
 }

--- a/fastcrypto/src/groups/class_group/compressed.rs
+++ b/fastcrypto/src/groups/class_group/compressed.rs
@@ -260,7 +260,7 @@ impl CompressedQuadraticForm {
     /// Deserialize a compressed binary form according to the format defined in the chiavdf library.
     fn deserialize(bytes: &[u8], discriminant: &Discriminant) -> FastCryptoResult<Self> {
         if bytes.len() != QuadraticForm::serialized_length(discriminant.bits()) {
-            return Err(FastCryptoError::InvalidInput);
+            return Err(FastCryptoError::InputLengthWrong(bytes.len()));
         }
 
         // This implementation follows https://github.com/Chia-Network/chiavdf/blob/bcc36af3a8de4d2fcafa571602040a4ebd4bdd56/src/bqfc.c#L258-L287.
@@ -419,7 +419,7 @@ mod tests {
         let discriminant_hex = "d2b4bc45525b1c2b59e1ad7f81a1003f2f0efdcbc734bf711ebf5599a73577a282af5e8959ffcf3ec8601b601bcd2fa54915823d73130e90cb90fe1c6c7c10bf";
         let discriminant =
             Discriminant::try_from(-BigInt::from_str_radix(discriminant_hex, 16).unwrap()).unwrap();
-        let compressed_hex = "0200222889d197dbfddc011bba8725c753b3caf8cb85b2a03b4f8d92cf5606e81208d717f068b8476ffe1f9c2e0443fc55030605000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let compressed_hex = "0200222889d197dbfddc011bba8725c753b3caf8cb85b2a03b4f8d92cf5606e81208d717f068b8476ffe1f9c2e0443fc55030605";
         let compressed = CompressedQuadraticForm::deserialize(
             &hex::decode(compressed_hex).unwrap(),
             &discriminant,

--- a/fastcrypto/src/groups/class_group/mod.rs
+++ b/fastcrypto/src/groups/class_group/mod.rs
@@ -235,6 +235,17 @@ impl QuadraticForm {
         }
         .reduce()
     }
+}
+
+impl ParameterizedGroupElement for QuadraticForm {
+    /// The discriminant of a quadratic form defines the class group.
+    type ParameterType = Discriminant;
+
+    type ScalarType = BigInt;
+
+    fn zero(discriminant: &Self::ParameterType) -> Self {
+        Self::from_a_b_discriminant(BigInt::one(), BigInt::one(), discriminant)
+    }
 
     fn double(&self) -> Self {
         // Slightly optimised version of Algorithm 2 from Jacobson, Jr, Michael & Poorten, Alfred
@@ -312,21 +323,6 @@ impl QuadraticForm {
             partial_gcd_limit: self.partial_gcd_limit.clone(),
         }
         .reduce()
-    }
-}
-
-impl ParameterizedGroupElement for QuadraticForm {
-    /// The discriminant of a quadratic form defines the class group.
-    type ParameterType = Discriminant;
-
-    type ScalarType = BigInt;
-
-    fn zero(discriminant: &Self::ParameterType) -> Self {
-        Self::from_a_b_discriminant(BigInt::one(), BigInt::one(), discriminant)
-    }
-
-    fn double(&self) -> Self {
-        self.double()
     }
 
     fn mul(&self, scale: &BigInt) -> Self {

--- a/fastcrypto/src/groups/class_group/mod.rs
+++ b/fastcrypto/src/groups/class_group/mod.rs
@@ -149,7 +149,7 @@ impl QuadraticForm {
         } else {
             // 3.
             let EuclideanAlgorithmOutput {
-                gcd,
+                gcd: g,
                 x: _,
                 y,
                 a_divided_by_gcd: h,
@@ -161,7 +161,7 @@ impl QuadraticForm {
             // 4.
             let l = (&y * (&b * (w1.mod_floor(&h)) + &c * (w2.mod_floor(&h)))).mod_floor(&h);
             (
-                gcd,
+                g,
                 &b * (&m / &h) + &l * (&capital_by / &h),
                 b_divided_by_gcd,
             )

--- a/fastcrypto/src/groups/class_group/mod.rs
+++ b/fastcrypto/src/groups/class_group/mod.rs
@@ -408,16 +408,15 @@ impl TryFrom<BigInt> for Discriminant {
     }
 }
 
-impl From<&Discriminant> for BigInt {
-    fn from(discriminant: &Discriminant) -> Self {
-        discriminant.0.clone()
-    }
-}
-
 impl Discriminant {
     /// Return the number of bits needed to represent this discriminant, not including the sign bit.
     pub fn bits(&self) -> usize {
         self.0.bits() as usize
+    }
+
+    /// Returns the big-endian byte representation of the absolute value of this discriminant.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes_be().1
     }
 }
 

--- a/fastcrypto/src/groups/class_group/mod.rs
+++ b/fastcrypto/src/groups/class_group/mod.rs
@@ -414,6 +414,13 @@ impl From<&Discriminant> for BigInt {
     }
 }
 
+impl Discriminant {
+    /// Return the number of bits needed to represent this discriminant, not including the sign bit.
+    pub fn bits(&self) -> usize {
+        self.0.bits() as usize
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::groups::class_group::{Discriminant, QuadraticForm};

--- a/fastcrypto/src/groups/class_group/mod.rs
+++ b/fastcrypto/src/groups/class_group/mod.rs
@@ -216,14 +216,8 @@ impl QuadraticForm {
                 (&cx * &dy - w1) / &dx
             };
 
-            let (ax_dx, ay_dy) = if g.is_one() {
-                (&x * &dx, &y * &dy)
-            } else {
-                (&g * &x * &dx, &g * &y * &dy)
-            };
-
-            u3 = &by * &cy - &ay_dy;
-            w3 = &bx * &cx - &ax_dx;
+            u3 = &by * &cy - &g * &y * &dy;
+            w3 = &bx * &cx - &g * &x * &dx;
             v3 = &g * (&q3 + &q4) - &q1 - &q2;
         }
 
@@ -306,14 +300,8 @@ impl ParameterizedGroupElement for QuadraticForm {
             let s = &bx + &by;
             v3 = &v3 - &s * &s + &u3 + &w3;
 
-            let (ax_dx, ay_dy) = if g.is_one() {
-                (&x * &dx, &y * &dy)
-            } else {
-                (&g * &x * &dx, &g * &y * &dy)
-            };
-
-            u3 = &u3 - &ay_dy;
-            w3 = &w3 - &ax_dx;
+            u3 = &u3 - &g * &y * &dy;
+            w3 = &w3 - &g * &x * &dx;
         }
 
         QuadraticForm {

--- a/fastcrypto/src/vdf/wesolowski.rs
+++ b/fastcrypto/src/vdf/wesolowski.rs
@@ -155,7 +155,7 @@ impl<const CHALLENGE_SIZE: usize> FiatShamir<QuadraticForm> for StrongFiatShamir
         let mut seed = vec![];
         seed.extend_from_slice(&input.as_bytes());
         seed.extend_from_slice(&output.as_bytes());
-        seed.extend_from_slice(&BigInt::from(&vdf.group_parameter).to_bytes_be().1);
+        seed.extend_from_slice(&vdf.group_parameter.to_bytes());
         seed.extend_from_slice(&vdf.iterations.to_be_bytes());
         hash_prime(&seed, CHALLENGE_SIZE, &[CHALLENGE_SIZE - 1])
             .expect("The length should be a multiple of 8")

--- a/fastcrypto/src/vdf/wesolowski.rs
+++ b/fastcrypto/src/vdf/wesolowski.rs
@@ -154,10 +154,15 @@ impl<const CHALLENGE_SIZE: usize> FiatShamir<QuadraticForm> for StrongFiatShamir
         output: &QuadraticForm,
     ) -> BigInt {
         let mut seed = vec![];
+
+        // The inputs to the hash function have a 1:1 encoding because the size of all parameters are
+        // fixed per discriminant size. See serialized_length for the input and output, and iterations
+        // is always 8 bytes: https://doc.rust-lang.org/std/primitive.u64.html#method.to_be_bytes.
         seed.extend_from_slice(&input.as_bytes());
         seed.extend_from_slice(&output.as_bytes());
         seed.extend_from_slice(&vdf.group_parameter.to_bytes());
         seed.extend_from_slice(&vdf.iterations.to_be_bytes());
+
         hash_prime(&seed, CHALLENGE_SIZE, &[CHALLENGE_SIZE - 1])
             .expect("The length should be a multiple of 8")
     }

--- a/fastcrypto/src/vdf/wesolowski.rs
+++ b/fastcrypto/src/vdf/wesolowski.rs
@@ -10,7 +10,6 @@ use crate::vdf::VDF;
 use num_bigint::{BigInt, Sign};
 use num_integer::Integer;
 use num_prime::nt_funcs::is_prime;
-use num_traits::{One, Zero};
 use std::cmp::min;
 use std::marker::PhantomData;
 use std::ops::Neg;

--- a/fastcrypto/src/vdf/wesolowski.rs
+++ b/fastcrypto/src/vdf/wesolowski.rs
@@ -205,7 +205,7 @@ fn hash_prime(seed: &[u8], length: usize, bitmask: &[usize]) -> FastCryptoResult
 
 impl Discriminant {
     /// Compute a valid discriminant (aka a negative prime equal to 3 mod 4) based on the given seed.
-    pub(crate) fn from_seed(seed: &[u8], length: usize) -> FastCryptoResult<Self> {
+    fn from_seed(seed: &[u8], length: usize) -> FastCryptoResult<Self> {
         Self::try_from(hash_prime(seed, length, &[0, 1, 2, length - 1])?.neg())
     }
 }


### PR DESCRIPTION
Allow discriminants of arbitrary sizes while maintaining compatibility with chiavdf if the size is 1024 bits. Also add the possibility to use a string Fiat-Shamir construction in the VDF implementation.