### PR TITLE
Use Baillie-PSW primality test + trial divisions

### DIFF
--- a/fastcrypto-vdf/src/class_group/hash.rs
+++ b/fastcrypto-vdf/src/class_group/hash.rs
@@ -59,7 +59,7 @@ fn sample_modulus(
 
     // This heuristic bound ensures that there will be enough distinct primes to sample from, so we won't end up in an
     // infinite loop. Consult the paper for details on how to pick the parameters.
-    if k > (discriminant.bits() / 32) as u16 {
+    if k > (discriminant.bits() >> 5) as u16 {
         return Err(InvalidInput);
     }
 

--- a/fastcrypto-vdf/src/class_group/hash.rs
+++ b/fastcrypto-vdf/src/class_group/hash.rs
@@ -101,6 +101,7 @@ fn sample_modulus(
     let result = factors.iter().product();
     let square_root = solve_congruence_equation_system(&square_roots, &factors)
         .expect("The factors are distinct primes");
+
     Ok((result, square_root))
 }
 

--- a/fastcrypto-vdf/src/class_group/hash.rs
+++ b/fastcrypto-vdf/src/class_group/hash.rs
@@ -92,15 +92,15 @@ fn sample_modulus(
                 break;
             }
         }
-        // This should not err because the Jacobi symbol is checked in the loop.
-        let square_root = modular_square_root(discriminant.as_bigint(), &factor, false)?;
+        let square_root = modular_square_root(discriminant.as_bigint(), &factor, false)
+            .expect("Legendre symbol checked above");
         factors.push(factor);
         square_roots.push(square_root);
     }
 
-    // This should not err because the factors are distinct primes and hence pair-wise coprime.
-    let square_root = solve_congruence_equation_system(&square_roots, &factors)?;
     let result = factors.iter().product();
+    let square_root = solve_congruence_equation_system(&square_roots, &factors)
+        .expect("The factors are distinct primes");
     Ok((result, square_root))
 }
 

--- a/fastcrypto-vdf/src/class_group/hash.rs
+++ b/fastcrypto-vdf/src/class_group/hash.rs
@@ -57,15 +57,11 @@ fn sample_modulus(
         bound = bound.nth_root(k as u32);
     }
 
-    // This heuristic bound ensures that there will be enough distinct primes to sample from so we wont end up in an
+    // This heuristic bound ensures that there will be enough distinct primes to sample from, so we won't end up in an
     // infinite loop. Consult the paper for details on how to pick the parameters.
-    if k > (discriminant.bits() >> 5) as u16 {
+    if k > (discriminant.bits() / 32) as u16 {
         return Err(InvalidInput);
     }
-
-    // If k is small, we can skip the duplicate check because they will only happen with negligible probability,
-    // approximately ~2^{-40}. Consult the paper for details.
-    let check_duplicates = k >= (discriminant.bits() / 100) as u16;
 
     // Seed a rng with the hash of the seed
     let mut rng = ChaCha8Rng::from_seed(Sha256::digest(seed).digest);
@@ -77,7 +73,13 @@ fn sample_modulus(
         loop {
             factor = sample_odd_number(&bound, &mut rng);
 
-            if check_duplicates && factors.contains(&factor) {
+            if factors.contains(&factor) {
+                continue;
+            }
+
+            // The primality check does not try divisions with small primes, so we do it here. This speeds up the
+            // algorithm significantly.
+            if !trial_division(&factor, &PRIMES) {
                 continue;
             }
 
@@ -90,16 +92,15 @@ fn sample_modulus(
                 break;
             }
         }
-        let square_root = modular_square_root(discriminant.as_bigint(), &factor, false)
-            .expect("Legendre symbol checked above");
+        // This should not err because the Jacobi symbol is checked in the loop.
+        let square_root = modular_square_root(discriminant.as_bigint(), &factor, false)?;
         factors.push(factor);
         square_roots.push(square_root);
     }
 
+    // This should not err because the factors are distinct primes and hence pair-wise coprime.
+    let square_root = solve_congruence_equation_system(&square_roots, &factors)?;
     let result = factors.iter().product();
-    let square_root = solve_congruence_equation_system(&square_roots, &factors)
-        .expect("The factors are distinct primes");
-
     Ok((result, square_root))
 }
 
@@ -109,4 +110,19 @@ fn sample_odd_number<R: Rng>(bound: &BigInt, rng: &mut R) -> BigInt {
     a.shl_assign(1);
     a.add_assign(1);
     a
+}
+
+/// The odd primes smaller than 100.
+const PRIMES: [u64; 24] = [
+    3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+];
+
+/// Perform trial division on `n` with the given primes. Returns true if neither of the divisors divide `n`
+fn trial_division(n: &BigInt, divisors: &[u64]) -> bool {
+    for p in divisors {
+        if n.is_multiple_of(&BigInt::from(*p)) {
+            return false;
+        }
+    }
+    true
 }

--- a/fastcrypto-vdf/src/math/hash_prime.rs
+++ b/fastcrypto-vdf/src/math/hash_prime.rs
@@ -102,8 +102,9 @@ mod tests {
         assert_eq!(BigUint::from(3u64), prime.mod_floor(&BigUint::from(4u64)));
 
         // The result is a prime, even when checking with a stricter test
-        assert!(is_prime(&prime, Some(PrimalityTestConfig::strict())).probably());
-
+        assert!(
+            num_prime::nt_funcs::is_prime(&prime, Some(PrimalityTestConfig::strict())).probably()
+        );
         // Regression test
         assert_eq!(prime, BigUint::from_str("7904272817142338150419757415334055106926417574777773392214522399425467199262039794276651240832053626391864792937889238336287002167559810128294881253078163").unwrap());
     }

--- a/fastcrypto-vdf/src/math/hash_prime.rs
+++ b/fastcrypto-vdf/src/math/hash_prime.rs
@@ -105,6 +105,7 @@ mod tests {
         assert!(
             num_prime::nt_funcs::is_prime(&prime, Some(PrimalityTestConfig::strict())).probably()
         );
+        
         // Regression test
         assert_eq!(prime, BigUint::from_str("7904272817142338150419757415334055106926417574777773392214522399425467199262039794276651240832053626391864792937889238336287002167559810128294881253078163").unwrap());
     }

--- a/fastcrypto-vdf/src/math/hash_prime.rs
+++ b/fastcrypto-vdf/src/math/hash_prime.rs
@@ -105,7 +105,7 @@ mod tests {
         assert!(
             num_prime::nt_funcs::is_prime(&prime, Some(PrimalityTestConfig::strict())).probably()
         );
-        
+
         // Regression test
         assert_eq!(prime, BigUint::from_str("7904272817142338150419757415334055106926417574777773392214522399425467199262039794276651240832053626391864792937889238336287002167559810128294881253078163").unwrap());
     }


### PR DESCRIPTION
This PR makes a few changes to the VDF implemenation:
* Use Baillie-PSW primality test instead of Miller-Rabin. This is more secure when an adversary may influence the input, as it is in this case.
* Do trial division with some small primes first.
* Always check for duplicate factors, because duplicates, although unlikely, will cause a panic.