### PR TITLE
Make quadratic form coordinates public

### DIFF
--- a/fastcrypto-vdf/src/class_group/mod.rs
+++ b/fastcrypto-vdf/src/class_group/mod.rs
@@ -41,9 +41,9 @@ pub mod discriminant;
 /// the composition algorithm.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct QuadraticForm {
-    a: BigInt,
-    b: BigInt,
-    c: BigInt,
+    pub a: BigInt,
+    pub b: BigInt,
+    pub c: BigInt,
     partial_gcd_limit: BigInt,
 }
 


### PR DESCRIPTION
This makes integration from other libraries easier. It is for example used here: https://github.com/jonas-lj/class_group_tests.