### PR TITLE
Speed up GCD computation

### DIFF
--- a/fastcrypto-vdf/src/class_group/mod.rs
+++ b/fastcrypto-vdf/src/class_group/mod.rs
@@ -165,6 +165,7 @@ impl QuadraticForm {
             a_divided_by_gcd: mut capital_cy,
             b_divided_by_gcd: mut capital_by,
         } = extended_euclidean_algorithm(u2, u1, true);
+        let b = b.unwrap();
 
         let (q, r) = s.div_rem(&f);
         let (g, capital_bx, capital_dy) = if r.is_zero() {

--- a/fastcrypto-vdf/src/class_group/mod.rs
+++ b/fastcrypto-vdf/src/class_group/mod.rs
@@ -5,7 +5,10 @@
 //! binary quadratic forms which forms a group under composition. Here we use additive notation
 //! for the composition.
 
-use crate::math::extended_gcd::{extended_euclidean_algorithm, EuclideanAlgorithmOutput};
+use crate::math::extended_gcd::{
+    extended_euclidean_algorithm, extended_euclidean_algorithm_partial, EuclideanAlgorithmOutput,
+    EuclideanAlgorithmOutputPartial,
+};
 use crate::{ParameterizedGroupElement, ToBytes, UnknownOrderGroupElement};
 use discriminant::Discriminant;
 use fastcrypto::error::FastCryptoError::InvalidInput;
@@ -171,13 +174,12 @@ impl QuadraticForm {
             (f, &m * &b, q)
         } else {
             // 3.
-            let EuclideanAlgorithmOutput {
+            let EuclideanAlgorithmOutputPartial {
                 gcd: g,
-                x: _,
                 y,
                 a_divided_by_gcd: h,
                 b_divided_by_gcd,
-            } = extended_euclidean_algorithm(&f, &s);
+            } = extended_euclidean_algorithm_partial(&f, &s);
             capital_by *= &h;
             capital_cy *= &h;
 
@@ -266,13 +268,12 @@ impl Doubling for QuadraticForm {
         let v = &self.b;
         let w = &self.c;
 
-        let EuclideanAlgorithmOutput {
+        let EuclideanAlgorithmOutputPartial {
             gcd: g,
-            x: _,
             y,
             a_divided_by_gcd: capital_by,
             b_divided_by_gcd: capital_dy,
-        } = extended_euclidean_algorithm(u, v);
+        } = extended_euclidean_algorithm_partial(u, v);
 
         let mut bx = (&y * w).mod_floor(&capital_by);
         let mut by = capital_by.clone();

--- a/fastcrypto-vdf/src/math/crt.rs
+++ b/fastcrypto-vdf/src/math/crt.rs
@@ -24,7 +24,7 @@ pub fn solve_simple_congruence_equation_system(
     }
 
     // The moduli must be relatively prime
-    let output = extended_euclidean_algorithm(p, q);
+    let output = extended_euclidean_algorithm(p, q, true);
     if !output.gcd.is_one() {
         return Err(InvalidInput);
     }

--- a/fastcrypto-vdf/src/math/crt.rs
+++ b/fastcrypto-vdf/src/math/crt.rs
@@ -32,7 +32,7 @@ pub fn solve_simple_congruence_equation_system(
     let a = a.mod_floor(p);
     let b = b.mod_floor(q);
 
-    let result = a * output.y * q + b * output.x * p;
+    let result = a * output.y * q + b * output.x.unwrap() * p;
 
     if result.is_negative() {
         Ok(result + &(p * q))

--- a/fastcrypto-vdf/src/math/extended_gcd.rs
+++ b/fastcrypto-vdf/src/math/extended_gcd.rs
@@ -15,7 +15,7 @@ use std::mem;
 /// and `y` such that `ax + by = gcd`. The quotients `a / gcd` and `b / gcd` are also returned.
 pub struct EuclideanAlgorithmOutput {
     pub gcd: BigInt,
-    pub x: BigInt,
+    pub x: Option<BigInt>,
     pub y: BigInt,
     pub a_divided_by_gcd: BigInt,
     pub b_divided_by_gcd: BigInt,
@@ -60,9 +60,9 @@ pub fn extended_euclidean_algorithm(
     };
 
     let x = if compute_x {
-        conditional_negate(negate, t.1)
+        Some(conditional_negate(negate, t.1))
     } else {
-        BigInt::zero()
+        None
     };
 
     EuclideanAlgorithmOutput {
@@ -90,13 +90,27 @@ fn test_xgcd() {
     test_xgcd_single(BigInt::from(-240), BigInt::from(46));
     test_xgcd_single(BigInt::from(240), BigInt::from(-46));
     test_xgcd_single(BigInt::from(-240), BigInt::from(-46));
+
+    test_xgcd_single_no_x(BigInt::from(240), BigInt::from(46));
+    test_xgcd_single_no_x(BigInt::from(-240), BigInt::from(46));
+    test_xgcd_single_no_x(BigInt::from(240), BigInt::from(-46));
+    test_xgcd_single_no_x(BigInt::from(-240), BigInt::from(-46));
 }
 
 #[cfg(test)]
 fn test_xgcd_single(a: BigInt, b: BigInt) {
     let output = extended_euclidean_algorithm(&a, &b, true);
     assert_eq!(output.gcd, a.gcd(&b));
-    assert_eq!(&output.x * &a + &output.y * &b, output.gcd);
+    assert_eq!(&output.x.unwrap() * &a + &output.y * &b, output.gcd);
+    assert_eq!(output.a_divided_by_gcd, &a / &output.gcd);
+    assert_eq!(output.b_divided_by_gcd, &b / &output.gcd);
+}
+
+#[cfg(test)]
+fn test_xgcd_single_no_x(a: BigInt, b: BigInt) {
+    let output = extended_euclidean_algorithm(&a, &b, false);
+    assert_eq!(output.gcd, a.gcd(&b));
+    assert!(output.x.is_none());
     assert_eq!(output.a_divided_by_gcd, &a / &output.gcd);
     assert_eq!(output.b_divided_by_gcd, &b / &output.gcd);
 }

--- a/fastcrypto-vdf/src/math/extended_gcd.rs
+++ b/fastcrypto-vdf/src/math/extended_gcd.rs
@@ -10,7 +10,6 @@ use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{One, Signed, Zero};
 use std::mem;
-use std::ops::Neg;
 
 /// The output of the extended Euclidean algorithm on inputs `a` and `b`: The Bezout coefficients `x`
 /// and `y` such that `ax + by = gcd`. The quotients `a / gcd` and `b / gcd` are also returned.

--- a/fastcrypto-vdf/src/math/extended_gcd.rs
+++ b/fastcrypto-vdf/src/math/extended_gcd.rs
@@ -14,26 +14,6 @@ use std::ops::Neg;
 
 /// The output of the extended Euclidean algorithm on inputs `a` and `b`: The Bezout coefficients `x`
 /// and `y` such that `ax + by = gcd`. The quotients `a / gcd` and `b / gcd` are also returned.
-pub struct EuclideanAlgorithmOutputPartial {
-    pub gcd: BigInt,
-    pub y: BigInt,
-    pub a_divided_by_gcd: BigInt,
-    pub b_divided_by_gcd: BigInt,
-}
-
-impl EuclideanAlgorithmOutputPartial {
-    fn neg(self) -> Self {
-        Self {
-            gcd: -self.gcd,
-            y: -self.y,
-            a_divided_by_gcd: self.a_divided_by_gcd,
-            b_divided_by_gcd: self.b_divided_by_gcd,
-        }
-    }
-}
-
-/// The output of the extended Euclidean algorithm on inputs `a` and `b`: The Bezout coefficients `x`
-/// and `y` such that `ax + by = gcd`. The quotients `a / gcd` and `b / gcd` are also returned.
 pub struct EuclideanAlgorithmOutput {
     pub gcd: BigInt,
     pub x: BigInt,
@@ -42,21 +22,13 @@ pub struct EuclideanAlgorithmOutput {
     pub b_divided_by_gcd: BigInt,
 }
 
-impl EuclideanAlgorithmOutput {
-    fn neg(self) -> Self {
-        Self {
-            gcd: -self.gcd,
-            x: -self.x,
-            y: -self.y,
-            a_divided_by_gcd: self.a_divided_by_gcd,
-            b_divided_by_gcd: self.b_divided_by_gcd,
-        }
-    }
-}
-
 /// Compute the greatest common divisor gcd of a and b. The output also returns the Bezout coefficients
 /// x and y such that ax + by = gcd and also the quotients a / gcd and b / gcd.
-pub fn extended_euclidean_algorithm(a: &BigInt, b: &BigInt) -> EuclideanAlgorithmOutput {
+pub fn extended_euclidean_algorithm(
+    a: &BigInt,
+    b: &BigInt,
+    compute_x: bool,
+) -> EuclideanAlgorithmOutput {
     let mut s = (BigInt::zero(), BigInt::one());
     let mut t = (BigInt::one(), BigInt::zero());
     let mut r = (a.clone(), b.clone());
@@ -69,69 +41,47 @@ pub fn extended_euclidean_algorithm(a: &BigInt, b: &BigInt) -> EuclideanAlgorith
         mem::swap(&mut s.0, &mut s.1);
         s.0 -= &q * &s.1;
 
-        mem::swap(&mut t.0, &mut t.1);
-        t.0 -= &q * &t.1;
+        if compute_x {
+            mem::swap(&mut t.0, &mut t.1);
+            t.0 -= &q * &t.1;
+        }
     }
 
     // The last coefficients are equal to +/- a / gcd(a,b) and b / gcd(a,b) respectively.
-    let a_divided_by_gcd = if a.sign() != s.0.sign() {
-        s.0.neg()
-    } else {
-        s.0
-    };
-    let b_divided_by_gcd = if b.sign() != t.0.sign() {
-        t.0.neg()
-    } else {
-        t.0
-    };
+    let a_divided_by_gcd = conditional_negate(a.sign() != s.0.sign(), s.0);
 
     let negate = r.1.is_negative();
-    let result = EuclideanAlgorithmOutput {
-        gcd: r.1,
-        x: t.1,
-        y: s.1,
+    let gcd = conditional_negate(negate, r.1);
+    let y = conditional_negate(negate, s.1);
+
+    let b_divided_by_gcd = if compute_x {
+        conditional_negate(b.sign() != t.0.sign(), t.0)
+    } else {
+        b / &gcd
+    };
+
+    let x = if compute_x {
+        conditional_negate(negate, t.1)
+    } else {
+        BigInt::zero()
+    };
+
+    EuclideanAlgorithmOutput {
+        gcd,
+        x,
+        y,
         a_divided_by_gcd,
         b_divided_by_gcd,
-    };
-    if negate {
-        result.neg()
-    } else {
-        result
     }
 }
 
-/// Compute the greatest common divisor gcd of a and b. The output also returns only the Bezout coefficients for b and
-/// but also the quotients a / gcd and b / gcd.
-pub fn extended_euclidean_algorithm_partial(
-    a: &BigInt,
-    b: &BigInt,
-) -> EuclideanAlgorithmOutputPartial {
-    let mut s = (BigInt::zero(), BigInt::one());
-    let mut r = (a.clone(), b.clone());
-
-    while !r.0.is_zero() {
-        let (q, r_prime) = r.1.div_rem(&r.0);
-        r.1 = r.0;
-        r.0 = r_prime;
-
-        mem::swap(&mut s.0, &mut s.1);
-        s.0 -= &q * &s.1;
-    }
-
-    // The last coefficients are equal to +/- a / gcd(a,b) and b / gcd(a,b) respectively.
-    let a_divided_by_gcd = if a.sign() != s.0.sign() { -s.0 } else { s.0 };
-    let negate = r.1.is_negative();
-    let b_divided_by_gcd = if negate { -b / &r.1 } else { b / &r.1 };
-    let result = EuclideanAlgorithmOutputPartial {
-        gcd: r.1,
-        y: s.1,
-        a_divided_by_gcd,
-        b_divided_by_gcd,
-    };
+/// Return `-value` if `negate` is true, otherwise return `value`.
+#[inline]
+fn conditional_negate(negate: bool, value: BigInt) -> BigInt {
     if negate {
-        result.neg()
+        -value
     } else {
-        result
+        value
     }
 }
 
@@ -145,7 +95,7 @@ fn test_xgcd() {
 
 #[cfg(test)]
 fn test_xgcd_single(a: BigInt, b: BigInt) {
-    let output = extended_euclidean_algorithm(&a, &b);
+    let output = extended_euclidean_algorithm(&a, &b, true);
     assert_eq!(output.gcd, a.gcd(&b));
     assert_eq!(&output.x * &a + &output.y * &b, output.gcd);
     assert_eq!(output.a_divided_by_gcd, &a / &output.gcd);


### PR DESCRIPTION
Only compute necessary Bezout coefficients. This speeds up class group composition by ~10%.