### PR TITLE
ThresholdBls: accept Iterator directly where possible

### DIFF
--- a/fastcrypto-tbls/benches/tbls.rs
+++ b/fastcrypto-tbls/benches/tbls.rs
@@ -25,7 +25,7 @@ mod tbls_benches {
                     .collect::<Vec<_>>();
 
                 create.bench_function(format!("w={}", w).as_str(), |b| {
-                    b.iter(|| ThresholdBls12381MinSig::partial_sign_batch(&shares, msg))
+                    b.iter(|| ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg))
                 });
             }
         }
@@ -39,10 +39,10 @@ mod tbls_benches {
                     .map(|i| private_poly.eval(NonZeroU32::new(i as u32).unwrap()))
                     .collect::<Vec<_>>();
 
-                let sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+                let sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
 
                 create.bench_function(format!("w={}", w).as_str(), |b| {
-                    b.iter(|| ThresholdBls12381MinSig::aggregate(w as u32, &sigs).unwrap())
+                    b.iter(|| ThresholdBls12381MinSig::aggregate(w as u32, sigs.iter()).unwrap())
                 });
             }
         }

--- a/fastcrypto-tbls/src/nidkg.rs
+++ b/fastcrypto-tbls/src/nidkg.rs
@@ -332,9 +332,8 @@ where
             .map(|(i, pk)| Eval {
                 index: NonZeroU32::new((i + 1) as u32).expect("non zero"),
                 value: *pk,
-            })
-            .collect::<Vec<Eval<G>>>();
-        let pk = Poly::<G>::recover_c0(self.t, &evals).expect("enough shares");
+            });
+        let pk = Poly::<G>::recover_c0(self.t, evals).expect("enough shares");
 
         (pk, partial_pks)
     }

--- a/fastcrypto-tbls/src/tbls.rs
+++ b/fastcrypto-tbls/src/tbls.rs
@@ -4,10 +4,12 @@
 // Some of the code below is based on code from https://github.com/celo-org/celo-threshold-bls-rs,
 // modified for our needs.
 
+use std::borrow::Borrow;
+
 use crate::dl_verification::{batch_coefficients, get_random_scalars};
 use crate::polynomial::Poly;
 use crate::types::IndexedValue;
-use fastcrypto::error::{FastCryptoError, FastCryptoResult};
+use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::{GroupElement, HashToGroupElement, MultiScalarMul, Scalar};
 use fastcrypto::traits::AllowedRng;
 use itertools::Itertools;
@@ -29,20 +31,22 @@ pub trait ThresholdBls {
 
     /// Sign a message using the private share/partial key.
     fn partial_sign(share: &Share<Self::Private>, msg: &[u8]) -> PartialSignature<Self::Signature> {
-        Self::partial_sign_batch(&[share.clone()], msg)[0].clone()
+        Self::partial_sign_batch(std::iter::once(share), msg)[0].clone()
     }
 
     /// Sign a message using one of more private share/partial keys.
     fn partial_sign_batch(
-        shares: &[Share<Self::Private>],
+        shares: impl Iterator<Item = impl Borrow<Share<Self::Private>>>,
         msg: &[u8],
     ) -> Vec<PartialSignature<Self::Signature>> {
         let h = Self::Signature::hash_to_group_element(msg);
         shares
-            .iter()
-            .map(|share| PartialSignature {
-                index: share.index,
-                value: h * share.value,
+            .map(|share| {
+                let share = share.borrow();
+                PartialSignature {
+                    index: share.index,
+                    value: h * share.value,
+                }
             })
             .collect()
     }
@@ -63,26 +67,24 @@ pub trait ThresholdBls {
     fn partial_verify_batch<R: AllowedRng>(
         vss_pk: &Poly<Self::Public>,
         msg: &[u8],
-        partial_sigs: &[PartialSignature<Self::Signature>],
+        partial_sigs: impl Iterator<Item = impl Borrow<PartialSignature<Self::Signature>>>,
         rng: &mut R,
     ) -> FastCryptoResult<()> {
         assert!(vss_pk.degree() > 0 || !msg.is_empty());
-        if partial_sigs.is_empty() {
+        let (evals_as_scalars, points): (Vec<_>, Vec<_>) = partial_sigs
+            .map(|sig| {
+                let sig = sig.borrow();
+                (Self::Private::from(sig.index.get().into()), sig.value)
+            })
+            .unzip();
+        if points.is_empty() {
             return Ok(());
         }
-        let rs = get_random_scalars::<Self::Private, R>(partial_sigs.len() as u32, rng);
-        let evals_as_scalars = partial_sigs
-            .iter()
-            .map(|e| Self::Private::from(e.index.get().into()))
-            .collect::<Vec<_>>();
+        let rs = get_random_scalars::<Self::Private, R>(points.len() as u32, rng);
         // TODO: should we cache it instead? that would replace t-wide msm with w-wide msm.
         let coeffs = batch_coefficients(&rs, &evals_as_scalars, vss_pk.degree());
         let pk = Self::Public::multi_scalar_mul(&coeffs, vss_pk.as_vec()).expect("sizes match");
-        let aggregated_sig = Self::Signature::multi_scalar_mul(
-            &rs,
-            &partial_sigs.iter().map(|s| s.value).collect::<Vec<_>>(),
-        )
-        .expect("sizes match");
+        let aggregated_sig = Self::Signature::multi_scalar_mul(&rs, &points).expect("sizes match");
 
         Self::verify(&pk, msg, &aggregated_sig)
     }
@@ -90,19 +92,17 @@ pub trait ThresholdBls {
     /// Interpolate partial signatures to recover the full signature.
     fn aggregate(
         threshold: u32,
-        partials: &[PartialSignature<Self::Signature>],
+        partials: impl Iterator<Item = impl Borrow<PartialSignature<Self::Signature>>> + Clone,
     ) -> FastCryptoResult<Self::Signature> {
         let unique_partials = partials
-            .iter()
-            .unique_by(|p| p.index)
-            .take(threshold as usize)
-            .cloned()
-            .collect::<Vec<_>>();
-        if unique_partials.len() != threshold as usize {
-            return Err(FastCryptoError::NotEnoughInputs);
-        }
+            .unique_by(|p| p.borrow().index)
+            .take(threshold as usize);
+        // TODO-DNS: I think this can be removed because it's already verified in `get_lagrange_coefficients_for_c0`, correct?
+        // if unique_partials.len() != threshold as usize {
+        //     return Err(FastCryptoError::NotEnoughInputs);
+        // }
         // No conversion is required since PartialSignature<S> and Eval<S> are different aliases to
         // IndexedValue<S>.
-        Poly::<Self::Signature>::recover_c0_msm(threshold, &unique_partials)
+        Poly::<Self::Signature>::recover_c0_msm(threshold, unique_partials)
     }
 }

--- a/fastcrypto-tbls/src/tbls.rs
+++ b/fastcrypto-tbls/src/tbls.rs
@@ -9,7 +9,7 @@ use std::borrow::Borrow;
 use crate::dl_verification::{batch_coefficients, get_random_scalars};
 use crate::polynomial::Poly;
 use crate::types::IndexedValue;
-use fastcrypto::error::FastCryptoResult;
+use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{GroupElement, HashToGroupElement, MultiScalarMul, Scalar};
 use fastcrypto::traits::AllowedRng;
 use itertools::Itertools;
@@ -97,10 +97,9 @@ pub trait ThresholdBls {
         let unique_partials = partials
             .unique_by(|p| p.borrow().index)
             .take(threshold as usize);
-        // TODO-DNS: I think this can be removed because it's already verified in `get_lagrange_coefficients_for_c0`, correct?
-        // if unique_partials.len() != threshold as usize {
-        //     return Err(FastCryptoError::NotEnoughInputs);
-        // }
+        if unique_partials.clone().count() != threshold as usize {
+            return Err(FastCryptoError::NotEnoughInputs);
+        }
         // No conversion is required since PartialSignature<S> and Eval<S> are different aliases to
         // IndexedValue<S>.
         Poly::<Self::Signature>::recover_c0_msm(threshold, unique_partials)

--- a/fastcrypto-tbls/src/tests/dkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_tests.rs
@@ -237,7 +237,7 @@ fn test_dkg_e2e_5_parties_min_weight_2_threshold_4() {
     S::partial_verify(&o3.vss_pk, &MSG, &sig31).unwrap();
 
     let sigs = vec![sig00, sig30, sig31];
-    let sig = S::aggregate(d0.t(), &sigs).unwrap();
+    let sig = S::aggregate(d0.t(), sigs.iter()).unwrap();
     S::verify(o0.vss_pk.c0(), &MSG, &sig).unwrap();
 }
 

--- a/fastcrypto-tbls/src/tests/polynomial_tests.rs
+++ b/fastcrypto-tbls/src/tests/polynomial_tests.rs
@@ -73,7 +73,6 @@ mod scalar_tests {
         for _ in 0..10 {
             shares.shuffle(&mut thread_rng());
             let used_shares = shares.iter().take(124);
-            // TODO-DNS verify
             assert_eq!(c0, &Poly::<S>::recover_c0(124, used_shares).unwrap());
         }
     }

--- a/fastcrypto-tbls/src/tests/polynomial_tests.rs
+++ b/fastcrypto-tbls/src/tests/polynomial_tests.rs
@@ -53,16 +53,13 @@ mod scalar_tests {
         let threshold = degree + 1;
         let poly = Poly::<S>::rand(4, &mut thread_rng());
         // insufficient shares gathered
-        let shares = (1..threshold)
-            .map(|i| poly.eval(ShareIndex::new(i).unwrap()))
-            .collect::<Vec<_>>();
-        Poly::<S>::recover_c0(threshold, &shares).unwrap_err();
+        let shares = (1..threshold).map(|i| poly.eval(ShareIndex::new(i).unwrap()));
+        Poly::<S>::recover_c0(threshold, shares).unwrap_err();
         // duplications
-        let mut shares = (1..=threshold)
+        let shares = (1..=threshold)
             .map(|i| poly.eval(ShareIndex::new(i).unwrap()))
-            .collect::<Vec<_>>();
-        shares.push(shares[0].clone());
-        Poly::<S>::recover_c0(threshold, &shares).unwrap_err();
+            .chain(std::iter::once(poly.eval(ShareIndex::new(1).unwrap()))); // duplicate value 1
+        Poly::<S>::recover_c0(threshold, shares).unwrap_err();
     }
 
     #[test]
@@ -75,7 +72,8 @@ mod scalar_tests {
         let c0 = poly.c0();
         for _ in 0..10 {
             shares.shuffle(&mut thread_rng());
-            let used_shares = &shares[..124];
+            let used_shares = shares.iter().take(124);
+            // TODO-DNS verify
             assert_eq!(c0, &Poly::<S>::recover_c0(124, used_shares).unwrap());
         }
     }
@@ -112,7 +110,10 @@ mod points_tests {
         let s2 = p.eval(NonZeroU32::new(20).unwrap());
         let s3 = p.eval(NonZeroU32::new(30).unwrap());
         let shares = vec![s1, s2, s3];
-        assert_eq!(Poly::<G::ScalarType>::recover_c0(3, &shares).unwrap(), one);
+        assert_eq!(
+            Poly::<G::ScalarType>::recover_c0(3, shares.iter()).unwrap(),
+            one
+        );
     }
 
     #[test]
@@ -122,16 +123,13 @@ mod points_tests {
         let poly = Poly::<G::ScalarType>::rand(4, &mut thread_rng());
         let poly_g = poly.commit();
         // insufficient shares gathered
+        let shares = (1..threshold).map(|i| poly_g.eval(ShareIndex::new(i).unwrap()));
+        Poly::<G>::recover_c0_msm(threshold, shares).unwrap_err();
+        // duplications
         let shares = (1..threshold)
             .map(|i| poly_g.eval(ShareIndex::new(i).unwrap()))
-            .collect::<Vec<_>>();
-        Poly::<G>::recover_c0_msm(threshold, &shares).unwrap_err();
-        // duplications
-        let mut shares = (1..threshold)
-            .map(|i| poly_g.eval(ShareIndex::new(i).unwrap()))
-            .collect::<Vec<_>>();
-        shares.push(shares[0].clone());
-        Poly::<G>::recover_c0_msm(threshold, &shares).unwrap_err();
+            .chain(std::iter::once(poly_g.eval(ShareIndex::new(1).unwrap()))); // duplicate value 1
+        Poly::<G>::recover_c0_msm(threshold, shares).unwrap_err();
     }
 
     #[test]
@@ -144,7 +142,7 @@ mod points_tests {
         let s2 = p.eval(NonZeroU32::new(20).unwrap());
         let s3 = p.eval(NonZeroU32::new(30).unwrap());
         let shares = vec![s1, s2, s3];
-        assert_eq!(Poly::<G>::recover_c0_msm(3, &shares).unwrap(), one);
+        assert_eq!(Poly::<G>::recover_c0_msm(3, shares.iter()).unwrap(), one);
 
         // and random tests
         let poly = Poly::<G::ScalarType>::rand(123, &mut thread_rng());
@@ -156,7 +154,7 @@ mod points_tests {
         let c0 = poly_g.c0();
         for _ in 0..10 {
             shares.shuffle(&mut thread_rng());
-            let used_shares = &shares[..124];
+            let used_shares = shares.iter().take(124);
             assert_eq!(c0, &Poly::<G>::recover_c0_msm(124, used_shares).unwrap());
         }
     }

--- a/fastcrypto-tbls/src/tests/tbls_tests.rs
+++ b/fastcrypto-tbls/src/tests/tbls_tests.rs
@@ -34,11 +34,11 @@ fn test_tbls_e2e() {
         ThresholdBls12381MinSig::partial_verify(&public_poly, b"other message", &sig1).is_err()
     );
     // Aggregate should fail if we don't have enough signatures.
-    assert!(ThresholdBls12381MinSig::aggregate(t, &[sig1.clone(), sig2.clone()]).is_err());
+    assert!(ThresholdBls12381MinSig::aggregate(t, [sig1.clone(), sig2.clone()].iter()).is_err());
 
     // Signatures should be the same no matter if calculated with the private key or from a
     // threshold of partial signatures.
-    let full_sig = ThresholdBls12381MinSig::aggregate(t, &[sig1, sig2, sig3]).unwrap();
+    let full_sig = ThresholdBls12381MinSig::aggregate(t, [sig1, sig2, sig3].iter()).unwrap();
     assert!(ThresholdBls12381MinSig::verify(public_poly.c0(), msg, &full_sig).is_ok());
     assert_eq!(
         full_sig,
@@ -69,26 +69,26 @@ fn test_partial_verify_batch() {
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &[],
+        [].iter(),
         &mut thread_rng()
     )
     .is_ok());
     // standard sigs should pass
-    let sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+    let sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_ok());
     // even if repeated
-    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
     sigs[0] = sigs[2].clone();
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_ok());
@@ -96,48 +96,48 @@ fn test_partial_verify_batch() {
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         b"other message",
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_err());
     // invalid signatures according to the polynomial should fail
-    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
     (sigs[0].index, sigs[1].index) = (sigs[1].index, sigs[0].index);
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_err());
     // identity as the signature should fail
-    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
     sigs[1].value = G1Element::zero();
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_err());
     // generator as the signature should fail
-    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
     sigs[1].value = G1Element::generator();
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_err());
     // even if the sum of sigs is ok, should fail since not consistent with the polynomial
-    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(&shares, msg);
+    let mut sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
     sigs[0].value -= G1Element::generator();
     sigs[1].value += G1Element::generator();
     assert!(ThresholdBls12381MinSig::partial_verify_batch(
         &public_poly,
         msg,
-        &sigs,
+        sigs.iter(),
         &mut thread_rng()
     )
     .is_err());


### PR DESCRIPTION
Instead of requiring a slice that we immediately and only call `iter()` on, accept the Iterator. This can enable clients to avoid extra copies.