### PR TITLE
Pull `fastcrypto-tbls` out of `experimental` feature

### DIFF
--- a/fastcrypto-tbls/Cargo.toml
+++ b/fastcrypto-tbls/Cargo.toml
@@ -9,7 +9,7 @@ description = "Threshold BLS and DKG protocols"
 repository = "https://github.com/MystenLabs/fastcrypto"
 
 [dependencies]
-fastcrypto = { path = "../fastcrypto", features = ["experimental"]}
+fastcrypto = { path = "../fastcrypto", features = ["beacon-dkg"]}
 fastcrypto-derive = { path = "../fastcrypto-derive" }
 
 zeroize.workspace = true
@@ -30,23 +30,18 @@ criterion = "0.4.0"
 [[bench]]
 name = "polynomial"
 harness = false
-required-features = ["experimental"]
 
 [[bench]]
 name = "dkg"
 harness = false
-required-features = ["experimental"]
 
 [[bench]]
 name = "nidkg"
 harness = false
-required-features = ["experimental"]
 
 [[bench]]
 name = "tbls"
 harness = false
-required-features = ["experimental"]
 
 [features]
 default = []
-experimental = []

--- a/fastcrypto-tbls/README.md
+++ b/fastcrypto-tbls/README.md
@@ -1,6 +1,6 @@
 # fastcrypto-tbls
 
-An experimental crate that implements threshold BLS (tBLS) and distributed key generation (DKG) protocols.
+A crate that implements threshold BLS (tBLS) and distributed key generation (DKG) protocols.
 
 Currently, it only provides a fake object for creating the outputs of the DKG protocol.
 

--- a/fastcrypto-tbls/src/lib.rs
+++ b/fastcrypto-tbls/src/lib.rs
@@ -8,11 +8,10 @@
     rust_2021_compatibility
 )]
 
-//! An experimental crate that implements threshold BLS (tBLS) and distributed key generation (DKG)
+//! A crate that implements threshold BLS (tBLS) and distributed key generation (DKG)
 //! protocols.
 
 // This is a hack for not repeating the conditional compilation for each module.
-#[cfg(any(test, feature = "experimental"))]
 #[path = ""]
 mod tbls_modules {
     pub mod dkg;
@@ -28,7 +27,6 @@ mod tbls_modules {
     pub mod types;
 }
 
-#[cfg(any(test, feature = "experimental"))]
 pub use tbls_modules::*;
 
 #[cfg(test)]

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -93,6 +93,7 @@ name = "hash"
 harness = false
 
 [features]
+beacon-dkg = []
 default = []
 copy_key = []
 unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -87,7 +87,7 @@ pub mod secp256r1_group_tests;
 
 pub mod traits;
 
-#[cfg(any(test, feature = "experimental"))]
+#[cfg(any(test, feature = "experimental", feature = "beacon-dkg"))]
 pub mod aes;
 pub mod bls12381;
 #[cfg(any(test, feature = "experimental"))]


### PR DESCRIPTION
Adds `beacon-dkg` flag in `fastcrypto` for dependencies.