### PR TITLE
DKG: clean interfaces

### DIFF
--- a/fastcrypto-tbls/src/dkg.rs
+++ b/fastcrypto-tbls/src/dkg.rs
@@ -111,6 +111,8 @@ impl<G: GroupElement, EG: GroupElement> VerifiedProcessedMessages<G, EG> {
 
 /// [Output] is the final output of the DKG protocol in case it runs
 /// successfully. It can be used later with [ThresholdBls], see examples in tests.
+///
+/// If shares is None, the object can only be used for verifying (partial and full) signatures.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Output<G: GroupElement, EG: GroupElement> {
     pub nodes: Nodes<EG>,
@@ -328,7 +330,7 @@ where
     ///    least t honest nodes have valid shares.
     ///
     ///    Returns NotEnoughInputs if the threshold minimal_threshold is not met.
-    pub fn process_confirmations<R: AllowedRng>(
+    pub(crate) fn process_confirmations<R: AllowedRng>(
         &self,
         messages: &UsedProcessedMessages<G, EG>,
         confirmations: &[Confirmation<EG>],
@@ -425,7 +427,7 @@ where
     }
 
     /// 8. Aggregate the valid shares (as returned from the previous step) and the public key.
-    pub fn aggregate(&self, messages: &VerifiedProcessedMessages<G, EG>) -> Output<G, EG> {
+    pub(crate) fn aggregate(&self, messages: &VerifiedProcessedMessages<G, EG>) -> Output<G, EG> {
         let id_to_m1 = messages
             .0
             .iter()

--- a/fastcrypto-tbls/src/dkg.rs
+++ b/fastcrypto-tbls/src/dkg.rs
@@ -87,7 +87,7 @@ impl<G: GroupElement, EG: GroupElement> From<&[ProcessedMessage<G, EG>]>
         let filtered = msgs
             .iter()
             .unique_by(|&m| m.message.sender)
-            .map(|m| m.clone())
+            .cloned()
             .collect::<Vec<_>>();
         Self(filtered)
     }
@@ -103,7 +103,7 @@ impl<G: GroupElement, EG: GroupElement> VerifiedProcessedMessages<G, EG> {
             .0
             .iter()
             .filter(|m| !to_exclude.contains(&m.message.sender))
-            .map(|m| m.clone())
+            .cloned()
             .collect::<Vec<_>>();
         Self(filtered)
     }

--- a/fastcrypto-tbls/src/dkg.rs
+++ b/fastcrypto-tbls/src/dkg.rs
@@ -329,6 +329,7 @@ where
     ///    minimal_threshold is the minimal number of second round messages we expect. Its value is
     ///    application dependent but in most cases it should be at least t+f to guarantee that at
     ///    least t honest nodes have valid shares.
+    ///
     ///    Returns NotEnoughInputs if the threshold minimal_threshold is not met.
     pub fn process_confirmations<R: AllowedRng>(
         &self,
@@ -469,28 +470,18 @@ where
         }
     }
 
-    // pub fn finish<R: AllowedRng>(
-    //     &self,
-    //     first_messages: &[Message<G, EG>],
-    //     confirmations: &[Confirmation<EG>],
-    //     minimal_threshold: u32,
-    //     rng: &mut R,
-    // ) -> FastCryptoResult<Output<G, EG>> {
-    //     let (shares, conf) = self.merge(
-    //         &first_messages
-    //             .iter()
-    //             .map(|m| self.process_message(m.clone(), rng).unwrap())
-    //             .collect::<Vec<_>>(),
-    //     )?;
-    //     let shares = self.process_confirmations(
-    //         first_messages,
-    //         confirmations,
-    //         shares,
-    //         minimal_threshold,
-    //         rng,
-    //     )?;
-    //     Ok(self.aggregate(first_messages, shares))
-    // }
+    /// Execute the previous two steps together.
+    pub fn complete<R: AllowedRng>(
+        &self,
+        messages: &UsedProcessedMessages<G, EG>,
+        confirmations: &[Confirmation<EG>],
+        minimal_threshold: u32,
+        rng: &mut R,
+    ) -> FastCryptoResult<Output<G, EG>> {
+        let verified_messages =
+            self.process_confirmations(messages, confirmations, minimal_threshold, rng)?;
+        Ok(self.aggregate(&verified_messages))
+    }
 
     fn decrypt_and_get_share(
         sk: &ecies::PrivateKey<EG>,

--- a/fastcrypto-tbls/src/dl_verification.rs
+++ b/fastcrypto-tbls/src/dl_verification.rs
@@ -176,6 +176,5 @@ pub fn verify_equal_exponents<R: AllowedRng>(
 }
 
 pub fn get_random_scalars<S: Scalar, R: AllowedRng>(n: u32, rng: &mut R) -> Vec<S> {
-    // TODO: can use 40 bits instead of 64 ("& 0x000F_FFFF_FFFF_FFFF" below)
     (0..n).map(|_| S::from(rng.next_u64())).collect::<Vec<_>>()
 }

--- a/fastcrypto-tbls/src/ecies.rs
+++ b/fastcrypto-tbls/src/ecies.rs
@@ -22,6 +22,7 @@ use typenum::consts::{U16, U32};
 /// APIs that use a random oracle must receive one as an argument. That RO must be unique and thus
 /// the caller should initialize/derive it using a unique prefix.
 
+// TODO: Use ZeroizeOnDrop.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrivateKey<G: GroupElement>(G::ScalarType);
 

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -7,6 +7,7 @@ use fastcrypto::error::FastCryptoError::InvalidInput;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::GroupElement;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::iter::Map;
 use std::ops::RangeInclusive;
 
@@ -23,6 +24,7 @@ pub struct Node<G: GroupElement> {
 pub struct Nodes<G: GroupElement> {
     nodes: Vec<Node<G>>,
     n: u32, // share ids are 1..n
+    share_id_to_party_id: HashMap<ShareIndex, PartyId>,
 }
 
 impl<G: GroupElement> Nodes<G> {
@@ -36,7 +38,27 @@ impl<G: GroupElement> Nodes<G> {
         }
         // Get the total weight of the nodes
         let n = nodes.iter().map(|n| n.weight as u32).sum::<u32>();
-        Ok(Self { nodes, n })
+
+        let share_id_to_party_id = Self::get_share_id_to_party_id(&nodes);
+
+        Ok(Self {
+            nodes,
+            n,
+            share_id_to_party_id,
+        })
+    }
+
+    fn get_share_id_to_party_id(nodes: &Vec<Node<G>>) -> HashMap<ShareIndex, PartyId> {
+        let mut curr_share_id = 1;
+        let mut share_id_to_party_id = HashMap::new();
+        for n in nodes {
+            for _ in 1..=n.weight {
+                let share_id = ShareIndex::new(curr_share_id).expect("nonzero");
+                share_id_to_party_id.insert(share_id, n.id);
+                curr_share_id += 1;
+            }
+        }
+        share_id_to_party_id
     }
 
     /// Total weight of the nodes.
@@ -56,16 +78,10 @@ impl<G: GroupElement> Nodes<G> {
 
     /// Get the node corresponding to a share id.
     pub fn share_id_to_node(&self, share_id: &ShareIndex) -> FastCryptoResult<&Node<G>> {
-        // TODO: [perf opt] Cache this
-        let mut curr_share_id = 1;
-        for n in &self.nodes {
-            if curr_share_id <= share_id.get() && share_id.get() < curr_share_id + (n.weight as u32)
-            {
-                return Ok(n);
-            }
-            curr_share_id += n.weight as u32;
-        }
-        Err(FastCryptoError::InvalidInput)
+        self.share_id_to_party_id
+            .get(share_id)
+            .map(|id| self.node_id_to_node(*id))
+            .ok_or(FastCryptoError::InvalidInput)?
     }
 
     pub fn node_id_to_node(&self, party_id: PartyId) -> FastCryptoResult<&Node<G>> {
@@ -113,8 +129,16 @@ impl<G: GroupElement> Nodes<G> {
                 weight: n.weight / max_d,
             })
             .collect::<Vec<_>>();
+        let share_id_to_party_id = Self::get_share_id_to_party_id(&nodes);
         let n = nodes.iter().map(|n| n.weight as u32).sum::<u32>();
         let new_t = t / max_d + (t % max_d != 0) as u16;
-        (Self { nodes, n }, new_t)
+        (
+            Self {
+                nodes,
+                n,
+                share_id_to_party_id,
+            },
+            new_t,
+        )
     }
 }

--- a/fastcrypto-tbls/src/polynomial.rs
+++ b/fastcrypto-tbls/src/polynomial.rs
@@ -86,8 +86,8 @@ impl<C: GroupElement> Poly<C> {
         t: u32,
         shares: &[Eval<C>],
     ) -> FastCryptoResult<Vec<C::ScalarType>> {
-        if shares.len() < t.try_into().unwrap() {
-            return Err(FastCryptoError::InvalidInput);
+        if shares.len() < t as usize {
+            return Err(FastCryptoError::NotEnoughInputs);
         }
         // Check for duplicates.
         let mut ids_set = HashSet::new();
@@ -95,7 +95,7 @@ impl<C: GroupElement> Poly<C> {
             ids_set.insert(id);
         });
         if ids_set.len() != shares.len() {
-            return Err(FastCryptoError::InvalidInput);
+            return Err(FastCryptoError::InvalidInput); // expected unique ids
         }
 
         let indices = shares

--- a/fastcrypto-tbls/src/tbls.rs
+++ b/fastcrypto-tbls/src/tbls.rs
@@ -104,8 +104,8 @@ pub trait ThresholdBls {
         let unique_partials = partials
             .iter()
             .unique_by(|p| p.index)
-            .map(|m| m.clone())
             .take(threshold as usize)
+            .cloned()
             .collect::<Vec<_>>();
         // No conversion is required since PartialSignature<S> and Eval<S> are different aliases to
         // IndexedValue<S>.

--- a/fastcrypto-tbls/src/tests/dkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_tests.rs
@@ -128,9 +128,9 @@ fn test_dkg_e2e_4_parties_threshold_2() {
     let o3 = d3.aggregate(&ver_msg3);
 
     // Use the shares from 01 and o4 to sign a message.
-    let sig00 = S::partial_sign(&o0.shares[0], &MSG);
-    let sig30 = S::partial_sign(&o3.shares[0], &MSG);
-    let sig31 = S::partial_sign(&o3.shares[1], &MSG);
+    let sig00 = S::partial_sign(&o0.shares.as_ref().unwrap()[0], &MSG);
+    let sig30 = S::partial_sign(&o3.shares.as_ref().unwrap()[0], &MSG);
+    let sig31 = S::partial_sign(&o3.shares.as_ref().unwrap()[1], &MSG);
 
     S::partial_verify(&o0.vss_pk, &MSG, &sig00).unwrap();
     S::partial_verify(&o3.vss_pk, &MSG, &sig30).unwrap();

--- a/fastcrypto-tbls/src/tests/dkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_tests.rs
@@ -81,34 +81,25 @@ fn test_dkg_e2e_4_parties_threshold_2() {
 
     let r1_all = vec![msg0, msg1];
 
-    let (shares0, conf0) = d0
-        .merge(
-            &r1_all
-                .iter()
-                .map(|m| d0.process_message(m.clone(), &mut thread_rng()).unwrap())
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
+    let proc_msg0 = &r1_all
+        .iter()
+        .map(|m| d0.process_message(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf0, used_msgs0) = d0.merge(proc_msg0).unwrap();
 
-    let (shares1, conf1) = d1
-        .merge(
-            &r1_all
-                .iter()
-                .map(|m| d1.process_message(m.clone(), &mut thread_rng()).unwrap())
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
+    let proc_msg1 = &r1_all
+        .iter()
+        .map(|m| d1.process_message(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf1, used_msgs1) = d1.merge(proc_msg1).unwrap();
 
     // Note that d3's first round message is not included but it should still be able to receive
     // shares and post complaints.
-    let (shares3, conf3) = d3
-        .merge(
-            &r1_all
-                .iter()
-                .map(|m| d3.process_message(m.clone(), &mut thread_rng()).unwrap())
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
+    let proc_msg3 = &r1_all
+        .iter()
+        .map(|m| d3.process_message(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf3, used_msgs3) = d3.merge(proc_msg3).unwrap();
 
     // There should be some complaints on the first messages of d1.
     assert!(
@@ -122,24 +113,19 @@ fn test_dkg_e2e_4_parties_threshold_2() {
     );
 
     let r2_all = vec![conf0, conf1, conf3];
-    let shares0 = d1
-        .process_confirmations(&r1_all, &r2_all, shares0, 3, &mut thread_rng())
+    let ver_msg0 = d1
+        .process_confirmations(&used_msgs0, &r2_all, 3, &mut thread_rng())
         .unwrap();
-    let shares1 = d1
-        .process_confirmations(&r1_all, &r2_all, shares1, 3, &mut thread_rng())
+    let ver_msg1 = d1
+        .process_confirmations(&used_msgs1, &r2_all, 3, &mut thread_rng())
         .unwrap();
-    let shares3 = d3
-        .process_confirmations(&r1_all, &r2_all, shares3, 3, &mut thread_rng())
+    let ver_msg3 = d3
+        .process_confirmations(&used_msgs3, &r2_all, 3, &mut thread_rng())
         .unwrap();
 
-    // Only the first message of d0 passed all tests -> only one vss is used.
-    assert_eq!(shares0.len(), 1);
-    assert_eq!(shares1.len(), 1);
-    assert_eq!(shares3.len(), 1);
-
-    let o0 = d0.aggregate(&r1_all, shares0);
-    let _o1 = d1.aggregate(&r1_all, shares1);
-    let o3 = d3.aggregate(&r1_all, shares3);
+    let o0 = d0.aggregate(&ver_msg0);
+    let _o1 = d1.aggregate(&ver_msg1);
+    let o3 = d3.aggregate(&ver_msg3);
 
     // Use the shares from 01 and o4 to sign a message.
     let sig00 = S::partial_sign(&o0.shares[0], &MSG);

--- a/fastcrypto/src/error.rs
+++ b/fastcrypto/src/error.rs
@@ -40,9 +40,13 @@ pub enum FastCryptoError {
     #[error("Invalid proof was given to the function")]
     InvalidProof,
 
-    /// Not enough inputs were given to the function
-    #[error("Not enough inputs were given to the function")]
+    /// Not enough inputs were given to the function, retry with more
+    #[error("Not enough inputs were given to the function, retry with more")]
     NotEnoughInputs,
+
+    /// Invalid message was given to the function
+    #[error("Invalid message was given to the function")]
+    InvalidMessage,
 
     /// General cryptographic error.
     #[error("General cryptographic error: {0}")]

--- a/fastcrypto/src/error.rs
+++ b/fastcrypto/src/error.rs
@@ -40,6 +40,10 @@ pub enum FastCryptoError {
     #[error("Invalid proof was given to the function")]
     InvalidProof,
 
+    /// Not enough inputs were given to the function
+    #[error("Not enough inputs were given to the function")]
+    NotEnoughInputs,
+
     /// General cryptographic error.
     #[error("General cryptographic error: {0}")]
     GeneralError(String),

--- a/fastcrypto/src/error.rs
+++ b/fastcrypto/src/error.rs
@@ -48,10 +48,6 @@ pub enum FastCryptoError {
     #[error("Invalid message was given to the function")]
     InvalidMessage,
 
-    /// Party does not have a valid share
-    #[error("Party does not have a valid share")]
-    NoValidShare,
-
     /// General cryptographic error.
     #[error("General cryptographic error: {0}")]
     GeneralError(String),

--- a/fastcrypto/src/error.rs
+++ b/fastcrypto/src/error.rs
@@ -48,6 +48,10 @@ pub enum FastCryptoError {
     #[error("Invalid message was given to the function")]
     InvalidMessage,
 
+    /// Party does not have a valid share
+    #[error("Party does not have a valid share")]
+    NoValidShare,
+
     /// General cryptographic error.
     #[error("General cryptographic error: {0}")]
     GeneralError(String),


### PR DESCRIPTION
- Introduce `complete` that combines `process_confirmations` and `aggregate`
- `merge` returns `NotEnoughInputs` in case the threshold is not yet met
- `process_message` returns an error for invalid messages (which could be skipped)
- `process_confirmations` returns `NotEnoughInputs` in case the threshold is not yet met
- `aggregate` returns `None` as the shares if the party doesn't have valid shares from the DKG (and thus cannot participate in the randomness generation)
- Fix TODOs