### PR TITLE
DKG: Use u16 everywhere + other small fixes

### DIFF
--- a/fastcrypto-tbls/benches/dkg.rs
+++ b/fastcrypto-tbls/benches/dkg.rs
@@ -58,7 +58,7 @@ mod dkg_benches {
             let mut create: BenchmarkGroup<_> = c.benchmark_group("DKG create");
             for (n, total_w) in iproduct!(SIZES.iter(), TOTAL_WEIGHTS.iter()) {
                 let w = total_w / n;
-                let t = (total_w / 3) as u16;
+                let t = total_w / 3;
                 let keys = gen_ecies_keys(*n);
                 let d0 = setup_party(0, t, w, &keys);
 
@@ -81,7 +81,7 @@ mod dkg_benches {
             let mut verify: BenchmarkGroup<_> = c.benchmark_group("DKG message processing");
             for (n, total_w) in iproduct!(SIZES.iter(), TOTAL_WEIGHTS.iter()) {
                 let w = total_w / n;
-                let t = (total_w / 3) as u16;
+                let t = total_w / 3;
                 let keys = gen_ecies_keys(*n);
                 let d0 = setup_party(0, t, w, &keys);
                 let d1 = setup_party(1, t, w, &keys);

--- a/fastcrypto-tbls/benches/dkg.rs
+++ b/fastcrypto-tbls/benches/dkg.rs
@@ -25,7 +25,7 @@ fn gen_ecies_keys(n: u16) -> Vec<(PartyId, ecies::PrivateKey<EG>, ecies::PublicK
 
 pub fn setup_party(
     id: PartyId,
-    threshold: u32,
+    threshold: u16,
     weight: u16,
     keys: &[(PartyId, ecies::PrivateKey<EG>, ecies::PublicKey<EG>)],
 ) -> Party<G, EG> {
@@ -58,7 +58,7 @@ mod dkg_benches {
             let mut create: BenchmarkGroup<_> = c.benchmark_group("DKG create");
             for (n, total_w) in iproduct!(SIZES.iter(), TOTAL_WEIGHTS.iter()) {
                 let w = total_w / n;
-                let t = (total_w / 3) as u32;
+                let t = (total_w / 3) as u16;
                 let keys = gen_ecies_keys(*n);
                 let d0 = setup_party(0, t, w, &keys);
 
@@ -67,7 +67,7 @@ mod dkg_benches {
                     |b| b.iter(|| d0.create_message(&mut thread_rng())),
                 );
 
-                let message = d0.create_message(&mut thread_rng());
+                let message = d0.create_message(&mut thread_rng()).unwrap();
                 println!(
                     "Message size for n={}, t={}: {}",
                     n,
@@ -81,11 +81,11 @@ mod dkg_benches {
             let mut verify: BenchmarkGroup<_> = c.benchmark_group("DKG message processing");
             for (n, total_w) in iproduct!(SIZES.iter(), TOTAL_WEIGHTS.iter()) {
                 let w = total_w / n;
-                let t = (total_w / 3) as u32;
+                let t = (total_w / 3) as u16;
                 let keys = gen_ecies_keys(*n);
                 let d0 = setup_party(0, t, w, &keys);
                 let d1 = setup_party(1, t, w, &keys);
-                let message = d0.create_message(&mut thread_rng());
+                let message = d0.create_message(&mut thread_rng()).unwrap();
 
                 verify.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),

--- a/fastcrypto-tbls/benches/nidkg.rs
+++ b/fastcrypto-tbls/benches/nidkg.rs
@@ -24,7 +24,7 @@ fn gen_ecies_keys(n: u16) -> Vec<(u16, ecies::PrivateKey<G>, ecies::PublicKey<G>
 
 pub fn setup_party(
     id: usize,
-    threshold: u32,
+    threshold: u16,
     keys: &[(u16, ecies::PrivateKey<G>, ecies::PublicKey<G>)],
 ) -> Party<G> {
     let nodes = keys
@@ -54,7 +54,7 @@ mod nidkg_benches {
         {
             let mut create: BenchmarkGroup<_> = c.benchmark_group("NI-DKG create");
             for n in SIZES {
-                let t = (n / 2) as u32;
+                let t = (n / 2) as u16;
                 let keys = gen_ecies_keys(n);
                 let d0 = setup_party(0, t, &keys);
 
@@ -67,11 +67,11 @@ mod nidkg_benches {
         {
             let mut verify: BenchmarkGroup<_> = c.benchmark_group("NI-DKG message verification");
             for n in SIZES {
-                let t = (n / 2) as u32;
+                let t = (n / 2) as u16;
                 let keys = gen_ecies_keys(n);
                 let d0 = setup_party(0, t, &keys);
                 let d1 = setup_party(1, t, &keys);
-                let m = d0.create_message(&mut thread_rng());
+                let m = d0.create_message(&mut thread_rng()).unwrap();
                 println!("Message size: {}", bcs::to_bytes(&m).unwrap().len());
 
                 verify.bench_function(format!("n={}, t={}", n, t).as_str(), |b| {
@@ -84,11 +84,11 @@ mod nidkg_benches {
             let mut verify: BenchmarkGroup<_> =
                 c.benchmark_group("NI-DKG message processing for one share");
             for n in SIZES {
-                let t = (n / 2) as u32;
+                let t = (n / 2) as u16;
                 let keys = gen_ecies_keys(n);
                 let d0 = setup_party(0, t, &keys);
                 let d1 = setup_party(1, t, &keys);
-                let m = d0.create_message(&mut thread_rng());
+                let m = d0.create_message(&mut thread_rng()).unwrap();
 
                 verify.bench_function(format!("n={}, t={}", n, t).as_str(), |b| {
                     b.iter(|| d1.process_message(&m, &mut thread_rng()))
@@ -101,7 +101,7 @@ mod nidkg_benches {
             let mut verify: BenchmarkGroup<_> =
                 c.benchmark_group("NI-DKG generate partial pks in g2");
             for n in SIZES {
-                let t = (n / 2) as u32;
+                let t = (n / 2) as u16;
                 let keys = gen_ecies_keys(n);
                 let d1 = setup_party(1, t, &keys);
 
@@ -114,7 +114,7 @@ mod nidkg_benches {
             let mut verify: BenchmarkGroup<_> =
                 c.benchmark_group("NI-DKG verify partial pks in g2");
             for n in SIZES {
-                let t = (n / 2) as u32;
+                let t = (n / 2) as u16;
                 let keys = gen_ecies_keys(n);
                 let d0 = setup_party(0, t, &keys);
                 let pks_in_g2 = d0.create_partial_pks_in_g2();
@@ -122,7 +122,7 @@ mod nidkg_benches {
                     "pks_in_g2 size: {}",
                     bcs::to_bytes(&pks_in_g2).unwrap().len()
                 );
-                let m = d0.create_message(&mut thread_rng());
+                let m = d0.create_message(&mut thread_rng()).unwrap();
 
                 verify.bench_function(format!("n={}, t={}", n, t).as_str(), |b| {
                     b.iter(|| {

--- a/fastcrypto-tbls/benches/polynomial.rs
+++ b/fastcrypto-tbls/benches/polynomial.rs
@@ -5,7 +5,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 use fastcrypto::groups::bls12381;
 use fastcrypto_tbls::polynomial::Poly;
 use rand::thread_rng;
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
 mod polynomial_benches {
     use super::*;
@@ -19,7 +19,7 @@ mod polynomial_benches {
             for n in SIZES {
                 let t = n / 3;
                 vss_sk_gen.bench_function(format!("n={}, t={}", n, t).as_str(), |b| {
-                    b.iter(|| Poly::<bls12381::Scalar>::rand(t as u32, &mut thread_rng()))
+                    b.iter(|| Poly::<bls12381::Scalar>::rand(t as u16, &mut thread_rng()))
                 });
             }
         }
@@ -28,7 +28,7 @@ mod polynomial_benches {
             let mut vss_pk_gen: BenchmarkGroup<_> = c.benchmark_group("VSS public key generation");
             for n in SIZES {
                 let t = n / 3;
-                let vss_sk = Poly::<bls12381::Scalar>::rand(t as u32, &mut thread_rng());
+                let vss_sk = Poly::<bls12381::Scalar>::rand(t as u16, &mut thread_rng());
                 vss_pk_gen.bench_function(format!("n={}, t={}", n, t).as_str(), |b| {
                     b.iter(|| vss_sk.commit::<G>())
                 });
@@ -39,11 +39,11 @@ mod polynomial_benches {
             let mut shares_gen: BenchmarkGroup<_> = c.benchmark_group("Shares generation");
             for n in SIZES {
                 let t = n / 3;
-                let vss_sk = Poly::<bls12381::Scalar>::rand(t as u32, &mut thread_rng());
+                let vss_sk = Poly::<bls12381::Scalar>::rand(t as u16, &mut thread_rng());
                 shares_gen.bench_function(format!("n={}, t={}", n, t).as_str(), |b| {
                     b.iter(|| {
-                        (1u32..=(n as u32)).for_each(|i| {
-                            vss_sk.eval(NonZeroU32::new(i).unwrap());
+                        (1u16..=(n as u16)).for_each(|i| {
+                            vss_sk.eval(NonZeroU16::new(i).unwrap());
                         })
                     })
                 });
@@ -58,14 +58,14 @@ mod polynomial_benches {
             for n in SIZES {
                 let t = n / 3;
                 let k = n / 10;
-                let vss_sk = Poly::<bls12381::Scalar>::rand(t as u32, &mut thread_rng());
+                let vss_sk = Poly::<bls12381::Scalar>::rand(t as u16, &mut thread_rng());
                 let vss_pk = vss_sk.commit::<G>();
                 shares_verification.bench_function(
                     format!("n={}, t={}, k={}", n, t, k).as_str(),
                     |b| {
                         b.iter(|| {
-                            (1u32..=(k as u32)).for_each(|i| {
-                                vss_pk.eval(NonZeroU32::new(i).unwrap());
+                            (1u16..=(k as u16)).for_each(|i| {
+                                vss_pk.eval(NonZeroU16::new(i).unwrap());
                             })
                         })
                     },

--- a/fastcrypto-tbls/benches/tbls.rs
+++ b/fastcrypto-tbls/benches/tbls.rs
@@ -4,7 +4,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 use fastcrypto::groups::bls12381;
 use rand::thread_rng;
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
 mod tbls_benches {
     use super::*;
@@ -21,7 +21,7 @@ mod tbls_benches {
             const WEIGHTS: [usize; 5] = [10, 20, 30, 40, 50];
             for w in WEIGHTS {
                 let shares = (1..=w)
-                    .map(|i| private_poly.eval(NonZeroU32::new(i as u32).unwrap()))
+                    .map(|i| private_poly.eval(NonZeroU16::new(i as u16).unwrap()))
                     .collect::<Vec<_>>();
 
                 create.bench_function(format!("w={}", w).as_str(), |b| {
@@ -34,15 +34,15 @@ mod tbls_benches {
             let mut create: BenchmarkGroup<_> = c.benchmark_group("Recover full signature");
             const TOTAL_WEIGHTS: [usize; 4] = [666, 833, 1111, 1666];
             for w in TOTAL_WEIGHTS {
-                let private_poly = Poly::<bls12381::Scalar>::rand(w as u32, &mut thread_rng());
+                let private_poly = Poly::<bls12381::Scalar>::rand(w as u16, &mut thread_rng());
                 let shares = (1..=w)
-                    .map(|i| private_poly.eval(NonZeroU32::new(i as u32).unwrap()))
+                    .map(|i| private_poly.eval(NonZeroU16::new(i as u16).unwrap()))
                     .collect::<Vec<_>>();
 
                 let sigs = ThresholdBls12381MinSig::partial_sign_batch(shares.iter(), msg);
 
                 create.bench_function(format!("w={}", w).as_str(), |b| {
-                    b.iter(|| ThresholdBls12381MinSig::aggregate(w as u32, sigs.iter()).unwrap())
+                    b.iter(|| ThresholdBls12381MinSig::aggregate(w as u16, sigs.iter()).unwrap())
                 });
             }
         }

--- a/fastcrypto-tbls/src/dkg.rs
+++ b/fastcrypto-tbls/src/dkg.rs
@@ -19,14 +19,12 @@ use fastcrypto::traits::AllowedRng;
 use itertools::Itertools;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use tracing::{debug, error, info, warn};
 
 use tap::prelude::*;
+use tracing::{debug, error, info, warn};
 
 /// Generics below use `G: GroupElement' for the group of the VSS public key, and `EG: GroupElement'
 /// for the group of the ECIES public key.
-
-// TODO: Add a description of the protocol.
 
 /// Party in the DKG protocol.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -39,9 +37,10 @@ pub struct Party<G: GroupElement, EG: GroupElement> {
     vss_sk: PrivatePoly<G>,
 }
 
-/// The higher-level protocol is responsible for verifying that the 'sender' is correct in the
-/// following messages (based on the chain's signatures).
-/// Also, the high level protocol is responsible that all parties see the same order of messages.
+/// Assumptions:
+/// - The high-level protocol is responsible for verifying that the 'sender' is correct in the
+///   following messages (based on the chain's authentication).
+/// - The high-level protocol is responsible that all parties see the same order of messages.
 
 /// [Message] holds all encrypted shares a dealer sends during the first phase of the
 /// protocol.
@@ -49,9 +48,9 @@ pub struct Party<G: GroupElement, EG: GroupElement> {
 pub struct Message<G: GroupElement, EG: GroupElement> {
     pub sender: PartyId,
     /// The commitment of the secret polynomial created by the sender.
-    pub vss_pk: PublicPoly<G>,
+    pub(crate) vss_pk: PublicPoly<G>,
     /// The encrypted shares created by the sender. Sorted according to the receivers.
-    pub encrypted_shares: MultiRecipientEncryption<EG>,
+    pub(crate) encrypted_shares: MultiRecipientEncryption<EG>,
 }
 
 /// A complaint/fraud claim against a dealer that created invalid encrypted share.
@@ -67,21 +66,21 @@ pub struct Complaint<EG: GroupElement> {
 pub struct Confirmation<EG: GroupElement> {
     pub sender: PartyId,
     /// List of complaints against other parties. Empty if there are none.
-    pub complaints: Vec<Complaint<EG>>,
+    pub(crate) complaints: Vec<Complaint<EG>>,
 }
 
 /// Wrapper for collecting everything related to a processed message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProcessedMessage<G: GroupElement, EG: GroupElement> {
-    pub message: Message<G, EG>,
-    pub shares: Vec<Share<G::ScalarType>>, //possibly empty
-    pub complaint: Option<Complaint<EG>>,
+    pub(crate) message: Message<G, EG>,
+    pub(crate) shares: Vec<Share<G::ScalarType>>, //possibly empty
+    pub(crate) complaint: Option<Complaint<EG>>,
 }
 
 /// Unique processed messages that are being used in the protocol.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UsedProcessedMessages<G: GroupElement, EG: GroupElement>(
-    pub Vec<ProcessedMessage<G, EG>>,
+    pub(crate) Vec<ProcessedMessage<G, EG>>,
 );
 
 impl<G: GroupElement, EG: GroupElement> From<&[ProcessedMessage<G, EG>]>
@@ -91,14 +90,14 @@ impl<G: GroupElement, EG: GroupElement> From<&[ProcessedMessage<G, EG>]>
     fn from(msgs: &[ProcessedMessage<G, EG>]) -> Self {
         let filtered = msgs
             .iter()
-            .unique_by(|&m| m.message.sender)
+            .unique_by(|&m| m.message.sender) // stable
             .cloned()
             .collect::<Vec<_>>();
         Self(filtered)
     }
 }
 
-/// Processed messages that were not excluded.
+/// Processed messages that were not excluded after the third phase of the protocol.
 pub struct VerifiedProcessedMessages<G: GroupElement, EG: GroupElement>(
     Vec<ProcessedMessage<G, EG>>,
 );
@@ -122,6 +121,7 @@ impl<G: GroupElement, EG: GroupElement> VerifiedProcessedMessages<G, EG> {
         self.0.is_empty()
     }
 
+    #[cfg(test)]
     pub fn data(&self) -> &[ProcessedMessage<G, EG>] {
         &self.0
     }
@@ -149,15 +149,16 @@ where
 {
     /// 1. Create a new ECIES private key and send the public key to all parties.
     /// 2. After *all* parties have sent their ECIES public keys, create the (same) set of nodes.
+
     /// 3. Create a new Party instance with the ECIES private key and the set of nodes.
     pub fn new<R: AllowedRng>(
         enc_sk: ecies::PrivateKey<EG>,
         nodes: Nodes<EG>,
-        t: u16, // The number of parties that are needed to reconstruct the full key/signature.
+        t: u16, // The number of parties that are needed to reconstruct the full key/signature (f+1).
         random_oracle: RandomOracle, // Should be unique for each invocation, but the same for all parties.
         rng: &mut R,
     ) -> FastCryptoResult<Self> {
-        // Check that my ecies pk is in the nodes.
+        // Confirm that my ecies pk is in the nodes.
         let enc_pk = ecies::PublicKey::<EG>::from_private_key(&enc_sk);
         let my_node = nodes
             .iter()
@@ -173,7 +174,6 @@ where
 
         // TODO: remove once the protocol is stable since it's a non negligible computation.
         let vss_pk = vss_sk.commit::<G>();
-
         info!(
             "DKG: Creating party {} with weight {}, nodes hash {:?}, t {}, n {}, ro {:?}, enc pk {:?}, vss pk c0 {:?}",
             my_node.id,
@@ -250,6 +250,7 @@ where
         })
     }
 
+    // Sanity checks that can be done by any party on a received message.
     fn sanity_check_message(&self, msg: &Message<G, EG>) -> FastCryptoResult<()> {
         let node = self
             .nodes
@@ -315,11 +316,16 @@ where
     ///    The second message contains the list of complaints on invalid shares. In addition, it
     ///    returns a set of valid shares (so far).
     ///
+    ///    We split this function into two parts: process_message and merge, so that the caller can
+    ///    process messages concurrently and then merge the results.
+
+    ///    [process_message] processes a message and returns an intermediate object ProcessedMessage.
+    ///
     ///    Returns error InvalidMessage if the message is invalid and should be ignored (note that we
     ///    could count it as part of the f+1 messages we wait for, but it's also safe to ignore it
     ///    and just wait for f+1 valid messages).
     ///
-    ///    Assumption on caller: Called only once per sender.
+    ///    Assumptions: Called only once per sender (the high level protocol is responsible for deduplication).
     pub fn process_message<R: AllowedRng>(
         &self,
         message: Message<G, EG>,
@@ -380,7 +386,7 @@ where
         );
         // Verify all shares in a batch.
         if verify_poly_evals(&decrypted_shares, &message.vss_pk, rng).is_err() {
-            debug!(
+            warn!(
                 "DKG: Processing message from party {} failed, invalid shares",
                 message.sender
             );
@@ -414,9 +420,10 @@ where
     }
 
     /// 6. Merge results from multiple ProcessedMessages so only one message needs to be sent.
+    ///
     ///    Returns NotEnoughInputs if the threshold t is not met.
     ///
-    ///    Assumption on caller: processed messages was computed on the same set of messages
+    ///    Assumptions: processed_messages is the result of process_message on the same set of messages
     ///    on all parties.
     pub fn merge(
         &self,
@@ -458,7 +465,7 @@ where
         };
         for m in &filtered_messages.0 {
             if let Some(complaint) = &m.complaint {
-                debug!("DKG: Including a complaint on party {}", m.message.sender);
+                info!("DKG: Including a complaint on party {}", m.message.sender);
                 conf.complaints.push(complaint.clone());
             }
         }
@@ -478,7 +485,7 @@ where
     ///
     ///    Returns NotEnoughInputs if the threshold minimal_threshold is not met.
     ///
-    ///    Assumption on caller: All parties use the same set of confirmations (and outputs from merge).
+    ///    Assumptions: All parties use the same set of confirmations (and outputs from merge).
     pub(crate) fn process_confirmations<R: AllowedRng>(
         &self,
         messages: &UsedProcessedMessages<G, EG>,
@@ -488,7 +495,7 @@ where
         debug!("Processing {} confirmations", confirmations.len());
         let required_threshold = self.t + self.t - 1; // guarantee that at least t honest nodes have valid shares.
 
-        // Ignore confirmations with invalid sender
+        // Ignore confirmations with invalid sender or zero weights
         let confirmations = confirmations
             .iter()
             .filter(|c| {

--- a/fastcrypto-tbls/src/dl_verification.rs
+++ b/fastcrypto-tbls/src/dl_verification.rs
@@ -183,6 +183,7 @@ pub fn verify_equal_exponents<R: AllowedRng>(
 }
 
 pub(crate) fn get_random_scalars<S: Scalar, R: AllowedRng>(n: usize, rng: &mut R) -> Vec<S> {
+    // We use rng directly since we want only u64 numbers, which will be cheaper to multiply.
     (0..n)
         .map(|_| S::from(rng.next_u64() as u128))
         .collect::<Vec<_>>()

--- a/fastcrypto-tbls/src/ecies.rs
+++ b/fastcrypto-tbls/src/ecies.rs
@@ -58,6 +58,7 @@ where
         Self(G::ScalarType::rand(rng))
     }
 
+    #[cfg(test)]
     pub fn from(sc: G::ScalarType) -> Self {
         Self(sc)
     }
@@ -116,6 +117,7 @@ where
     }
 }
 
+#[cfg(test)]
 impl<G: GroupElement> From<G> for PublicKey<G> {
     fn from(p: G) -> Self {
         Self(p)
@@ -123,12 +125,14 @@ impl<G: GroupElement> From<G> for PublicKey<G> {
 }
 
 impl<G: GroupElement + Serialize> Encryption<G> {
-    fn deterministic_encrypt(msg: &[u8], r_g: &G, r_x_g: &G) -> Self {
-        let hkdf_result = Self::hkdf(r_x_g);
-        let cipher = Aes256Ctr::new(
-            AesKey::<U32>::from_bytes(&hkdf_result)
+    fn sym_encrypt(k: &G) -> Aes256Ctr {
+        Aes256Ctr::new(
+            AesKey::<U32>::from_bytes(&Self::hkdf(k))
                 .expect("New shouldn't fail as use fixed size key is used"),
-        );
+        )
+    }
+    fn deterministic_encrypt(msg: &[u8], r_g: &G, r_x_g: &G) -> Self {
+        let cipher = Self::sym_encrypt(r_x_g);
         let encrypted_message = cipher.encrypt(&Self::fixed_zero_nonce(), msg);
         Self(*r_g, encrypted_message)
     }
@@ -146,11 +150,7 @@ impl<G: GroupElement + Serialize> Encryption<G> {
     }
 
     pub fn decrypt_from_partial_decryption(&self, partial_key: &G) -> Vec<u8> {
-        let hkdf_result = Self::hkdf(partial_key);
-        let cipher = Aes256Ctr::new(
-            AesKey::<U32>::from_bytes(&hkdf_result)
-                .expect("New shouldn't fail as use fixed size key is used"),
-        );
+        let cipher = Self::sym_encrypt(partial_key);
         cipher
             .decrypt(&Self::fixed_zero_nonce(), &self.1)
             .expect("Decrypt should never fail for CTR mode")

--- a/fastcrypto-tbls/src/ecies.rs
+++ b/fastcrypto-tbls/src/ecies.rs
@@ -125,7 +125,6 @@ impl<G: GroupElement> From<G> for PublicKey<G> {
 impl<G: GroupElement + Serialize> Encryption<G> {
     fn deterministic_encrypt(msg: &[u8], r_g: &G, r_x_g: &G) -> Self {
         let hkdf_result = Self::hkdf(r_x_g);
-        // TODO: Should we just xor with the hkdf output and append with hmac?
         let cipher = Aes256Ctr::new(
             AesKey::<U32>::from_bytes(&hkdf_result)
                 .expect("New shouldn't fail as use fixed size key is used"),

--- a/fastcrypto-tbls/src/mocked_dkg.rs
+++ b/fastcrypto-tbls/src/mocked_dkg.rs
@@ -7,7 +7,7 @@ use crate::polynomial::PrivatePoly;
 use fastcrypto::groups::GroupElement;
 use serde::Serialize;
 
-/// Emulates the output of an insecure DKG protocol.
+/// Emulates the output of an insecure DKG protocol (to be used in tests).
 pub fn generate_mocked_output<G: GroupElement + Serialize, EG: GroupElement + Serialize>(
     nodes: Nodes<EG>,
     t: u32,

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -99,12 +99,7 @@ impl<G: GroupElement + Serialize> Nodes<G> {
 
     /// Get the node corresponding to a share id.
     pub fn share_id_to_node(&self, share_id: &ShareIndex) -> FastCryptoResult<&Node<G>> {
-        let nonzero_node_id = match self.accumulated_weights.binary_search(
-            &share_id
-                .get()
-                .try_into()
-                .expect("Num of shares should fit u16"),
-        ) {
+        let nonzero_node_id = match self.accumulated_weights.binary_search(&share_id.get()) {
             Ok(i) => i,
             Err(i) => i,
         };

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -3,7 +3,6 @@
 
 use crate::ecies;
 use crate::types::ShareIndex;
-use fastcrypto::error::FastCryptoError::InvalidInput;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::GroupElement;
 use fastcrypto::hash::{Blake2b256, Digest, HashFunction};
@@ -17,7 +16,7 @@ pub type PartyId = u16;
 pub struct Node<G: GroupElement> {
     pub id: PartyId,
     pub pk: ecies::PublicKey<G>,
-    pub weight: u16, // May be zero
+    pub weight: u16, // May be zero after reduce()
 }
 
 /// Wrapper for a set of nodes.
@@ -31,6 +30,9 @@ pub struct Nodes<G: GroupElement> {
 }
 
 impl<G: GroupElement + Serialize> Nodes<G> {
+    // We don't expect to have more than 1000 nodes (simplifies some checks).
+    const MAX_NODES: usize = 1000;
+
     /// Create a new set of nodes. Nodes must have consecutive ids starting from 0.
     pub fn new(nodes: Vec<Node<G>>) -> FastCryptoResult<Self> {
         let mut nodes = nodes;
@@ -39,12 +41,11 @@ impl<G: GroupElement + Serialize> Nodes<G> {
         if (0..nodes.len()).any(|i| (nodes[i].id as usize) != i) {
             return Err(FastCryptoError::InvalidInput);
         }
-        // Make sure we never overflow, as we don't expect to have more than 1000 nodes
-        if nodes.is_empty() || nodes.len() > 1000 {
+        // Make sure we never overflow in the functions below.
+        if nodes.is_empty() || nodes.len() > Self::MAX_NODES {
             return Err(FastCryptoError::InvalidInput);
         }
-
-        // Make sure we never overflow, as we don't expect to have more than u16::MAX total weight.
+        // Make sure we never overflow in the functions below, as we don't expect to have more than u16::MAX total weight.
         let total_weight = nodes.iter().map(|n| n.weight as u32).sum::<u32>();
         if total_weight > u16::MAX as u32 || total_weight == 0 {
             return Err(FastCryptoError::InvalidInput);
@@ -99,27 +100,25 @@ impl<G: GroupElement + Serialize> Nodes<G> {
 
     /// Get the node corresponding to a share id.
     pub fn share_id_to_node(&self, share_id: &ShareIndex) -> FastCryptoResult<&Node<G>> {
-        let nonzero_node_id = match self.accumulated_weights.binary_search(&share_id.get()) {
-            Ok(i) => i,
-            Err(i) => i,
-        };
+        let nonzero_node_id = self
+            .accumulated_weights
+            .binary_search(&share_id.get())
+            .unwrap_or_else(|i| i);
         match self.nodes_with_nonzero_weight.get(nonzero_node_id) {
             Some(node_id) => self.node_id_to_node(*node_id),
-            None => Err(InvalidInput),
+            None => Err(FastCryptoError::InvalidInput),
         }
     }
 
     pub fn node_id_to_node(&self, party_id: PartyId) -> FastCryptoResult<&Node<G>> {
-        if party_id as usize >= self.nodes.len() {
-            Err(InvalidInput)
-        } else {
-            Ok(&self.nodes[party_id as usize])
-        }
+        self.nodes
+            .get(party_id as usize)
+            .ok_or(FastCryptoError::InvalidInput)
     }
 
     /// Get the share ids of a node (ordered).
     pub fn share_ids_of(&self, id: PartyId) -> Vec<ShareIndex> {
-        // TODO: [perf opt] Cache this
+        // TODO: [perf opt] Cache this or impl differently.
         self.share_ids_iter()
             .filter(|node_id| self.share_id_to_node(node_id).expect("valid ids").id == id)
             .collect::<Vec<_>>()

--- a/fastcrypto-tbls/src/polynomial.rs
+++ b/fastcrypto-tbls/src/polynomial.rs
@@ -33,15 +33,13 @@ impl<C> Poly<C> {
     pub fn degree(&self) -> u16 {
         // e.g. c_0 + c_1 * x + c_2 * x^2 + c_3 * x^3
         // ^ 4 coefficients correspond to a 3rd degree poly
-        (self.0.len() - 1)
-            .try_into()
-            .expect("Degree should be at most 2^16")
+        (self.0.len() - 1) as u16
     }
 }
 
 impl<C> From<Vec<C>> for Poly<C> {
     fn from(c: Vec<C>) -> Self {
-        assert!((c.len() - 1) < u16::MAX as usize);
+        assert!((c.len() - 1) <= u16::MAX as usize);
         Self(c)
     }
 }
@@ -128,6 +126,7 @@ impl<C: GroupElement> Poly<C> {
                         negative = !negative;
                         i - j
                     } else {
+                        // i < j (but not equal)
                         j - i
                     };
                     debug_assert_ne!(diff, 0);
@@ -138,8 +137,8 @@ impl<C: GroupElement> Poly<C> {
                     }
                 },
             );
-
-            denominator = denominator * C::ScalarType::from(remaining); // remaining != 0
+            debug_assert_ne!(remaining, 0);
+            denominator = denominator * C::ScalarType::from(remaining);
             if negative {
                 denominator = -denominator;
             }

--- a/fastcrypto-tbls/src/polynomial.rs
+++ b/fastcrypto-tbls/src/polynomial.rs
@@ -30,15 +30,18 @@ pub type PublicPoly<C> = Poly<C>;
 
 impl<C> Poly<C> {
     /// Returns the degree of the polynomial
-    pub fn degree(&self) -> u32 {
+    pub fn degree(&self) -> u16 {
         // e.g. c_0 + c_1 * x + c_2 * x^2 + c_3 * x^3
         // ^ 4 coefficients correspond to a 3rd degree poly
-        (self.0.len() - 1) as u32
+        (self.0.len() - 1)
+            .try_into()
+            .expect("Degree should be at most 2^16")
     }
 }
 
 impl<C> From<Vec<C>> for Poly<C> {
     fn from(c: Vec<C>) -> Self {
+        assert!((c.len() - 1) < u16::MAX as usize);
         Self(c)
     }
 }
@@ -91,7 +94,7 @@ impl<C: GroupElement> Poly<C> {
 
     // Expects exactly t unique shares.
     fn get_lagrange_coefficients_for_c0(
-        t: u32,
+        t: u16,
         mut shares: impl Iterator<Item = impl Borrow<Eval<C>>>,
     ) -> FastCryptoResult<Vec<C::ScalarType>> {
         let mut ids_set = HashSet::new();
@@ -140,6 +143,7 @@ impl<C: GroupElement> Poly<C> {
             if negative {
                 denominator = -denominator;
             }
+            // TODO: Consider returning full_numerator and dividing once outside instead of here per iteration.
             let coeff = full_numerator / denominator;
             coeffs.push(coeff.expect("safe since i != j"));
         }
@@ -148,7 +152,7 @@ impl<C: GroupElement> Poly<C> {
 
     /// Given exactly `t` polynomial evaluations, it will recover the polynomial's constant term.
     pub fn recover_c0(
-        t: u32,
+        t: u16,
         shares: impl Iterator<Item = impl Borrow<Eval<C>>> + Clone,
     ) -> Result<C, FastCryptoError> {
         let coeffs = Self::get_lagrange_coefficients_for_c0(t, shares.clone())?;
@@ -188,7 +192,7 @@ impl<C: Scalar> Poly<C> {
     /// Returns a new polynomial of the given degree where each coefficients is
     /// sampled at random from the given RNG.
     /// In the context of secret sharing, the threshold is the degree + 1.
-    pub fn rand<R: AllowedRng>(degree: u32, rng: &mut R) -> Self {
+    pub fn rand<R: AllowedRng>(degree: u16, rng: &mut R) -> Self {
         let coeffs: Vec<C> = (0..=degree).map(|_| C::rand(rng)).collect();
         Self::from(coeffs)
     }
@@ -210,7 +214,7 @@ impl<C: GroupElement + MultiScalarMul> Poly<C> {
     /// Given exactly `t` polynomial evaluations, it will recover the polynomial's
     /// constant term.
     pub fn recover_c0_msm(
-        t: u32,
+        t: u16,
         shares: impl Iterator<Item = impl Borrow<Eval<C>>> + Clone,
     ) -> Result<C, FastCryptoError> {
         let coeffs = Self::get_lagrange_coefficients_for_c0(t, shares.clone())?;

--- a/fastcrypto-tbls/src/tbls.rs
+++ b/fastcrypto-tbls/src/tbls.rs
@@ -81,7 +81,7 @@ pub trait ThresholdBls {
         if points.is_empty() {
             return Ok(());
         }
-        let rs = get_random_scalars::<Self::Private, R>(points.len() as u32, rng);
+        let rs = get_random_scalars::<Self::Private, R>(points.len(), rng);
         // TODO: should we cache it instead? that would replace t-wide msm with w-wide msm.
         let coeffs = batch_coefficients(&rs, &evals_as_scalars, vss_pk.degree());
         let pk = Self::Public::multi_scalar_mul(&coeffs, vss_pk.as_vec()).expect("sizes match");
@@ -92,7 +92,7 @@ pub trait ThresholdBls {
 
     /// Interpolate partial signatures to recover the full signature.
     fn aggregate(
-        threshold: u32,
+        threshold: u16,
         partials: impl Iterator<Item = impl Borrow<PartialSignature<Self::Signature>>> + Clone,
     ) -> FastCryptoResult<Self::Signature> {
         let unique_partials = partials

--- a/fastcrypto-tbls/src/tests/dkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_tests.rs
@@ -105,17 +105,17 @@ fn test_dkg_e2e_5_parties_min_weight_2_threshold_4() {
 
     // Only the first messages of d0, d4, d5 will pass all tests. d4's messages will be excluded
     // later because of an invalid complaint
-    let msg4 = d4.create_message(&mut thread_rng());
-    let msg5 = d5.create_message(&mut thread_rng());
+    let msg4 = d4.create_message(&mut thread_rng()).unwrap();
+    let msg5 = d5.create_message(&mut thread_rng()).unwrap();
     // d5 will receive invalid shares from d0, but its complaint will not be processed on time.
-    let mut msg0 = d0.create_message(&mut thread_rng());
+    let mut msg0 = d0.create_message(&mut thread_rng()).unwrap();
     let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg0);
     pk_and_msgs[5] = pk_and_msgs[0].clone();
     msg0.encrypted_shares =
         MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 0"), &mut thread_rng());
     // We will modify d1's message to make it invalid (emulating a cheating party). d0 and d1
     // should detect that and send complaints.
-    let mut msg1 = d1.create_message(&mut thread_rng());
+    let mut msg1 = d1.create_message(&mut thread_rng()).unwrap();
     let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg1);
     pk_and_msgs.swap(0, 1);
     msg1.encrypted_shares =
@@ -190,23 +190,11 @@ fn test_dkg_e2e_5_parties_min_weight_2_threshold_4() {
 
     let all_confirmations = vec![conf0.clone(), conf1.clone(), conf3, conf1.clone(), conf4]; // duplicates should be ignored
 
-    // expect failure - process_confirmations() should receive valid minimal_threshold
-    assert_eq!(
-        d1.process_confirmations(&used_msgs0, &all_confirmations, 0, &mut thread_rng())
-            .err(),
-        Some(FastCryptoError::InvalidInput)
-    );
-    assert_eq!(
-        d1.process_confirmations(&used_msgs0, &all_confirmations, 1, &mut thread_rng())
-            .err(),
-        Some(FastCryptoError::InvalidInput)
-    );
     // expect failure - process_confirmations() should receive enough messages (non duplicated).
     assert_eq!(
         d1.process_confirmations(
             &used_msgs0,
             &[conf0.clone(), conf0.clone(), conf0.clone()],
-            3,
             &mut thread_rng()
         )
         .err(),
@@ -215,19 +203,19 @@ fn test_dkg_e2e_5_parties_min_weight_2_threshold_4() {
 
     // back to the happy case
     let ver_msg0 = d1
-        .process_confirmations(&used_msgs0, &all_confirmations, 3, &mut thread_rng())
+        .process_confirmations(&used_msgs0, &all_confirmations, &mut thread_rng())
         .unwrap();
     let ver_msg1 = d1
-        .process_confirmations(&used_msgs1, &all_confirmations, 3, &mut thread_rng())
+        .process_confirmations(&used_msgs1, &all_confirmations, &mut thread_rng())
         .unwrap();
     let ver_msg2 = d2
-        .process_confirmations(&used_msgs2, &all_confirmations, 3, &mut thread_rng())
+        .process_confirmations(&used_msgs2, &all_confirmations, &mut thread_rng())
         .unwrap();
     let ver_msg3 = d3
-        .process_confirmations(&used_msgs3, &all_confirmations, 3, &mut thread_rng())
+        .process_confirmations(&used_msgs3, &all_confirmations, &mut thread_rng())
         .unwrap();
     let ver_msg5 = d5
-        .process_confirmations(&used_msgs5, &all_confirmations, 3, &mut thread_rng())
+        .process_confirmations(&used_msgs5, &all_confirmations, &mut thread_rng())
         .unwrap();
     assert_eq!(ver_msg0.len(), 2); // only msg0, msg5 were valid and didn't send invalid complaints
     assert_eq!(ver_msg1.len(), 2);
@@ -342,7 +330,7 @@ fn test_process_message_failures() {
         &mut thread_rng(),
     )
     .unwrap();
-    let mut invalid_msg = d1.create_message(&mut thread_rng());
+    let mut invalid_msg = d1.create_message(&mut thread_rng()).unwrap();
     invalid_msg.sender = 50;
     assert!(d0.process_message(invalid_msg, &mut thread_rng()).is_err());
 
@@ -355,7 +343,7 @@ fn test_process_message_failures() {
         &mut thread_rng(),
     )
     .unwrap();
-    let invalid_msg = d1.create_message(&mut thread_rng());
+    let invalid_msg = d1.create_message(&mut thread_rng()).unwrap();
     assert!(d0.process_message(invalid_msg, &mut thread_rng()).is_err());
 
     // invalid c0
@@ -367,14 +355,14 @@ fn test_process_message_failures() {
         &mut thread_rng(),
     )
     .unwrap();
-    let mut invalid_msg = d1.create_message(&mut thread_rng());
+    let mut invalid_msg = d1.create_message(&mut thread_rng()).unwrap();
     let mut poly: Vec<G> = invalid_msg.vss_pk.as_vec().clone();
     poly[0] = G::zero();
     invalid_msg.vss_pk = poly.into();
     assert!(d0.process_message(invalid_msg, &mut thread_rng()).is_err());
 
     // invalid number of encrypted shares
-    let mut msg1 = d1.create_message(&mut thread_rng());
+    let mut msg1 = d1.create_message(&mut thread_rng()).unwrap();
     // Switch the encrypted shares of two receivers.
     let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg1);
     pk_and_msgs.swap(0, 1);
@@ -390,7 +378,7 @@ fn test_process_message_failures() {
     };
 
     // invalid encryption's proof
-    let mut msg1 = d1.create_message(&mut thread_rng());
+    let mut msg1 = d1.create_message(&mut thread_rng()).unwrap();
     // Switch the encrypted shares of two receivers.
     msg1.encrypted_shares.swap_for_testing(0, 1);
     assert!(d0.process_message(msg1, &mut thread_rng()).is_err());
@@ -405,8 +393,8 @@ fn test_process_message_failures() {
         &mut thread_rng(),
     )
     .unwrap();
-    let msg1_from_another_d1 = another_d1.create_message(&mut thread_rng());
-    let mut msg1 = d1.create_message(&mut thread_rng());
+    let msg1_from_another_d1 = another_d1.create_message(&mut thread_rng()).unwrap();
+    let mut msg1 = d1.create_message(&mut thread_rng()).unwrap();
     msg1.encrypted_shares = msg1_from_another_d1.encrypted_shares;
     let ProcessedMessage {
         message: _,
@@ -457,16 +445,18 @@ fn test_test_process_confirmations() {
     )
     .unwrap();
 
-    let msg0 = d0.create_message(&mut thread_rng());
-    let msg1 = d1.create_message(&mut thread_rng());
-    let msg2 = d2.create_message(&mut thread_rng());
-    let mut msg3 = d3.create_message(&mut thread_rng());
+    let msg0 = d0.create_message(&mut thread_rng()).unwrap();
+    let msg1 = d1.create_message(&mut thread_rng()).unwrap();
+    assert!(d2.create_message(&mut thread_rng()).is_err()); // zero weight
+    let mut msg3 = d3.create_message(&mut thread_rng()).unwrap();
     let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg3);
     pk_and_msgs.swap(0, 1);
     msg3.encrypted_shares =
         MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 3"), &mut thread_rng());
 
-    let all_messages = vec![msg0, msg1, msg2, msg3];
+    let all_messages = vec![msg0, msg1, msg3];
+
+    // TODO: Test that process_message ignores messages from nodes with 0 weight
 
     let proc_msg0 = &all_messages
         .iter()
@@ -497,18 +487,17 @@ fn test_test_process_confirmations() {
         .process_confirmations(
             &used_msgs0,
             &[conf0.clone(), conf1.clone(), conf2.clone(), conf3.clone()],
-            3,
             &mut thread_rng(),
         )
         .unwrap();
-    // d3 is ignored because it sent an invalid message
+    // d3 is ignored because it sent an invalid message, d2 is ignored because it's weight is 0
     assert_eq!(
         ver_msg
             .data()
             .iter()
             .map(|m| m.message.sender)
             .collect::<Vec<_>>(),
-        vec![0, 1, 2]
+        vec![0, 1]
     );
 
     // invalid senders should be ignored
@@ -518,18 +507,17 @@ fn test_test_process_confirmations() {
         .process_confirmations(
             &used_msgs0,
             &[conf2.clone(), conf3.clone(), conf7],
-            3,
             &mut thread_rng(),
         )
         .unwrap();
-    // d3 is not ignored since conf7 is ignored
+    // d3 is not ignored since conf7 is ignored, d2 is ignored because it's weight is 0
     assert_eq!(
         ver_msg
             .data()
             .iter()
             .map(|m| m.message.sender)
             .collect::<Vec<_>>(),
-        vec![0, 1, 2, 3]
+        vec![0, 1, 3]
     );
 
     // create an invalid complaint from d4 (invalid recovery package)
@@ -540,7 +528,6 @@ fn test_test_process_confirmations() {
         .process_confirmations(
             &used_msgs0,
             &[conf0.clone(), conf1.clone(), conf2.clone(), conf3.clone()],
-            3,
             &mut thread_rng(),
         )
         .unwrap();
@@ -566,7 +553,7 @@ fn create_message_generates_valid_message() {
         &mut thread_rng(),
     )
     .unwrap();
-    let msg = d.create_message(&mut thread_rng());
+    let msg = d.create_message(&mut thread_rng()).unwrap();
 
     assert_eq!(msg.sender, 1);
     assert_eq!(msg.encrypted_shares.len(), 4);
@@ -577,7 +564,7 @@ fn create_message_generates_valid_message() {
 fn test_mock() {
     let (_, nodes) = gen_keys_and_nodes(4);
     let sk = 321;
-    let t: u32 = 6;
+    let t: u16 = 6;
     let p0: Output<G, EG> = generate_mocked_output(nodes.clone(), 5, sk, 0);
     let p1: Output<G, EG> = generate_mocked_output(nodes.clone(), 5, sk, 1);
     let p2: Output<G, EG> = generate_mocked_output(nodes.clone(), 5, sk, 2);

--- a/fastcrypto-tbls/src/tests/nidkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/nidkg_tests.rs
@@ -24,7 +24,7 @@ pub fn gen_ecies_keys(n: u16) -> Vec<(u16, ecies::PrivateKey<G>, ecies::PublicKe
 
 pub fn setup_party(
     id: usize,
-    threshold: u32,
+    threshold: u16,
     keys: &[(u16, ecies::PrivateKey<G>, ecies::PublicKey<G>)],
 ) -> Party<G> {
     let nodes = keys

--- a/fastcrypto-tbls/src/tests/nodes_tests.rs
+++ b/fastcrypto-tbls/src/tests/nodes_tests.rs
@@ -48,6 +48,15 @@ fn test_new_failures() {
     // too little
     let nodes_vec: Vec<Node<G2Element>> = Vec::new();
     assert!(Nodes::new(nodes_vec).is_err());
+    // too large total weight
+    let mut nodes_vec = get_nodes::<G2Element>(20);
+    nodes_vec[19].weight = u16::MAX - 5;
+    assert!(Nodes::new(nodes_vec).is_err());
+    // zero total weight
+    let mut nodes_vec = get_nodes::<G2Element>(2);
+    nodes_vec[0].weight = 0;
+    nodes_vec[1].weight = 0;
+    assert!(Nodes::new(nodes_vec).is_err());
 }
 
 #[test]

--- a/fastcrypto-tbls/src/tests/nodes_tests.rs
+++ b/fastcrypto-tbls/src/tests/nodes_tests.rs
@@ -10,7 +10,7 @@ use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
 fn get_nodes<G>(n: u16) -> Vec<Node<G>>
 where
@@ -23,7 +23,7 @@ where
         .map(|i| Node {
             id: i,
             pk: pk.clone(),
-            weight: 1 + i,
+            weight: if i > 10 { 10 + i % 10 } else { 1 + i },
         })
         .collect()
 }
@@ -69,19 +69,19 @@ fn test_zero_weight() {
     let nodes1 = Nodes::new(nodes_vec.clone()).unwrap();
     assert_eq!(
         nodes1
-            .share_id_to_node(&NonZeroU32::new(1).unwrap())
+            .share_id_to_node(&NonZeroU16::new(1).unwrap())
             .unwrap()
             .id,
         0
     );
     assert_eq!(
         nodes1
-            .share_id_to_node(&NonZeroU32::new(2).unwrap())
+            .share_id_to_node(&NonZeroU16::new(2).unwrap())
             .unwrap()
             .id,
         1
     );
-    assert_eq!(nodes1.share_ids_of(0), vec![NonZeroU32::new(1).unwrap()]);
+    assert_eq!(nodes1.share_ids_of(0), vec![NonZeroU16::new(1).unwrap()]);
 
     // first node's weight is 0
     let mut nodes_vec = get_nodes::<G2Element>(10);
@@ -89,14 +89,14 @@ fn test_zero_weight() {
     let nodes1 = Nodes::new(nodes_vec.clone()).unwrap();
     assert_eq!(
         nodes1
-            .share_id_to_node(&NonZeroU32::new(1).unwrap())
+            .share_id_to_node(&NonZeroU16::new(1).unwrap())
             .unwrap()
             .id,
         1
     );
     assert_eq!(
         nodes1
-            .share_id_to_node(&NonZeroU32::new(2).unwrap())
+            .share_id_to_node(&NonZeroU16::new(2).unwrap())
             .unwrap()
             .id,
         1
@@ -109,7 +109,7 @@ fn test_zero_weight() {
     let nodes1 = Nodes::new(nodes_vec.clone()).unwrap();
     assert_eq!(
         nodes1
-            .share_id_to_node(&NonZeroU32::new(nodes1.total_weight()).unwrap())
+            .share_id_to_node(&NonZeroU16::new(nodes1.total_weight()).unwrap())
             .unwrap()
             .id,
         8
@@ -122,7 +122,7 @@ fn test_zero_weight() {
     let nodes1 = Nodes::new(nodes_vec.clone()).unwrap();
     assert_eq!(
         nodes1
-            .share_id_to_node(&NonZeroU32::new(4).unwrap())
+            .share_id_to_node(&NonZeroU16::new(4).unwrap())
             .unwrap()
             .id,
         3
@@ -134,49 +134,49 @@ fn test_zero_weight() {
 fn test_interfaces() {
     let nodes_vec = get_nodes::<G2Element>(100);
     let nodes = Nodes::new(nodes_vec.clone()).unwrap();
-    assert_eq!(nodes.total_weight(), 5050);
+    assert_eq!(nodes.total_weight(), 1361);
     assert_eq!(nodes.num_nodes(), 100);
     assert!(nodes
         .share_ids_iter()
-        .zip(1u32..=5050)
+        .zip(1u16..=5050)
         .all(|(a, b)| a.get() == b));
 
     assert_eq!(
         nodes
-            .share_id_to_node(&NonZeroU32::new(1).unwrap())
+            .share_id_to_node(&NonZeroU16::new(1).unwrap())
             .unwrap(),
         &nodes_vec[0]
     );
     assert_eq!(
         nodes
-            .share_id_to_node(&NonZeroU32::new(3).unwrap())
+            .share_id_to_node(&NonZeroU16::new(3).unwrap())
             .unwrap(),
         &nodes_vec[1]
     );
     assert_eq!(
         nodes
-            .share_id_to_node(&NonZeroU32::new(4).unwrap())
+            .share_id_to_node(&NonZeroU16::new(4).unwrap())
             .unwrap(),
         &nodes_vec[2]
     );
     assert_eq!(
         nodes
-            .share_id_to_node(&NonZeroU32::new(5050).unwrap())
+            .share_id_to_node(&NonZeroU16::new(1361).unwrap())
             .unwrap(),
         &nodes_vec[99]
     );
     assert!(nodes
-        .share_id_to_node(&NonZeroU32::new(5051).unwrap())
+        .share_id_to_node(&NonZeroU16::new(1362).unwrap())
         .is_err());
     assert!(nodes
-        .share_id_to_node(&NonZeroU32::new(15051).unwrap())
+        .share_id_to_node(&NonZeroU16::new(15051).unwrap())
         .is_err());
 
     assert_eq!(nodes.node_id_to_node(1).unwrap(), &nodes_vec[1]);
 
     assert_eq!(
         nodes.share_ids_of(1),
-        vec![NonZeroU32::new(2).unwrap(), NonZeroU32::new(3).unwrap()]
+        vec![NonZeroU16::new(2).unwrap(), NonZeroU16::new(3).unwrap()]
     );
 }
 
@@ -215,11 +215,17 @@ fn test_reduce_with_lower_bounds() {
     assert_eq!(t, new_t);
 
     // 10% gap
-    let (new_nodes1, _new_t1) = nodes.reduce(t, (nodes.total_weight() / 20) as u16, 1);
+    let (new_nodes1, _new_t1) = nodes.reduce(t, (nodes.total_weight() / 10) as u16, 1);
     let (new_nodes2, _new_t2) = nodes.reduce(
         t,
-        (nodes.total_weight() / 20) as u16,
+        (nodes.total_weight() / 10) as u16,
         nodes.total_weight() / 3,
+    );
+    println!(
+        "new_nodes1.total_weight() = {}, new_nodes2.total_weight() = {}, nodes.total_weight() = {}",
+        new_nodes1.total_weight(),
+        new_nodes2.total_weight(),
+        nodes.total_weight()
     );
     assert!(new_nodes1.total_weight() < new_nodes2.total_weight());
     assert!(new_nodes2.total_weight() >= nodes.total_weight() / 3);

--- a/fastcrypto-tbls/src/tests/polynomial_tests.rs
+++ b/fastcrypto-tbls/src/tests/polynomial_tests.rs
@@ -11,9 +11,9 @@ use fastcrypto::groups::bls12381::{G1Element, G2Element, Scalar as BlsScalar};
 use fastcrypto::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use fastcrypto::groups::{GroupElement, MultiScalarMul, Scalar};
 use rand::prelude::*;
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
-const I10: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(10) };
+const I10: NonZeroU16 = unsafe { NonZeroU16::new_unchecked(10) };
 
 #[generic_tests::define]
 mod scalar_tests {
@@ -21,7 +21,7 @@ mod scalar_tests {
 
     #[test]
     fn test_degree<S: Scalar>() {
-        let s: u32 = 5;
+        let s: u16 = 5;
         let p = Poly::<S>::rand(s, &mut thread_rng());
         assert_eq!(p.degree(), s);
     }
@@ -106,9 +106,9 @@ mod points_tests {
         let coeff = vec![one, one, one];
         let p = Poly::<G::ScalarType>::from(coeff);
         assert_eq!(p.degree(), 2);
-        let s1 = p.eval(NonZeroU32::new(10).unwrap());
-        let s2 = p.eval(NonZeroU32::new(20).unwrap());
-        let s3 = p.eval(NonZeroU32::new(30).unwrap());
+        let s1 = p.eval(NonZeroU16::new(10).unwrap());
+        let s2 = p.eval(NonZeroU16::new(20).unwrap());
+        let s3 = p.eval(NonZeroU16::new(30).unwrap());
         let shares = vec![s1, s2, s3];
         assert_eq!(
             Poly::<G::ScalarType>::recover_c0(3, shares.iter()).unwrap(),
@@ -138,9 +138,9 @@ mod points_tests {
         let coeff = vec![one, one, one];
         let p = Poly::<G>::from(coeff);
         assert_eq!(p.degree(), 2);
-        let s1 = p.eval(NonZeroU32::new(10).unwrap());
-        let s2 = p.eval(NonZeroU32::new(20).unwrap());
-        let s3 = p.eval(NonZeroU32::new(30).unwrap());
+        let s1 = p.eval(NonZeroU16::new(10).unwrap());
+        let s2 = p.eval(NonZeroU16::new(20).unwrap());
+        let s3 = p.eval(NonZeroU16::new(30).unwrap());
         let shares = vec![s1, s2, s3];
         assert_eq!(Poly::<G>::recover_c0_msm(3, shares.iter()).unwrap(), one);
 

--- a/fastcrypto-tbls/src/tests/tbls_tests.rs
+++ b/fastcrypto-tbls/src/tests/tbls_tests.rs
@@ -9,7 +9,7 @@ use crate::{tbls::ThresholdBls, types::ThresholdBls12381MinSig};
 use fastcrypto::groups::bls12381::{G1Element, G2Element, Scalar};
 use fastcrypto::groups::{bls12381, GroupElement};
 use rand::prelude::*;
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
 #[test]
 fn test_tbls_e2e() {
@@ -17,9 +17,9 @@ fn test_tbls_e2e() {
     let private_poly = Poly::<bls12381::Scalar>::rand(t - 1, &mut thread_rng());
     let public_poly = private_poly.commit();
 
-    let share1 = private_poly.eval(NonZeroU32::new(1).unwrap());
-    let share2 = private_poly.eval(NonZeroU32::new(10).unwrap());
-    let share3 = private_poly.eval(NonZeroU32::new(100).unwrap());
+    let share1 = private_poly.eval(NonZeroU16::new(1).unwrap());
+    let share2 = private_poly.eval(NonZeroU16::new(10).unwrap());
+    let share3 = private_poly.eval(NonZeroU16::new(100).unwrap());
 
     let msg = b"test";
     let sig1 = ThresholdBls12381MinSig::partial_sign(&share1, msg);
@@ -45,7 +45,7 @@ fn test_tbls_e2e() {
         full_sig,
         ThresholdBls12381MinSig::partial_sign(
             &Share {
-                index: NonZeroU32::new(1234).unwrap(),
+                index: NonZeroU16::new(1234).unwrap(),
                 value: *private_poly.c0()
             },
             msg
@@ -60,9 +60,9 @@ fn test_partial_verify_batch() {
     let private_poly = Poly::<bls12381::Scalar>::rand(t - 1, &mut thread_rng());
     let public_poly = private_poly.commit();
 
-    let share1 = private_poly.eval(NonZeroU32::new(1).unwrap());
-    let share2 = private_poly.eval(NonZeroU32::new(10).unwrap());
-    let share3 = private_poly.eval(NonZeroU32::new(100).unwrap());
+    let share1 = private_poly.eval(NonZeroU16::new(1).unwrap());
+    let share2 = private_poly.eval(NonZeroU16::new(10).unwrap());
+    let share3 = private_poly.eval(NonZeroU16::new(100).unwrap());
     let shares = [share1, share2, share3];
 
     let msg = b"test";
@@ -155,40 +155,40 @@ fn test_verify_poly_evals() {
     // standard evals should pass
     let shares = [1, 10, 100]
         .into_iter()
-        .map(|i| private_poly.eval(NonZeroU32::new(i).unwrap()))
+        .map(|i| private_poly.eval(NonZeroU16::new(i).unwrap()))
         .collect::<Vec<_>>();
     assert!(verify_poly_evals(&shares, &public_poly, &mut thread_rng()).is_ok());
     // even if repeated
     let shares = [1, 10, 10]
         .into_iter()
-        .map(|i| private_poly.eval(NonZeroU32::new(i).unwrap()))
+        .map(|i| private_poly.eval(NonZeroU16::new(i).unwrap()))
         .collect::<Vec<_>>();
     assert!(verify_poly_evals(&shares, &public_poly, &mut thread_rng()).is_ok());
     // invalid evals according to the polynomial should fail
     let mut shares = [1, 10, 100]
         .into_iter()
-        .map(|i| private_poly.eval(NonZeroU32::new(i).unwrap()))
+        .map(|i| private_poly.eval(NonZeroU16::new(i).unwrap()))
         .collect::<Vec<_>>();
     (shares[0].index, shares[1].index) = (shares[1].index, shares[0].index);
     assert!(verify_poly_evals(&shares, &public_poly, &mut thread_rng()).is_err());
     // identity as the eval should fail
     let mut shares = [1, 10, 100]
         .into_iter()
-        .map(|i| private_poly.eval(NonZeroU32::new(i).unwrap()))
+        .map(|i| private_poly.eval(NonZeroU16::new(i).unwrap()))
         .collect::<Vec<_>>();
     shares[0].value = Scalar::zero();
     assert!(verify_poly_evals(&shares, &public_poly, &mut thread_rng()).is_err());
     // generator as the eval should fail
     let mut shares = [1, 10, 100]
         .into_iter()
-        .map(|i| private_poly.eval(NonZeroU32::new(i).unwrap()))
+        .map(|i| private_poly.eval(NonZeroU16::new(i).unwrap()))
         .collect::<Vec<_>>();
     shares[0].value = Scalar::generator();
     assert!(verify_poly_evals(&shares, &public_poly, &mut thread_rng()).is_err());
     // even if the sum of evals is ok, should fail since not consistent with the polynomial
     let mut shares = [1, 10, 100]
         .into_iter()
-        .map(|i| private_poly.eval(NonZeroU32::new(i).unwrap()))
+        .map(|i| private_poly.eval(NonZeroU16::new(i).unwrap()))
         .collect::<Vec<_>>();
     shares[0].value += Scalar::generator();
     shares[1].value -= Scalar::generator();

--- a/fastcrypto-tbls/src/types.rs
+++ b/fastcrypto-tbls/src/types.rs
@@ -7,7 +7,7 @@ use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::ristretto255::RistrettoPoint;
 use fastcrypto::groups::{bls12381, GroupElement, HashToGroupElement, Pairing};
 use serde::{Deserialize, Serialize};
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
 /// Implementation of [ThresholdBls] for BLS12-381-min-sig. A variant for BLS12-381-min-pk can be
 /// defined in a similar way if needed in the future.
@@ -41,7 +41,7 @@ pub type Signature = <ThresholdBls12381MinSig as tbls::ThresholdBls>::Signature;
 pub type RawSignature = bls12381::G1ElementAsBytes;
 
 /// Indexes of shares/private keys (0 is reserved for the secret itself).
-pub type ShareIndex = NonZeroU32;
+pub type ShareIndex = NonZeroU16;
 
 /// Wrapper of a value that is associated with a specific index.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/fastcrypto/src/error.rs
+++ b/fastcrypto/src/error.rs
@@ -48,6 +48,10 @@ pub enum FastCryptoError {
     #[error("Invalid message was given to the function")]
     InvalidMessage,
 
+    /// Message should be ignored
+    #[error("Message should be ignored")]
+    IgnoredMessage,
+
     /// General cryptographic error.
     #[error("General cryptographic error: {0}")]
     GeneralError(String),


### PR DESCRIPTION
- use u16 instead of unsafe conversions
- more documentation
- create message for 0 weight should fail, and similarly sanity check of that message
- fix the expected threshold for process confirmations (instead of a caller supplied argument)