### PR TITLE
Degrade num-traits crate

### DIFF
--- a/fastcrypto-vdf/Cargo.toml
+++ b/fastcrypto-vdf/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/MystenLabs/fastcrypto"
 [dependencies]
 fastcrypto = { path = "../fastcrypto" }
 num-bigint = "0.4.4"
-num-traits = "0.2.17"
+num-traits = "0.2.16"
 num-integer = "0.1.45"
 num-prime = { version = "0.4.3", features = ["big-int"] }
 rand = "0.8.5"


### PR DESCRIPTION
The num-traits dependency is also used (indirectly) in Sui in an fixed older version, so we need to degrade here to be compatible.