### PR TITLE
Reorganize features and clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
@@ -198,7 +198,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.10.6",
- "itertools 0.10.5",
+ "itertools",
  "num-bigint 0.4.4",
  "num-traits",
  "paste",
@@ -937,7 +937,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -963,7 +963,7 @@ dependencies = [
  "clap 4.1.8",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -984,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1501,7 +1501,7 @@ dependencies = [
  "fastcrypto",
  "generic-tests",
  "hex",
- "itertools 0.10.5",
+ "itertools",
  "rand",
  "serde",
  "sha3 0.10.6",
@@ -1517,7 +1517,6 @@ dependencies = [
  "criterion 0.5.1",
  "fastcrypto",
  "hex",
- "itertools 0.12.0",
  "num-bigint 0.4.4",
  "num-bigint-dig",
  "num-integer",
@@ -2102,15 +2101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,7 +2620,7 @@ checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.10.5",
+ "itertools",
  "predicates-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.0",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -583,21 +583,7 @@ checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.0",
-]
-
-[[package]]
-name = "blake3"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if 1.0.0",
- "constant_time_eq 0.2.5",
- "digest 0.10.6",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -891,12 +877,6 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "constant_time_eq"
@@ -1414,7 +1394,6 @@ dependencies = [
  "bech32",
  "bincode",
  "blake2",
- "blake3",
  "blst",
  "bs58",
  "bulletproofs",

--- a/fastcrypto-tbls/Cargo.toml
+++ b/fastcrypto-tbls/Cargo.toml
@@ -9,7 +9,7 @@ description = "Threshold BLS and DKG protocols"
 repository = "https://github.com/MystenLabs/fastcrypto"
 
 [dependencies]
-fastcrypto = { path = "../fastcrypto", features = ["beacon-dkg"]}
+fastcrypto = { path = "../fastcrypto", features = ["aes"]}
 
 rand.workspace = true
 serde.workspace = true

--- a/fastcrypto-vdf/Cargo.toml
+++ b/fastcrypto-vdf/Cargo.toml
@@ -17,7 +17,6 @@ num-integer = "0.1.45"
 num-prime = { version = "0.4.3", features = ["big-int"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-itertools = { version = "0.12.0", features = [] }
 
 [features]
 experimental = []

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -25,13 +25,9 @@ serde-big-array = { version = "0.5.0", optional = true }
 signature = { version = "2.0.0" }
 tokio = { version = "1.24.1", features = ["sync", "rt", "macros"] }
 zeroize.workspace = true
-bulletproofs = "4.0.0"
+bulletproofs = { version = "4.0.0", optional = true }
 curve25519-dalek-ng = "4.1.1"
 merlin = "3.0.0"
-aes = "0.8.2"
-ctr = "0.9.2"
-cbc = { version = "0.1.2", features = ["std"] }
-aes-gcm = "0.10.1"
 generic-array = { version = "0.14.6", features = ["serde"] }
 typenum.workspace = true
 auto_ops = "0.3.0"
@@ -40,7 +36,7 @@ p256 = { version = "0.13.2", features = ["ecdsa"] }
 ecdsa = { version = "0.16.6", features = ["rfc6979", "verifying"] }
 rfc6979 = "0.4.0"
 blake2 = "0.10.6"
-blake3 = "1.3.3"
+blake3 = { version = "1.3.3", optional = true }
 blst = { version = "0.3.10", features = ["no-threads"] }
 digest.workspace = true
 once_cell = "1.17.0"
@@ -51,8 +47,8 @@ thiserror = "1.0.38"
 twox-hash = { version = "1.6.3", optional = true }
 schemars ="0.8.12"
 bincode.workspace = true
-elliptic-curve = {version = "0.13.2", features = ["hash2curve"]}
-rsa = {version = "0.8.2", features = ["sha2"] }
+elliptic-curve = { version = "0.13.2", features = ["hash2curve"] }
+rsa = { version = "0.8.2", features = ["sha2"] }
 static_assertions = "1.1.0"
 ark-secp256r1 = "0.4.0"
 ark-ec = "0.4.1"
@@ -63,6 +59,12 @@ fastcrypto-derive = { path = "../fastcrypto-derive", version = "0.1.3" }
 serde_json = "1.0.93"
 num-bigint = "0.4.4"
 bech32 = "0.9.1"
+
+# Required for the aes feature
+aes = { version = "0.8.2", optional = true }
+ctr = { version = "0.9.2", optional = true }
+cbc = { version = "0.1.2", features = ["std"], optional = true }
+aes-gcm = { version = "0.10.1", optional = true }
 
 [[bench]]
 name = "crypto"
@@ -95,11 +97,19 @@ name = "hash"
 harness = false
 
 [features]
-beacon-dkg = []
 default = []
+
+# Allow copying keys
 copy_key = []
+
+# Enable the unsecure signature and hash schemes for benchmarking.
 unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]
-experimental = []
+
+# Used for feature that are not yet audited.
+experimental = ["dep:bulletproofs", "dep:blake3"]
+
+# Include AES and its modes.
+aes = ["dep:aes", "dep:cbc", "dep:aes-gcm", "dep:ctr"]
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -21,13 +21,10 @@ rand.workspace = true
 rust_secp256k1 = { version = "0.27.0", package = "secp256k1", features = ["recovery", "rand-std", "bitcoin_hashes", "global-context"] }
 serde.workspace = true
 serde_with = "2.1.0"
-serde-big-array = { version = "0.5.0", optional = true }
 signature = { version = "2.0.0" }
 tokio = { version = "1.24.1", features = ["sync", "rt", "macros"] }
 zeroize.workspace = true
-bulletproofs = { version = "4.0.0", optional = true }
 curve25519-dalek-ng = "4.1.1"
-merlin = "3.0.0"
 generic-array = { version = "0.14.6", features = ["serde"] }
 typenum.workspace = true
 auto_ops = "0.3.0"
@@ -36,7 +33,6 @@ p256 = { version = "0.13.2", features = ["ecdsa"] }
 ecdsa = { version = "0.16.6", features = ["rfc6979", "verifying"] }
 rfc6979 = "0.4.0"
 blake2 = "0.10.6"
-blake3 = { version = "1.3.3", optional = true }
 blst = { version = "0.3.10", features = ["no-threads"] }
 digest.workspace = true
 once_cell = "1.17.0"
@@ -44,8 +40,7 @@ readonly = "0.2.3"
 sha2 = "0.10.6"
 sha3.workspace = true
 thiserror = "1.0.38"
-twox-hash = { version = "1.6.3", optional = true }
-schemars ="0.8.12"
+schemars = "0.8.12"
 bincode.workspace = true
 elliptic-curve = { version = "0.13.2", features = ["hash2curve"] }
 rsa = { version = "0.8.2", features = ["sha2"] }
@@ -59,6 +54,14 @@ fastcrypto-derive = { path = "../fastcrypto-derive", version = "0.1.3" }
 serde_json = "1.0.93"
 num-bigint = "0.4.4"
 bech32 = "0.9.1"
+
+# Required for bulletproofs
+bulletproofs = { version = "4.0.0", optional = true }
+merlin = { version = "3.0.0", optional = true }
+
+# Required for the unsecure signature and hash schemes
+twox-hash = { version = "1.6.3", optional = true }
+serde-big-array = { version = "0.5.0", optional = true }
 
 # Required for the aes feature
 aes = { version = "0.8.2", optional = true }
@@ -106,7 +109,7 @@ copy_key = []
 unsecure_schemes = ["dep:twox-hash", "dep:serde-big-array"]
 
 # Used for feature that are not yet audited.
-experimental = ["dep:bulletproofs", "dep:blake3"]
+experimental = ["dep:bulletproofs", "dep:merlin"]
 
 # Include AES and its modes.
 aes = ["dep:aes", "dep:cbc", "dep:aes-gcm", "dep:ctr"]

--- a/fastcrypto/benches/hash.rs
+++ b/fastcrypto/benches/hash.rs
@@ -38,7 +38,6 @@ mod hash_benches {
             hash_single::<Sha256, 32, _>("Sha256", &input, &mut group);
             hash_single::<Sha3_256, 32, _>("Sha3_256", &input, &mut group);
             hash_single::<Blake2b256, 32, _>("Blake2b256", &input, &mut group);
-            hash_single::<Blake3, 32, _>("Blake3", &input, &mut group);
             hash_single::<Keccak256, 32, _>("Keccak256", &input, &mut group);
             hash_single::<Sha512, 64, _>("Sha512", &input, &mut group);
             hash_single::<Sha3_512, 64, _>("Sha3_512", &input, &mut group);

--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -177,28 +177,6 @@ pub type Keccak256 = HashFunctionWrapper<sha3::Keccak256, 32>;
 /// The [BLAKE2-256](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2) hash function with 256 bit digests.
 pub type Blake2b256 = HashFunctionWrapper<blake2::Blake2b<typenum::U32>, 32>;
 
-// Note: This has been audited but is not used in sui currently.
-#[cfg(any(test, feature = "experimental"))]
-/// The [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3) hash function with 256 bit digests.
-#[derive(Default)]
-pub struct Blake3 {
-    instance: blake3::Hasher,
-}
-
-// Note: This has been audited but is not used in sui currently.
-#[cfg(any(test, feature = "experimental"))]
-impl HashFunction<32> for Blake3 {
-    fn update<Data: AsRef<[u8]>>(&mut self, data: Data) {
-        self.instance.update(data.as_ref());
-    }
-
-    fn finalize(self) -> Digest<32> {
-        Digest {
-            digest: self.instance.finalize().into(),
-        }
-    }
-}
-
 /// A Multiset Hash is a homomorphic hash function, which hashes arbitrary multisets of objects such
 /// that the hash of the union of two multisets is easy to compute from the hashes of the two multisets.
 ///

--- a/fastcrypto/src/hash.rs
+++ b/fastcrypto/src/hash.rs
@@ -177,12 +177,16 @@ pub type Keccak256 = HashFunctionWrapper<sha3::Keccak256, 32>;
 /// The [BLAKE2-256](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2) hash function with 256 bit digests.
 pub type Blake2b256 = HashFunctionWrapper<blake2::Blake2b<typenum::U32>, 32>;
 
+// Note: This has been audited but is not used in sui currently.
+#[cfg(any(test, feature = "experimental"))]
 /// The [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3) hash function with 256 bit digests.
 #[derive(Default)]
 pub struct Blake3 {
     instance: blake3::Hasher,
 }
 
+// Note: This has been audited but is not used in sui currently.
+#[cfg(any(test, feature = "experimental"))]
 impl HashFunction<32> for Blake3 {
     fn update<Data: AsRef<[u8]>>(&mut self, data: Data) {
         self.instance.update(data.as_ref());

--- a/fastcrypto/src/lib.rs
+++ b/fastcrypto/src/lib.rs
@@ -87,7 +87,7 @@ pub mod secp256r1_group_tests;
 
 pub mod traits;
 
-#[cfg(any(test, feature = "experimental", feature = "beacon-dkg"))]
+#[cfg(any(test, feature = "aes"))]
 pub mod aes;
 pub mod bls12381;
 #[cfg(any(test, feature = "experimental"))]

--- a/fastcrypto/src/tests/hash_tests.rs
+++ b/fastcrypto/src/tests/hash_tests.rs
@@ -3,8 +3,8 @@
 
 use crate::encoding::{Base64, Encoding};
 use crate::hash::{
-    Blake2b256, Blake3, Digest, EllipticCurveMultisetHash, HashFunction, Keccak256, MultisetHash,
-    Sha256, Sha3_256, Sha3_512, Sha512,
+    Blake2b256, Digest, EllipticCurveMultisetHash, HashFunction, Keccak256, MultisetHash, Sha256,
+    Sha3_256, Sha3_512, Sha512,
 };
 use std::io::Write;
 
@@ -135,17 +135,6 @@ fn test_blake2b_256() {
     assert_eq!(
         digest.as_ref(),
         hex::decode("cc4e83cd4f030b0aabe27cf65a3ff92d0b5445f6466282e6b83a529b66094ebb").unwrap()
-    );
-}
-
-#[test]
-fn test_blake3() {
-    let data =
-        hex::decode("301d56460954541aab6dd7ddc0dd08f8cb3ebd884784a0e797905107533cae62").unwrap();
-    let digest = Blake3::digest(data);
-    assert_eq!(
-        digest.as_ref(),
-        hex::decode("1b6d57a5017077b00cc9ce0641fb8ddcc136fbdb83325b31597fbe9441d9b269").unwrap()
     );
 }
 


### PR DESCRIPTION
* Add an `aes` feature flag to avoid AES and it's dependencies being included when not used.
* Remove blake3.
* Dependencies only used when the `experimental` or `aes` features are enabled are now optional.