### PR TITLE
Align error handling and clean up `encoding`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,16 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
-name = "eyre"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastcrypto"
 version = "0.1.8"
 dependencies = [
@@ -1389,7 +1379,6 @@ dependencies = [
  "ecdsa 0.16.6",
  "ed25519-consensus",
  "elliptic-curve 0.13.4",
- "eyre",
  "fastcrypto-derive",
  "faster-hex",
  "generic-array",
@@ -1970,12 +1959,6 @@ dependencies = [
  "typenum",
  "version_check",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/MystenLabs/fastcrypto"
 base64ct = { version = "1.5.3", features = ["alloc"] }
 bs58 = "0.4.0"
 ed25519-consensus = { version = "2.1.0", features = ["serde"] }
-eyre = "0.6.8"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 hkdf = { version = "0.12.3", features = ["std"] }

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -32,6 +32,10 @@ use std::{
     mem::MaybeUninit,
     str::FromStr,
 };
+#[cfg(any(test, feature = "experimental"))]
+use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature};
+#[cfg(any(test, feature = "experimental"))]
+use crate::error::FastCryptoResult;
 
 /// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
 /// and of the second using 96 bytes. BLS supports two modes:

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -32,7 +32,8 @@ use std::{
     mem::MaybeUninit,
     str::FromStr,
 };
-use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidSignature, InvalidInput};
+
+use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature};
 use crate::error::FastCryptoResult;
 
 /// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
@@ -43,659 +44,677 @@ use crate::error::FastCryptoResult;
 /// Below we define BLS related objects for each of the modes, see instantiations
 /// [fastcrypto::bls12381::min_sig] and [fastcrypto::bls12381::min_pk].
 macro_rules! define_bls12381 {
-(
+    (
     $pk_length:expr,
     $sig_length:expr,
     $dst_string:expr
 ) => {
-
-/// BLS 12-381 public key.
-///
-/// For optimizing performance, throughout this module we assume that before being used, public keys
-/// are:
-/// * Validated by calling [BLS12381PublicKey::validate]), and,
-/// * Proof-of-Possession (PoP) is performed on them as a protection against rough key attacks.
-#[readonly::make]
-#[derive(Clone)]
-pub struct BLS12381PublicKey {
-    pub pubkey: blst::PublicKey,
-    pub bytes: OnceCell<[u8; $pk_length]>,
-}
-
-/// BLS 12-381 private key.
-#[readonly::make]
-#[derive(SilentDebug, SilentDisplay)]
-pub struct BLS12381PrivateKey {
-    pub privkey: blst::SecretKey,
-    pub bytes: OnceCell<zeroize::Zeroizing<[u8; BLS_PRIVATE_KEY_LENGTH]>>,
-}
-
-/// BLS 12-381 key pair.
-#[derive(Debug, PartialEq, Eq)]
-pub struct BLS12381KeyPair {
-    public: BLS12381PublicKey,
-    private: BLS12381PrivateKey,
-}
-
-/// BLS 12-381 signature.
-#[readonly::make]
-#[derive(Debug, Clone)]
-pub struct BLS12381Signature {
-    pub sig: blst::Signature,
-    pub bytes: OnceCell<[u8; $sig_length]>,
-}
-
-/// Aggregation of multiple BLS 12-381 signatures.
-#[readonly::make]
-#[derive(Debug, Clone)]
-pub struct BLS12381AggregateSignature {
-    pub sig: blst::Signature,
-    pub bytes: OnceCell<[u8; $sig_length]>,
-}
-
-//
-// Boilerplate code for [BLS12381PublicKey].
-//
-
-impl std::hash::Hash for BLS12381PublicKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state);
-    }
-}
-
-impl PartialEq for BLS12381PublicKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.pubkey == other.pubkey
-    }
-}
-
-impl Eq for BLS12381PublicKey {}
-
-impl PartialOrd for BLS12381PublicKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for BLS12381PublicKey {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.as_ref().cmp(other.as_ref())
-    }
-}
-
-impl_base64_display_fmt!(BLS12381PublicKey);
-
-impl Debug for BLS12381PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl AsRef<[u8]> for BLS12381PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| self.pubkey.to_bytes())
-    }
-}
-
-impl ToFromBytes for BLS12381PublicKey {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // key_validate() does NOT validate the public key. Please use validate() where needed.
-        let pubkey =
-            blst::PublicKey::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381PublicKey {
-            pubkey,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-//
-// Custom code for [BLS12381PublicKey].
-//
-
-// Needed since the current NW implementation requires default public keys.
-// Note that deserialization of this object will fail if we validate it is a valid public key.
-impl InsecureDefault for BLS12381PublicKey {
-    fn insecure_default() -> Self {
-        BLS12381PublicKey {
-            pubkey: blst::PublicKey::default(),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
-generate_bytes_representation!(BLS12381PublicKey, {$pk_length}, BLS12381PublicKeyAsBytes);
-
-impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
-    fn from(secret: &'a BLS12381PrivateKey) -> Self {
-        let inner = &secret.privkey;
-        let pubkey = inner.sk_to_pk();
-        BLS12381PublicKey {
-            pubkey,
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-// TODO: Once NW does not need to ser/deser public keys in many places we should call validate
-// during deserialization and get rid of this function.
-impl BLS12381PublicKey {
-    pub fn validate(&self) -> Result<(), FastCryptoError> {
-        self.pubkey.validate().map_err(|_e| FastCryptoError::InvalidInput)
-    }
-}
-
-impl VerifyingKey for BLS12381PublicKey {
-    type PrivKey = BLS12381PrivateKey;
-    type Sig = BLS12381Signature;
-    const LENGTH: usize = $pk_length;
-
-    fn verify(&self, msg: &[u8], signature: &BLS12381Signature) -> Result<(), FastCryptoError> {
-        // verify() only validates the signature. Please use pk that was validated.
-        let err = signature
-            .sig
-            .verify(true, msg, $dst_string, &[], &self.pubkey, false);
-        if err == BLST_ERROR::BLST_SUCCESS {
-            Ok(())
-        } else {
-            Err(InvalidSignature)
-        }
-    }
-
-    #[cfg(any(test, feature = "experimental"))]
-    fn verify_batch_empty_fail(
-        msg: &[u8],
-        pks: &[Self],
-        sigs: &[Self::Sig],
-    ) -> FastCryptoResult<()> {
-        if sigs.is_empty() {
-            // This behaviour can signal something dangerous, and that someone may be trying to
-            // bypass signature verification through providing empty batches.
-            return Err(GeneralOpaqueError);
-        }
-        if sigs.len() != pks.len() {
-            return Err(InvalidInput);
-        }
-        let aggregated_sig = BLS12381AggregateSignature::aggregate(sigs)
-            .map_err(|_| GeneralOpaqueError)?;
-        aggregated_sig
-            .verify(pks, msg)
-            .map_err(|_| InvalidSignature)
-    }
-
-    #[cfg(any(test, feature = "experimental"))]
-    fn verify_batch_empty_fail_different_msg<'a, M>(
-        msgs: &[M],
-        pks: &[Self],
-        sigs: &[Self::Sig],
-    ) -> FastCryptoResult<()>
-    where
-        M: Borrow<[u8]> + 'a,
-    {
-        if sigs.is_empty() {
-            // This behaviour can signal something dangerous, and that someone may be trying to
-            // bypass signature verification through providing empty batches.
-            return Err(GeneralOpaqueError);
-        }
-        if sigs.len() != pks.len() {
-            return Err(InvalidInput);
+        /// BLS 12-381 public key.
+        ///
+        /// For optimizing performance, throughout this module we assume that before being used, public keys
+        /// are:
+        /// * Validated by calling [BLS12381PublicKey::validate]), and,
+        /// * Proof-of-Possession (PoP) is performed on them as a protection against rough key attacks.
+        #[readonly::make]
+        #[derive(Clone)]
+        pub struct BLS12381PublicKey {
+            pub pubkey: blst::PublicKey,
+            pub bytes: OnceCell<[u8; $pk_length]>,
         }
 
-        let rands = get_random_scalars(sigs.len());
-
-        let result = blst::Signature::verify_multiple_aggregate_signatures(
-            &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
-            $dst_string,
-            &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
-            false,
-            &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
-            true,
-            &rands,
-            BLS_BATCH_RANDOM_SCALAR_LENGTH,
-        );
-        if result == BLST_ERROR::BLST_SUCCESS {
-            Ok(())
-        } else {
-            Err(InvalidSignature)
+        /// BLS 12-381 private key.
+        #[readonly::make]
+        #[derive(SilentDebug, SilentDisplay)]
+        pub struct BLS12381PrivateKey {
+            pub privkey: blst::SecretKey,
+            pub bytes: OnceCell<zeroize::Zeroizing<[u8; BLS_PRIVATE_KEY_LENGTH]>>,
         }
-    }
-}
 
-fn get_random_scalar<Rng: AllowedRng>(rng: &mut Rng) -> blst_scalar {
-    static_assertions::const_assert!(
-        64 <= BLS_BATCH_RANDOM_SCALAR_LENGTH && BLS_BATCH_RANDOM_SCALAR_LENGTH <= 128
-    );
-
-    let mut vals = [0u64; 4];
-    loop {
-        vals[0] = rng.next_u64();
-        vals[1] = rng.next_u64();
-
-        // Reject zero as it is used for multiplication.
-        let vals1_lsb = vals[1] & (((1u128 << (BLS_BATCH_RANDOM_SCALAR_LENGTH - 64)) - 1) as u64);
-        if vals[0] | vals1_lsb != 0 {
-            break;
+        /// BLS 12-381 key pair.
+        #[derive(Debug, PartialEq, Eq)]
+        pub struct BLS12381KeyPair {
+            public: BLS12381PublicKey,
+            private: BLS12381PrivateKey,
         }
-    }
-    let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
-    unsafe {
-        blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
-        return rand_i.assume_init();
-    }
-}
 
-fn get_one() -> blst_scalar {
-    let mut one = blst_scalar::default();
-    let mut vals = [0u8; 32];
-    vals[0] = 1;
-    unsafe {
-        blst_scalar_from_le_bytes(&mut one, vals.as_ptr(), 32);
-    }
-    one
-}
-
-// Always generates 128bit numbers though not all the bits must be used.
-fn get_random_scalars(n: usize) -> Vec<blst_scalar> {
-    if n == 0 {
-        return Vec::new();
-    }
-    let mut rands: Vec<blst_scalar> = Vec::with_capacity(n);
-    // The first coefficient can safely be set to 1 (see https://github.com/MystenLabs/fastcrypto/issues/120)
-    rands.push(get_one());
-    let mut rng = rand::thread_rng();
-    (1..n).into_iter().for_each(|_| rands.push(get_random_scalar(&mut rng)));
-    rands
-}
-
-//
-// Boilerplate code for [BLS12381PrivateKey].
-//
-
-impl PartialEq for BLS12381PrivateKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl Eq for BLS12381PrivateKey {}
-
-// All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
-// ZeroizeOnDrop).
-impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
-
-impl AsRef<[u8]> for BLS12381PrivateKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| zeroize::Zeroizing::new(self.privkey.to_bytes())).as_ref()
-    }
-}
-
-impl ToFromBytes for BLS12381PrivateKey {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // from_bytes() validates that the key is in the right group.
-        let privkey =
-            blst::SecretKey::from_bytes(bytes).map_err(|_e| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381PrivateKey {
-            privkey,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-//
-// Custom code for [BLS12381PrivateKey].
-//
-
-serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
-
-impl SigningKey for BLS12381PrivateKey {
-    type PubKey = BLS12381PublicKey;
-    type Sig = BLS12381Signature;
-    const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
-}
-
-impl Signer<BLS12381Signature> for BLS12381PrivateKey {
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        BLS12381Signature {
-            sig: self.privkey.sign(msg, $dst_string, &[]),
-            bytes: OnceCell::new(),
+        /// BLS 12-381 signature.
+        #[readonly::make]
+        #[derive(Debug, Clone)]
+        pub struct BLS12381Signature {
+            pub sig: blst::Signature,
+            pub bytes: OnceCell<[u8; $sig_length]>,
         }
-    }
-}
 
-//
-// Boilerplate code for [BLS12381Signature].
-//
-
-impl PartialEq for BLS12381Signature {
-    fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
-    }
-}
-
-impl Eq for BLS12381Signature {}
-
-impl std::hash::Hash for BLS12381Signature {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state);
-    }
-}
-
-impl AsRef<[u8]> for BLS12381Signature {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| self.sig.to_bytes())
-    }
-}
-
-impl ToFromBytes for BLS12381Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // from_bytes() does NOT check if the signature is in the right group. We check that when
-        // verifying the signature.
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381Signature {
-            sig,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-impl_base64_display_fmt!(BLS12381Signature);
-
-//
-// Custom code for [BLS12381Signature].
-//
-
-serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
-
-impl Default for BLS12381Signature {
-    fn default() -> Self {
-        // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
-        // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
-        let mut infinity: [u8; $sig_length] = [0; $sig_length];
-        infinity[0] = 0xc0;
-
-        BLS12381Signature {
-            sig: blst::Signature::from_bytes(&infinity).expect("Should decode infinity signature"),
-            bytes: OnceCell::new(),
+        /// Aggregation of multiple BLS 12-381 signatures.
+        #[readonly::make]
+        #[derive(Debug, Clone)]
+        pub struct BLS12381AggregateSignature {
+            pub sig: blst::Signature,
+            pub bytes: OnceCell<[u8; $sig_length]>,
         }
-    }
-}
 
-impl Authenticator for BLS12381Signature {
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-    const LENGTH: usize = $sig_length;
-}
+        //
+        // Boilerplate code for [BLS12381PublicKey].
+        //
 
-//
-// Boilerplate code for [BLS12381KeyPair].
-//
-
-impl From<BLS12381PrivateKey> for BLS12381KeyPair {
-    fn from(private: BLS12381PrivateKey) -> Self {
-        let public = BLS12381PublicKey::from(&private);
-        BLS12381KeyPair { public, private }
-    }
-}
-
-/// The bytes form of the keypair only contain the private key bytes
-impl AsRef<[u8]> for BLS12381KeyPair {
-    fn as_ref(&self) -> &[u8] {
-        self.private.as_ref()
-    }
-}
-
-impl ToFromBytes for BLS12381KeyPair {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
-    }
-}
-
-//
-// Custom code for [BLS12381KeyPair].
-//
-
-serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
-
-impl KeyPair for BLS12381KeyPair {
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-    type Sig = BLS12381Signature;
-
-    fn public(&'_ self) -> &'_ Self::PubKey {
-        &self.public
-    }
-
-    fn private(self) -> Self::PrivKey {
-        BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
-    }
-
-    #[cfg(feature = "copy_key")]
-    fn copy(&self) -> Self {
-        BLS12381KeyPair {
-            public: self.public.clone(),
-            private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+        impl std::hash::Hash for BLS12381PublicKey {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.as_ref().hash(state);
+            }
         }
-    }
 
-    fn generate<R: AllowedRng>(rng: &mut R) -> Self {
-        let mut ikm = [0u8; 32];
-        rng.fill_bytes(&mut ikm);
-        // TODO: Consider moving to key gen version 5.
-        let privkey = blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
-        let pubkey = privkey.sk_to_pk();
-        BLS12381KeyPair {
-            public: BLS12381PublicKey {
-                pubkey,
-                bytes: OnceCell::new(),
-            },
-            private: BLS12381PrivateKey {
-                privkey,
-                bytes: OnceCell::new(),
-            },
+        impl PartialEq for BLS12381PublicKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.pubkey == other.pubkey
+            }
         }
-    }
-}
 
-impl Signer<BLS12381Signature> for BLS12381KeyPair {
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        self.private.sign(msg)
-    }
-}
+        impl Eq for BLS12381PublicKey {}
 
-impl FromStr for BLS12381KeyPair {
-    type Err = FastCryptoError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::decode_base64(s)
-    }
-}
-
-//
-// Boilerplate code for [BLS12381AggregateSignature].
-//
-
-impl_base64_display_fmt!(BLS12381AggregateSignature);
-
-impl PartialEq for BLS12381AggregateSignature {
-    fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
-    }
-}
-
-impl Eq for BLS12381AggregateSignature {}
-
-impl Default for BLS12381AggregateSignature {
-    fn default() -> Self {
-        BLS12381Signature::default().into()
-    }
-}
-
-impl AsRef<[u8]> for BLS12381AggregateSignature {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| self.sig.to_bytes())
-    }
-}
-
-impl From <BLS12381Signature> for BLS12381AggregateSignature {
-    fn from(sig: BLS12381Signature) -> Self {
-        BLS12381AggregateSignature {
-            sig: sig.sig,
-            bytes: OnceCell::new(),
+        impl PartialOrd for BLS12381PublicKey {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
         }
-    }
-}
 
-//
-// Custom code for [BLS12381AggregateSignature].
-//
+        impl Ord for BLS12381PublicKey {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                self.as_ref().cmp(other.as_ref())
+            }
+        }
 
-serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
-generate_bytes_representation!(BLS12381AggregateSignature, {$sig_length}, BLS12381AggregateSignatureAsBytes);
+        impl_base64_display_fmt!(BLS12381PublicKey);
 
-impl ToFromBytes for BLS12381AggregateSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // from_bytes does NOT validate the signature. We do that in verify.
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381AggregateSignature {
-            sig,
-            bytes: OnceCell::new(),
-        })
-    }
-}
+        impl Debug for BLS12381PublicKey {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                write!(f, "{}", Base64::encode(self.as_ref()))
+            }
+        }
 
-impl AggregateAuthenticator for BLS12381AggregateSignature {
-    type Sig = BLS12381Signature;
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
+        impl AsRef<[u8]> for BLS12381PublicKey {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes.get_or_init::<_>(|| self.pubkey.to_bytes())
+            }
+        }
 
-    fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
-        signatures: I,
-    ) -> Result<Self, FastCryptoError> {
-        // aggregate() below does not validate signatures.
-        blst::AggregateSignature::aggregate(
-            &signatures
+        impl ToFromBytes for BLS12381PublicKey {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // key_validate() does NOT validate the public key. Please use validate() where needed.
+                let pubkey = blst::PublicKey::from_bytes(bytes)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381PublicKey {
+                    pubkey,
+                    bytes: OnceCell::new(),
+                })
+            }
+        }
+
+        //
+        // Custom code for [BLS12381PublicKey].
+        //
+
+        // Needed since the current NW implementation requires default public keys.
+        // Note that deserialization of this object will fail if we validate it is a valid public key.
+        impl InsecureDefault for BLS12381PublicKey {
+            fn insecure_default() -> Self {
+                BLS12381PublicKey {
+                    pubkey: blst::PublicKey::default(),
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
+        generate_bytes_representation!(BLS12381PublicKey, { $pk_length }, BLS12381PublicKeyAsBytes);
+
+        impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
+            fn from(secret: &'a BLS12381PrivateKey) -> Self {
+                let inner = &secret.privkey;
+                let pubkey = inner.sk_to_pk();
+                BLS12381PublicKey {
+                    pubkey,
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        // TODO: Once NW does not need to ser/deser public keys in many places we should call validate
+        // during deserialization and get rid of this function.
+        impl BLS12381PublicKey {
+            pub fn validate(&self) -> Result<(), FastCryptoError> {
+                self.pubkey
+                    .validate()
+                    .map_err(|_e| FastCryptoError::InvalidInput)
+            }
+        }
+
+        impl VerifyingKey for BLS12381PublicKey {
+            type PrivKey = BLS12381PrivateKey;
+            type Sig = BLS12381Signature;
+            const LENGTH: usize = $pk_length;
+
+            fn verify(
+                &self,
+                msg: &[u8],
+                signature: &BLS12381Signature,
+            ) -> Result<(), FastCryptoError> {
+                // verify() only validates the signature. Please use pk that was validated.
+                let err = signature
+                    .sig
+                    .verify(true, msg, $dst_string, &[], &self.pubkey, false);
+                if err == BLST_ERROR::BLST_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(InvalidSignature)
+                }
+            }
+
+            #[cfg(any(test, feature = "experimental"))]
+            fn verify_batch_empty_fail(
+                msg: &[u8],
+                pks: &[Self],
+                sigs: &[Self::Sig],
+            ) -> FastCryptoResult<()> {
+                if sigs.is_empty() {
+                    // This behaviour can signal something dangerous, and that someone may be trying to
+                    // bypass signature verification through providing empty batches.
+                    return Err(GeneralOpaqueError);
+                }
+                if sigs.len() != pks.len() {
+                    return Err(InvalidInput);
+                }
+                let aggregated_sig =
+                    BLS12381AggregateSignature::aggregate(sigs).map_err(|_| GeneralOpaqueError)?;
+                aggregated_sig
+                    .verify(pks, msg)
+                    .map_err(|_| InvalidSignature)
+            }
+
+            #[cfg(any(test, feature = "experimental"))]
+            fn verify_batch_empty_fail_different_msg<'a, M>(
+                msgs: &[M],
+                pks: &[Self],
+                sigs: &[Self::Sig],
+            ) -> FastCryptoResult<()>
+            where
+                M: Borrow<[u8]> + 'a,
+            {
+                if sigs.is_empty() {
+                    // This behaviour can signal something dangerous, and that someone may be trying to
+                    // bypass signature verification through providing empty batches.
+                    return Err(GeneralOpaqueError);
+                }
+                if sigs.len() != pks.len() {
+                    return Err(InvalidInput);
+                }
+
+                let rands = get_random_scalars(sigs.len());
+
+                let result = blst::Signature::verify_multiple_aggregate_signatures(
+                    &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+                    $dst_string,
+                    &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
+                    false,
+                    &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
+                    true,
+                    &rands,
+                    BLS_BATCH_RANDOM_SCALAR_LENGTH,
+                );
+                if result == BLST_ERROR::BLST_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(InvalidSignature)
+                }
+            }
+        }
+
+        fn get_random_scalar<Rng: AllowedRng>(rng: &mut Rng) -> blst_scalar {
+            static_assertions::const_assert!(
+                64 <= BLS_BATCH_RANDOM_SCALAR_LENGTH && BLS_BATCH_RANDOM_SCALAR_LENGTH <= 128
+            );
+
+            let mut vals = [0u64; 4];
+            loop {
+                vals[0] = rng.next_u64();
+                vals[1] = rng.next_u64();
+
+                // Reject zero as it is used for multiplication.
+                let vals1_lsb =
+                    vals[1] & (((1u128 << (BLS_BATCH_RANDOM_SCALAR_LENGTH - 64)) - 1) as u64);
+                if vals[0] | vals1_lsb != 0 {
+                    break;
+                }
+            }
+            let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
+            unsafe {
+                blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
+                return rand_i.assume_init();
+            }
+        }
+
+        fn get_one() -> blst_scalar {
+            let mut one = blst_scalar::default();
+            let mut vals = [0u8; 32];
+            vals[0] = 1;
+            unsafe {
+                blst_scalar_from_le_bytes(&mut one, vals.as_ptr(), 32);
+            }
+            one
+        }
+
+        // Always generates 128bit numbers though not all the bits must be used.
+        fn get_random_scalars(n: usize) -> Vec<blst_scalar> {
+            if n == 0 {
+                return Vec::new();
+            }
+            let mut rands: Vec<blst_scalar> = Vec::with_capacity(n);
+            // The first coefficient can safely be set to 1 (see https://github.com/MystenLabs/fastcrypto/issues/120)
+            rands.push(get_one());
+            let mut rng = rand::thread_rng();
+            (1..n)
                 .into_iter()
-                .map(|x| &x.borrow().sig)
-                .collect::<Vec<_>>(),
-            false,
-        )
-        .map(|sig| BLS12381AggregateSignature {
-            sig: sig.to_signature(),
-            bytes: OnceCell::new(),
-        })
-        .map_err(|_| FastCryptoError::InvalidInput)
-    }
-
-    fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
-        let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
-        // add_signature() does not validate the new signature.
-        aggr_sig.add_signature(&signature.sig, false).map_err(|_| FastCryptoError::InvalidInput)?;
-        self.sig = aggr_sig.to_signature();
-        self.bytes.take();
-        Ok(())
-    }
-
-    fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
-        // aggregate() does not validate the new signature.
-        let result = blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
-            .map_err(|_| FastCryptoError::InvalidInput)?.to_signature();
-        self.sig = result;
-        self.bytes.take();
-        Ok(())
-    }
-
-    // This function assumes that that all public keys were verified using a proof of possession.
-    // See comment above [BLS12381PublicKey].
-    fn verify(
-        &self,
-        pks: &[<Self::Sig as Authenticator>::PubKey],
-        message: &[u8],
-    ) -> Result<(), FastCryptoError> {
-        // Validate signatures but not public keys which the user must validate before calling this.
-        let result = self
-            .sig
-            .fast_aggregate_verify(
-                true,
-                message,
-                $dst_string,
-                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-            );
-        if result != BLST_ERROR::BLST_SUCCESS {
-            return Err(FastCryptoError::InvalidSignature);
-        }
-        Ok(())
-    }
-
-    // This function assumes that that all public keys were verified using a proof of possession.
-    // See comment above [BLS12381PublicKey].
-    fn verify_different_msg(
-        &self,
-        pks: &[<Self::Sig as Authenticator>::PubKey],
-        messages: &[&[u8]],
-    ) -> Result<(), FastCryptoError> {
-        // Validate signatures but not public keys which the user must validate before calling this.
-        let result = self
-            .sig
-            .aggregate_verify(
-                true,
-                messages,
-                $dst_string,
-                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-                false,
-            );
-        if result != BLST_ERROR::BLST_SUCCESS {
-            return Err(FastCryptoError::InvalidSignature);
-        }
-        Ok(())
-    }
-
-    fn batch_verify<'a>(
-        signatures: &[&Self],
-        pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
-        messages: &[&[u8]],
-    ) -> Result<(), FastCryptoError> {
-        if signatures.len() != pks.len() || signatures.len() != messages.len() {
-            return Err(FastCryptoError::InputLengthWrong(signatures.len()));
+                .for_each(|_| rands.push(get_random_scalar(&mut rng)));
+            rands
         }
 
-        if signatures.is_empty() {
-            // verify_multiple_aggregate_signatures fails on empty input, but we accept here.
-            return Ok(())
+        //
+        // Boilerplate code for [BLS12381PrivateKey].
+        //
+
+        impl PartialEq for BLS12381PrivateKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.as_ref() == other.as_ref()
+            }
         }
 
-        let mut agg_pks: Vec<blst::PublicKey> = Vec::with_capacity(signatures.len());
-        for keys in pks {
-             let keys_as_vec = keys.map(|x| x.pubkey.borrow()).collect::<Vec<_>>();
-             agg_pks.push(blst::AggregatePublicKey::aggregate(&keys_as_vec, false).unwrap().to_public_key()
-             );
-         }
+        impl Eq for BLS12381PrivateKey {}
 
-        // Validate signatures but not public keys which the user must validate before calling this.
-        let result = blst::Signature::verify_multiple_aggregate_signatures(
-            &messages,
-            $dst_string,
-            &agg_pks.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
-            false,
-            &signatures.iter().map(|agg_sig| &agg_sig.sig).collect::<Vec<_>>(),
-            true,
-            &get_random_scalars(signatures.len()),
-            BLS_BATCH_RANDOM_SCALAR_LENGTH,
+        // All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
+        // ZeroizeOnDrop).
+        impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
+
+        impl AsRef<[u8]> for BLS12381PrivateKey {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes
+                    .get_or_init::<_>(|| zeroize::Zeroizing::new(self.privkey.to_bytes()))
+                    .as_ref()
+            }
+        }
+
+        impl ToFromBytes for BLS12381PrivateKey {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // from_bytes() validates that the key is in the right group.
+                let privkey = blst::SecretKey::from_bytes(bytes)
+                    .map_err(|_e| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381PrivateKey {
+                    privkey,
+                    bytes: OnceCell::new(),
+                })
+            }
+        }
+
+        //
+        // Custom code for [BLS12381PrivateKey].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
+
+        impl SigningKey for BLS12381PrivateKey {
+            type PubKey = BLS12381PublicKey;
+            type Sig = BLS12381Signature;
+            const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
+        }
+
+        impl Signer<BLS12381Signature> for BLS12381PrivateKey {
+            fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+                BLS12381Signature {
+                    sig: self.privkey.sign(msg, $dst_string, &[]),
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        //
+        // Boilerplate code for [BLS12381Signature].
+        //
+
+        impl PartialEq for BLS12381Signature {
+            fn eq(&self, other: &Self) -> bool {
+                self.sig == other.sig
+            }
+        }
+
+        impl Eq for BLS12381Signature {}
+
+        impl std::hash::Hash for BLS12381Signature {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.as_ref().hash(state);
+            }
+        }
+
+        impl AsRef<[u8]> for BLS12381Signature {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes.get_or_init::<_>(|| self.sig.to_bytes())
+            }
+        }
+
+        impl ToFromBytes for BLS12381Signature {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // from_bytes() does NOT check if the signature is in the right group. We check that when
+                // verifying the signature.
+                let sig = blst::Signature::from_bytes(bytes)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381Signature {
+                    sig,
+                    bytes: OnceCell::new(),
+                })
+            }
+        }
+
+        impl_base64_display_fmt!(BLS12381Signature);
+
+        //
+        // Custom code for [BLS12381Signature].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
+
+        impl Default for BLS12381Signature {
+            fn default() -> Self {
+                // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
+                // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
+                let mut infinity: [u8; $sig_length] = [0; $sig_length];
+                infinity[0] = 0xc0;
+
+                BLS12381Signature {
+                    sig: blst::Signature::from_bytes(&infinity)
+                        .expect("Should decode infinity signature"),
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        impl Authenticator for BLS12381Signature {
+            type PubKey = BLS12381PublicKey;
+            type PrivKey = BLS12381PrivateKey;
+            const LENGTH: usize = $sig_length;
+        }
+
+        //
+        // Boilerplate code for [BLS12381KeyPair].
+        //
+
+        impl From<BLS12381PrivateKey> for BLS12381KeyPair {
+            fn from(private: BLS12381PrivateKey) -> Self {
+                let public = BLS12381PublicKey::from(&private);
+                BLS12381KeyPair { public, private }
+            }
+        }
+
+        /// The bytes form of the keypair only contain the private key bytes
+        impl AsRef<[u8]> for BLS12381KeyPair {
+            fn as_ref(&self) -> &[u8] {
+                self.private.as_ref()
+            }
+        }
+
+        impl ToFromBytes for BLS12381KeyPair {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
+            }
+        }
+
+        //
+        // Custom code for [BLS12381KeyPair].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
+
+        impl KeyPair for BLS12381KeyPair {
+            type PubKey = BLS12381PublicKey;
+            type PrivKey = BLS12381PrivateKey;
+            type Sig = BLS12381Signature;
+
+            fn public(&'_ self) -> &'_ Self::PubKey {
+                &self.public
+            }
+
+            fn private(self) -> Self::PrivKey {
+                BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
+            }
+
+            #[cfg(feature = "copy_key")]
+            fn copy(&self) -> Self {
+                BLS12381KeyPair {
+                    public: self.public.clone(),
+                    private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+                }
+            }
+
+            fn generate<R: AllowedRng>(rng: &mut R) -> Self {
+                let mut ikm = [0u8; 32];
+                rng.fill_bytes(&mut ikm);
+                // TODO: Consider moving to key gen version 5.
+                let privkey =
+                    blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
+                let pubkey = privkey.sk_to_pk();
+                BLS12381KeyPair {
+                    public: BLS12381PublicKey {
+                        pubkey,
+                        bytes: OnceCell::new(),
+                    },
+                    private: BLS12381PrivateKey {
+                        privkey,
+                        bytes: OnceCell::new(),
+                    },
+                }
+            }
+        }
+
+        impl Signer<BLS12381Signature> for BLS12381KeyPair {
+            fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+                self.private.sign(msg)
+            }
+        }
+
+        impl FromStr for BLS12381KeyPair {
+            type Err = FastCryptoError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::decode_base64(s)
+            }
+        }
+
+        //
+        // Boilerplate code for [BLS12381AggregateSignature].
+        //
+
+        impl_base64_display_fmt!(BLS12381AggregateSignature);
+
+        impl PartialEq for BLS12381AggregateSignature {
+            fn eq(&self, other: &Self) -> bool {
+                self.sig == other.sig
+            }
+        }
+
+        impl Eq for BLS12381AggregateSignature {}
+
+        impl Default for BLS12381AggregateSignature {
+            fn default() -> Self {
+                BLS12381Signature::default().into()
+            }
+        }
+
+        impl AsRef<[u8]> for BLS12381AggregateSignature {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes.get_or_init::<_>(|| self.sig.to_bytes())
+            }
+        }
+
+        impl From<BLS12381Signature> for BLS12381AggregateSignature {
+            fn from(sig: BLS12381Signature) -> Self {
+                BLS12381AggregateSignature {
+                    sig: sig.sig,
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        //
+        // Custom code for [BLS12381AggregateSignature].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
+        generate_bytes_representation!(
+            BLS12381AggregateSignature,
+            { $sig_length },
+            BLS12381AggregateSignatureAsBytes
         );
-        if result == BLST_ERROR::BLST_SUCCESS {
-            Ok(())
-        } else {
-            Err(FastCryptoError::GeneralOpaqueError)
+
+        impl ToFromBytes for BLS12381AggregateSignature {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // from_bytes does NOT validate the signature. We do that in verify.
+                let sig = blst::Signature::from_bytes(bytes)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381AggregateSignature {
+                    sig,
+                    bytes: OnceCell::new(),
+                })
+            }
         }
-    }
-}
 
-};
+        impl AggregateAuthenticator for BLS12381AggregateSignature {
+            type Sig = BLS12381Signature;
+            type PubKey = BLS12381PublicKey;
+            type PrivKey = BLS12381PrivateKey;
 
+            fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
+                signatures: I,
+            ) -> Result<Self, FastCryptoError> {
+                // aggregate() below does not validate signatures.
+                blst::AggregateSignature::aggregate(
+                    &signatures
+                        .into_iter()
+                        .map(|x| &x.borrow().sig)
+                        .collect::<Vec<_>>(),
+                    false,
+                )
+                .map(|sig| BLS12381AggregateSignature {
+                    sig: sig.to_signature(),
+                    bytes: OnceCell::new(),
+                })
+                .map_err(|_| FastCryptoError::InvalidInput)
+            }
+
+            fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
+                let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
+                // add_signature() does not validate the new signature.
+                aggr_sig
+                    .add_signature(&signature.sig, false)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                self.sig = aggr_sig.to_signature();
+                self.bytes.take();
+                Ok(())
+            }
+
+            fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
+                // aggregate() does not validate the new signature.
+                let result =
+                    blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
+                        .map_err(|_| FastCryptoError::InvalidInput)?
+                        .to_signature();
+                self.sig = result;
+                self.bytes.take();
+                Ok(())
+            }
+
+            // This function assumes that that all public keys were verified using a proof of possession.
+            // See comment above [BLS12381PublicKey].
+            fn verify(
+                &self,
+                pks: &[<Self::Sig as Authenticator>::PubKey],
+                message: &[u8],
+            ) -> Result<(), FastCryptoError> {
+                // Validate signatures but not public keys which the user must validate before calling this.
+                let result = self.sig.fast_aggregate_verify(
+                    true,
+                    message,
+                    $dst_string,
+                    &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+                );
+                if result != BLST_ERROR::BLST_SUCCESS {
+                    return Err(FastCryptoError::InvalidSignature);
+                }
+                Ok(())
+            }
+
+            // This function assumes that that all public keys were verified using a proof of possession.
+            // See comment above [BLS12381PublicKey].
+            fn verify_different_msg(
+                &self,
+                pks: &[<Self::Sig as Authenticator>::PubKey],
+                messages: &[&[u8]],
+            ) -> Result<(), FastCryptoError> {
+                // Validate signatures but not public keys which the user must validate before calling this.
+                let result = self.sig.aggregate_verify(
+                    true,
+                    messages,
+                    $dst_string,
+                    &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+                    false,
+                );
+                if result != BLST_ERROR::BLST_SUCCESS {
+                    return Err(FastCryptoError::InvalidSignature);
+                }
+                Ok(())
+            }
+
+            fn batch_verify<'a>(
+                signatures: &[&Self],
+                pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
+                messages: &[&[u8]],
+            ) -> Result<(), FastCryptoError> {
+                if signatures.len() != pks.len() || signatures.len() != messages.len() {
+                    return Err(FastCryptoError::InputLengthWrong(signatures.len()));
+                }
+
+                if signatures.is_empty() {
+                    // verify_multiple_aggregate_signatures fails on empty input, but we accept here.
+                    return Ok(());
+                }
+
+                let mut agg_pks: Vec<blst::PublicKey> = Vec::with_capacity(signatures.len());
+                for keys in pks {
+                    let keys_as_vec = keys.map(|x| x.pubkey.borrow()).collect::<Vec<_>>();
+                    agg_pks.push(
+                        blst::AggregatePublicKey::aggregate(&keys_as_vec, false)
+                            .unwrap()
+                            .to_public_key(),
+                    );
+                }
+
+                // Validate signatures but not public keys which the user must validate before calling this.
+                let result = blst::Signature::verify_multiple_aggregate_signatures(
+                    &messages,
+                    $dst_string,
+                    &agg_pks.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+                    false,
+                    &signatures
+                        .iter()
+                        .map(|agg_sig| &agg_sig.sig)
+                        .collect::<Vec<_>>(),
+                    true,
+                    &get_random_scalars(signatures.len()),
+                    BLS_BATCH_RANDOM_SCALAR_LENGTH,
+                );
+                if result == BLST_ERROR::BLST_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(FastCryptoError::GeneralOpaqueError)
+                }
+            }
+        }
+    };
 } // macro_rules! define_bls12381.
 
 /// The length of a private key in bytes.

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -24,8 +24,6 @@ use crate::{
 };
 use crate::{generate_bytes_representation, impl_base64_display_fmt};
 use blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
-#[cfg(any(test, feature = "experimental"))]
-use eyre::eyre;
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 use once_cell::sync::OnceCell;
 use std::{

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -15,7 +15,7 @@
 
 #[cfg(any(test, feature = "experimental"))]
 use crate::error::{
-    FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature},
+    FastCryptoError::{InvalidInput, InvalidSignature},
     FastCryptoResult,
 };
 use crate::serde_helpers::BytesRepresentation;

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -219,10 +219,9 @@ impl VerifyingKey for BLS12381PublicKey {
             return Err(InvalidInput);
         }
         let aggregated_sig =
-            BLS12381AggregateSignature::aggregate(sigs).map_err(|_| GeneralOpaqueError)?;
+            BLS12381AggregateSignature::aggregate(sigs)?;
         aggregated_sig
             .verify(pks, msg)
-            .map_err(|_| InvalidSignature)
     }
 
     #[cfg(any(test, feature = "experimental"))]

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -24,6 +24,8 @@ use crate::{
 };
 use crate::{generate_bytes_representation, impl_base64_display_fmt};
 use blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
+#[cfg(any(test, feature = "experimental"))]
+use eyre::eyre;
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 use once_cell::sync::OnceCell;
 use std::{
@@ -33,13 +35,6 @@ use std::{
     str::FromStr,
 };
 
-#[cfg(any(test, feature = "experimental"))]
-use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput};
-#[cfg(any(test, feature = "experimental"))]
-use crate::error::FastCryptoResult;
-
-use crate::error::FastCryptoError::InvalidSignature;
-
 /// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
 /// and of the second using 96 bytes. BLS supports two modes:
 /// - Minimal-signature-size (or min-sig) - signatures are in G1 and public keys are in G2.
@@ -48,677 +43,659 @@ use crate::error::FastCryptoError::InvalidSignature;
 /// Below we define BLS related objects for each of the modes, see instantiations
 /// [fastcrypto::bls12381::min_sig] and [fastcrypto::bls12381::min_pk].
 macro_rules! define_bls12381 {
-    (
+(
     $pk_length:expr,
     $sig_length:expr,
     $dst_string:expr
 ) => {
-        /// BLS 12-381 public key.
-        ///
-        /// For optimizing performance, throughout this module we assume that before being used, public keys
-        /// are:
-        /// * Validated by calling [BLS12381PublicKey::validate]), and,
-        /// * Proof-of-Possession (PoP) is performed on them as a protection against rough key attacks.
-        #[readonly::make]
-        #[derive(Clone)]
-        pub struct BLS12381PublicKey {
-            pub pubkey: blst::PublicKey,
-            pub bytes: OnceCell<[u8; $pk_length]>,
+
+/// BLS 12-381 public key.
+///
+/// For optimizing performance, throughout this module we assume that before being used, public keys
+/// are:
+/// * Validated by calling [BLS12381PublicKey::validate]), and,
+/// * Proof-of-Possession (PoP) is performed on them as a protection against rough key attacks.
+#[readonly::make]
+#[derive(Clone)]
+pub struct BLS12381PublicKey {
+    pub pubkey: blst::PublicKey,
+    pub bytes: OnceCell<[u8; $pk_length]>,
+}
+
+/// BLS 12-381 private key.
+#[readonly::make]
+#[derive(SilentDebug, SilentDisplay)]
+pub struct BLS12381PrivateKey {
+    pub privkey: blst::SecretKey,
+    pub bytes: OnceCell<zeroize::Zeroizing<[u8; BLS_PRIVATE_KEY_LENGTH]>>,
+}
+
+/// BLS 12-381 key pair.
+#[derive(Debug, PartialEq, Eq)]
+pub struct BLS12381KeyPair {
+    public: BLS12381PublicKey,
+    private: BLS12381PrivateKey,
+}
+
+/// BLS 12-381 signature.
+#[readonly::make]
+#[derive(Debug, Clone)]
+pub struct BLS12381Signature {
+    pub sig: blst::Signature,
+    pub bytes: OnceCell<[u8; $sig_length]>,
+}
+
+/// Aggregation of multiple BLS 12-381 signatures.
+#[readonly::make]
+#[derive(Debug, Clone)]
+pub struct BLS12381AggregateSignature {
+    pub sig: blst::Signature,
+    pub bytes: OnceCell<[u8; $sig_length]>,
+}
+
+//
+// Boilerplate code for [BLS12381PublicKey].
+//
+
+impl std::hash::Hash for BLS12381PublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl PartialEq for BLS12381PublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.pubkey == other.pubkey
+    }
+}
+
+impl Eq for BLS12381PublicKey {}
+
+impl PartialOrd for BLS12381PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BLS12381PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+impl_base64_display_fmt!(BLS12381PublicKey);
+
+impl Debug for BLS12381PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", Base64::encode(self.as_ref()))
+    }
+}
+
+impl AsRef<[u8]> for BLS12381PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_init::<_>(|| self.pubkey.to_bytes())
+    }
+}
+
+impl ToFromBytes for BLS12381PublicKey {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // key_validate() does NOT validate the public key. Please use validate() where needed.
+        let pubkey =
+            blst::PublicKey::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381PublicKey {
+            pubkey,
+            bytes: OnceCell::new(),
+        })
+    }
+}
+
+//
+// Custom code for [BLS12381PublicKey].
+//
+
+// Needed since the current NW implementation requires default public keys.
+// Note that deserialization of this object will fail if we validate it is a valid public key.
+impl InsecureDefault for BLS12381PublicKey {
+    fn insecure_default() -> Self {
+        BLS12381PublicKey {
+            pubkey: blst::PublicKey::default(),
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
+generate_bytes_representation!(BLS12381PublicKey, {$pk_length}, BLS12381PublicKeyAsBytes);
+
+impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
+    fn from(secret: &'a BLS12381PrivateKey) -> Self {
+        let inner = &secret.privkey;
+        let pubkey = inner.sk_to_pk();
+        BLS12381PublicKey {
+            pubkey,
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+// TODO: Once NW does not need to ser/deser public keys in many places we should call validate
+// during deserialization and get rid of this function.
+impl BLS12381PublicKey {
+    pub fn validate(&self) -> Result<(), FastCryptoError> {
+        self.pubkey.validate().map_err(|_e| FastCryptoError::InvalidInput)
+    }
+}
+
+impl VerifyingKey for BLS12381PublicKey {
+    type PrivKey = BLS12381PrivateKey;
+    type Sig = BLS12381Signature;
+    const LENGTH: usize = $pk_length;
+
+    fn verify(&self, msg: &[u8], signature: &BLS12381Signature) -> Result<(), FastCryptoError> {
+        // verify() only validates the signature. Please use pk that was validated.
+        let err = signature
+            .sig
+            .verify(true, msg, $dst_string, &[], &self.pubkey, false);
+        if err == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(FastCryptoError::InvalidSignature)
+        }
+    }
+
+    #[cfg(any(test, feature = "experimental"))]
+    fn verify_batch_empty_fail(
+        msg: &[u8],
+        pks: &[Self],
+        sigs: &[Self::Sig],
+    ) -> FastCryptoResult<()> {
+        if sigs.is_empty() {
+            // This behaviour can signal something dangerous, and that someone may be trying to
+            // bypass signature verification through providing empty batches.
+            return Err(GeneralOpaqueError);
+        }
+        if sigs.len() != pks.len() {
+            return Err(InvalidInput);
+        }
+        let aggregated_sig =
+            BLS12381AggregateSignature::aggregate(sigs).map_err(|_| GeneralOpaqueError)?;
+        aggregated_sig
+            .verify(pks, msg)
+            .map_err(|_| InvalidSignature)
+    }
+
+    #[cfg(any(test, feature = "experimental"))]
+    fn verify_batch_empty_fail_different_msg<'a, M>(
+        msgs: &[M],
+        pks: &[Self],
+        sigs: &[Self::Sig],
+    ) -> FastCryptoResult<()>
+    where
+        M: Borrow<[u8]> + 'a,
+    {
+        if sigs.is_empty() {
+            // This behaviour can signal something dangerous, and that someone may be trying to
+            // bypass signature verification through providing empty batches.
+            return Err(GeneralOpaqueError);
+        }
+        if sigs.len() != pks.len() {
+            return Err(InvalidInput);
         }
 
-        /// BLS 12-381 private key.
-        #[readonly::make]
-        #[derive(SilentDebug, SilentDisplay)]
-        pub struct BLS12381PrivateKey {
-            pub privkey: blst::SecretKey,
-            pub bytes: OnceCell<zeroize::Zeroizing<[u8; BLS_PRIVATE_KEY_LENGTH]>>,
-        }
-
-        /// BLS 12-381 key pair.
-        #[derive(Debug, PartialEq, Eq)]
-        pub struct BLS12381KeyPair {
-            public: BLS12381PublicKey,
-            private: BLS12381PrivateKey,
-        }
-
-        /// BLS 12-381 signature.
-        #[readonly::make]
-        #[derive(Debug, Clone)]
-        pub struct BLS12381Signature {
-            pub sig: blst::Signature,
-            pub bytes: OnceCell<[u8; $sig_length]>,
-        }
-
-        /// Aggregation of multiple BLS 12-381 signatures.
-        #[readonly::make]
-        #[derive(Debug, Clone)]
-        pub struct BLS12381AggregateSignature {
-            pub sig: blst::Signature,
-            pub bytes: OnceCell<[u8; $sig_length]>,
-        }
-
-        //
-        // Boilerplate code for [BLS12381PublicKey].
-        //
-
-        impl std::hash::Hash for BLS12381PublicKey {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-                self.as_ref().hash(state);
-            }
-        }
-
-        impl PartialEq for BLS12381PublicKey {
-            fn eq(&self, other: &Self) -> bool {
-                self.pubkey == other.pubkey
-            }
-        }
-
-        impl Eq for BLS12381PublicKey {}
-
-        impl PartialOrd for BLS12381PublicKey {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
-        impl Ord for BLS12381PublicKey {
-            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                self.as_ref().cmp(other.as_ref())
-            }
-        }
-
-        impl_base64_display_fmt!(BLS12381PublicKey);
-
-        impl Debug for BLS12381PublicKey {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-                write!(f, "{}", Base64::encode(self.as_ref()))
-            }
-        }
-
-        impl AsRef<[u8]> for BLS12381PublicKey {
-            fn as_ref(&self) -> &[u8] {
-                self.bytes.get_or_init::<_>(|| self.pubkey.to_bytes())
-            }
-        }
-
-        impl ToFromBytes for BLS12381PublicKey {
-            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-                // key_validate() does NOT validate the public key. Please use validate() where needed.
-                let pubkey = blst::PublicKey::from_bytes(bytes)
-                    .map_err(|_| FastCryptoError::InvalidInput)?;
-                Ok(BLS12381PublicKey {
-                    pubkey,
-                    bytes: OnceCell::new(),
-                })
-            }
-        }
-
-        //
-        // Custom code for [BLS12381PublicKey].
-        //
-
-        // Needed since the current NW implementation requires default public keys.
-        // Note that deserialization of this object will fail if we validate it is a valid public key.
-        impl InsecureDefault for BLS12381PublicKey {
-            fn insecure_default() -> Self {
-                BLS12381PublicKey {
-                    pubkey: blst::PublicKey::default(),
-                    bytes: OnceCell::new(),
-                }
-            }
-        }
-
-        serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
-        generate_bytes_representation!(BLS12381PublicKey, { $pk_length }, BLS12381PublicKeyAsBytes);
-
-        impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
-            fn from(secret: &'a BLS12381PrivateKey) -> Self {
-                let inner = &secret.privkey;
-                let pubkey = inner.sk_to_pk();
-                BLS12381PublicKey {
-                    pubkey,
-                    bytes: OnceCell::new(),
-                }
-            }
-        }
-
-        // TODO: Once NW does not need to ser/deser public keys in many places we should call validate
-        // during deserialization and get rid of this function.
-        impl BLS12381PublicKey {
-            pub fn validate(&self) -> Result<(), FastCryptoError> {
-                self.pubkey
-                    .validate()
-                    .map_err(|_e| FastCryptoError::InvalidInput)
-            }
-        }
-
-        impl VerifyingKey for BLS12381PublicKey {
-            type PrivKey = BLS12381PrivateKey;
-            type Sig = BLS12381Signature;
-            const LENGTH: usize = $pk_length;
-
-            fn verify(
-                &self,
-                msg: &[u8],
-                signature: &BLS12381Signature,
-            ) -> Result<(), FastCryptoError> {
-                // verify() only validates the signature. Please use pk that was validated.
-                let err = signature
-                    .sig
-                    .verify(true, msg, $dst_string, &[], &self.pubkey, false);
-                if err == BLST_ERROR::BLST_SUCCESS {
-                    Ok(())
-                } else {
-                    Err(InvalidSignature)
-                }
-            }
-
-            #[cfg(any(test, feature = "experimental"))]
-            fn verify_batch_empty_fail(
-                msg: &[u8],
-                pks: &[Self],
-                sigs: &[Self::Sig],
-            ) -> FastCryptoResult<()> {
-                if sigs.is_empty() {
-                    // This behaviour can signal something dangerous, and that someone may be trying to
-                    // bypass signature verification through providing empty batches.
-                    return Err(GeneralOpaqueError);
-                }
-                if sigs.len() != pks.len() {
-                    return Err(InvalidInput);
-                }
-                let aggregated_sig =
-                    BLS12381AggregateSignature::aggregate(sigs).map_err(|_| GeneralOpaqueError)?;
-                aggregated_sig
-                    .verify(pks, msg)
-                    .map_err(|_| InvalidSignature)
-            }
-
-            #[cfg(any(test, feature = "experimental"))]
-            fn verify_batch_empty_fail_different_msg<'a, M>(
-                msgs: &[M],
-                pks: &[Self],
-                sigs: &[Self::Sig],
-            ) -> FastCryptoResult<()>
-            where
-                M: Borrow<[u8]> + 'a,
-            {
-                if sigs.is_empty() {
-                    // This behaviour can signal something dangerous, and that someone may be trying to
-                    // bypass signature verification through providing empty batches.
-                    return Err(GeneralOpaqueError);
-                }
-                if sigs.len() != pks.len() {
-                    return Err(InvalidInput);
-                }
-
-                let rands = get_random_scalars(sigs.len());
-
-                let result = blst::Signature::verify_multiple_aggregate_signatures(
-                    &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
-                    $dst_string,
-                    &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
-                    false,
-                    &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
-                    true,
-                    &rands,
-                    BLS_BATCH_RANDOM_SCALAR_LENGTH,
-                );
-                if result == BLST_ERROR::BLST_SUCCESS {
-                    Ok(())
-                } else {
-                    Err(InvalidSignature)
-                }
-            }
-        }
-
-        fn get_random_scalar<Rng: AllowedRng>(rng: &mut Rng) -> blst_scalar {
-            static_assertions::const_assert!(
-                64 <= BLS_BATCH_RANDOM_SCALAR_LENGTH && BLS_BATCH_RANDOM_SCALAR_LENGTH <= 128
-            );
-
-            let mut vals = [0u64; 4];
-            loop {
-                vals[0] = rng.next_u64();
-                vals[1] = rng.next_u64();
-
-                // Reject zero as it is used for multiplication.
-                let vals1_lsb =
-                    vals[1] & (((1u128 << (BLS_BATCH_RANDOM_SCALAR_LENGTH - 64)) - 1) as u64);
-                if vals[0] | vals1_lsb != 0 {
-                    break;
-                }
-            }
-            let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
-            unsafe {
-                blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
-                return rand_i.assume_init();
-            }
-        }
-
-        fn get_one() -> blst_scalar {
-            let mut one = blst_scalar::default();
-            let mut vals = [0u8; 32];
-            vals[0] = 1;
-            unsafe {
-                blst_scalar_from_le_bytes(&mut one, vals.as_ptr(), 32);
-            }
-            one
-        }
-
-        // Always generates 128bit numbers though not all the bits must be used.
-        fn get_random_scalars(n: usize) -> Vec<blst_scalar> {
-            if n == 0 {
-                return Vec::new();
-            }
-            let mut rands: Vec<blst_scalar> = Vec::with_capacity(n);
-            // The first coefficient can safely be set to 1 (see https://github.com/MystenLabs/fastcrypto/issues/120)
-            rands.push(get_one());
-            let mut rng = rand::thread_rng();
-            (1..n)
-                .into_iter()
-                .for_each(|_| rands.push(get_random_scalar(&mut rng)));
-            rands
-        }
-
-        //
-        // Boilerplate code for [BLS12381PrivateKey].
-        //
-
-        impl PartialEq for BLS12381PrivateKey {
-            fn eq(&self, other: &Self) -> bool {
-                self.as_ref() == other.as_ref()
-            }
-        }
-
-        impl Eq for BLS12381PrivateKey {}
-
-        // All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
-        // ZeroizeOnDrop).
-        impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
-
-        impl AsRef<[u8]> for BLS12381PrivateKey {
-            fn as_ref(&self) -> &[u8] {
-                self.bytes
-                    .get_or_init::<_>(|| zeroize::Zeroizing::new(self.privkey.to_bytes()))
-                    .as_ref()
-            }
-        }
-
-        impl ToFromBytes for BLS12381PrivateKey {
-            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-                // from_bytes() validates that the key is in the right group.
-                let privkey = blst::SecretKey::from_bytes(bytes)
-                    .map_err(|_e| FastCryptoError::InvalidInput)?;
-                Ok(BLS12381PrivateKey {
-                    privkey,
-                    bytes: OnceCell::new(),
-                })
-            }
-        }
-
-        //
-        // Custom code for [BLS12381PrivateKey].
-        //
-
-        serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
-
-        impl SigningKey for BLS12381PrivateKey {
-            type PubKey = BLS12381PublicKey;
-            type Sig = BLS12381Signature;
-            const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
-        }
-
-        impl Signer<BLS12381Signature> for BLS12381PrivateKey {
-            fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-                BLS12381Signature {
-                    sig: self.privkey.sign(msg, $dst_string, &[]),
-                    bytes: OnceCell::new(),
-                }
-            }
-        }
-
-        //
-        // Boilerplate code for [BLS12381Signature].
-        //
-
-        impl PartialEq for BLS12381Signature {
-            fn eq(&self, other: &Self) -> bool {
-                self.sig == other.sig
-            }
-        }
-
-        impl Eq for BLS12381Signature {}
-
-        impl std::hash::Hash for BLS12381Signature {
-            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-                self.as_ref().hash(state);
-            }
-        }
-
-        impl AsRef<[u8]> for BLS12381Signature {
-            fn as_ref(&self) -> &[u8] {
-                self.bytes.get_or_init::<_>(|| self.sig.to_bytes())
-            }
-        }
-
-        impl ToFromBytes for BLS12381Signature {
-            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-                // from_bytes() does NOT check if the signature is in the right group. We check that when
-                // verifying the signature.
-                let sig = blst::Signature::from_bytes(bytes)
-                    .map_err(|_| FastCryptoError::InvalidInput)?;
-                Ok(BLS12381Signature {
-                    sig,
-                    bytes: OnceCell::new(),
-                })
-            }
-        }
-
-        impl_base64_display_fmt!(BLS12381Signature);
-
-        //
-        // Custom code for [BLS12381Signature].
-        //
-
-        serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
-
-        impl Default for BLS12381Signature {
-            fn default() -> Self {
-                // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
-                // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
-                let mut infinity: [u8; $sig_length] = [0; $sig_length];
-                infinity[0] = 0xc0;
-
-                BLS12381Signature {
-                    sig: blst::Signature::from_bytes(&infinity)
-                        .expect("Should decode infinity signature"),
-                    bytes: OnceCell::new(),
-                }
-            }
-        }
-
-        impl Authenticator for BLS12381Signature {
-            type PubKey = BLS12381PublicKey;
-            type PrivKey = BLS12381PrivateKey;
-            const LENGTH: usize = $sig_length;
-        }
-
-        //
-        // Boilerplate code for [BLS12381KeyPair].
-        //
-
-        impl From<BLS12381PrivateKey> for BLS12381KeyPair {
-            fn from(private: BLS12381PrivateKey) -> Self {
-                let public = BLS12381PublicKey::from(&private);
-                BLS12381KeyPair { public, private }
-            }
-        }
-
-        /// The bytes form of the keypair only contain the private key bytes
-        impl AsRef<[u8]> for BLS12381KeyPair {
-            fn as_ref(&self) -> &[u8] {
-                self.private.as_ref()
-            }
-        }
-
-        impl ToFromBytes for BLS12381KeyPair {
-            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-                BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
-            }
-        }
-
-        //
-        // Custom code for [BLS12381KeyPair].
-        //
-
-        serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
-
-        impl KeyPair for BLS12381KeyPair {
-            type PubKey = BLS12381PublicKey;
-            type PrivKey = BLS12381PrivateKey;
-            type Sig = BLS12381Signature;
-
-            fn public(&'_ self) -> &'_ Self::PubKey {
-                &self.public
-            }
-
-            fn private(self) -> Self::PrivKey {
-                BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
-            }
-
-            #[cfg(feature = "copy_key")]
-            fn copy(&self) -> Self {
-                BLS12381KeyPair {
-                    public: self.public.clone(),
-                    private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
-                }
-            }
-
-            fn generate<R: AllowedRng>(rng: &mut R) -> Self {
-                let mut ikm = [0u8; 32];
-                rng.fill_bytes(&mut ikm);
-                // TODO: Consider moving to key gen version 5.
-                let privkey =
-                    blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
-                let pubkey = privkey.sk_to_pk();
-                BLS12381KeyPair {
-                    public: BLS12381PublicKey {
-                        pubkey,
-                        bytes: OnceCell::new(),
-                    },
-                    private: BLS12381PrivateKey {
-                        privkey,
-                        bytes: OnceCell::new(),
-                    },
-                }
-            }
-        }
-
-        impl Signer<BLS12381Signature> for BLS12381KeyPair {
-            fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-                self.private.sign(msg)
-            }
-        }
-
-        impl FromStr for BLS12381KeyPair {
-            type Err = FastCryptoError;
-
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
-                Self::decode_base64(s)
-            }
-        }
-
-        //
-        // Boilerplate code for [BLS12381AggregateSignature].
-        //
-
-        impl_base64_display_fmt!(BLS12381AggregateSignature);
-
-        impl PartialEq for BLS12381AggregateSignature {
-            fn eq(&self, other: &Self) -> bool {
-                self.sig == other.sig
-            }
-        }
-
-        impl Eq for BLS12381AggregateSignature {}
-
-        impl Default for BLS12381AggregateSignature {
-            fn default() -> Self {
-                BLS12381Signature::default().into()
-            }
-        }
-
-        impl AsRef<[u8]> for BLS12381AggregateSignature {
-            fn as_ref(&self) -> &[u8] {
-                self.bytes.get_or_init::<_>(|| self.sig.to_bytes())
-            }
-        }
-
-        impl From<BLS12381Signature> for BLS12381AggregateSignature {
-            fn from(sig: BLS12381Signature) -> Self {
-                BLS12381AggregateSignature {
-                    sig: sig.sig,
-                    bytes: OnceCell::new(),
-                }
-            }
-        }
-
-        //
-        // Custom code for [BLS12381AggregateSignature].
-        //
-
-        serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
-        generate_bytes_representation!(
-            BLS12381AggregateSignature,
-            { $sig_length },
-            BLS12381AggregateSignatureAsBytes
+        let rands = get_random_scalars(sigs.len());
+
+        let result = blst::Signature::verify_multiple_aggregate_signatures(
+            &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+            $dst_string,
+            &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
+            false,
+            &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
+            true,
+            &rands,
+            BLS_BATCH_RANDOM_SCALAR_LENGTH,
         );
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(InvalidSignature)
+        }
+    }
+}
 
-        impl ToFromBytes for BLS12381AggregateSignature {
-            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-                // from_bytes does NOT validate the signature. We do that in verify.
-                let sig = blst::Signature::from_bytes(bytes)
-                    .map_err(|_| FastCryptoError::InvalidInput)?;
-                Ok(BLS12381AggregateSignature {
-                    sig,
-                    bytes: OnceCell::new(),
-                })
-            }
+fn get_random_scalar<Rng: AllowedRng>(rng: &mut Rng) -> blst_scalar {
+    static_assertions::const_assert!(
+        64 <= BLS_BATCH_RANDOM_SCALAR_LENGTH && BLS_BATCH_RANDOM_SCALAR_LENGTH <= 128
+    );
+
+    let mut vals = [0u64; 4];
+    loop {
+        vals[0] = rng.next_u64();
+        vals[1] = rng.next_u64();
+
+        // Reject zero as it is used for multiplication.
+        let vals1_lsb = vals[1] & (((1u128 << (BLS_BATCH_RANDOM_SCALAR_LENGTH - 64)) - 1) as u64);
+        if vals[0] | vals1_lsb != 0 {
+            break;
+        }
+    }
+    let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
+    unsafe {
+        blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
+        return rand_i.assume_init();
+    }
+}
+
+fn get_one() -> blst_scalar {
+    let mut one = blst_scalar::default();
+    let mut vals = [0u8; 32];
+    vals[0] = 1;
+    unsafe {
+        blst_scalar_from_le_bytes(&mut one, vals.as_ptr(), 32);
+    }
+    one
+}
+
+// Always generates 128bit numbers though not all the bits must be used.
+fn get_random_scalars(n: usize) -> Vec<blst_scalar> {
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut rands: Vec<blst_scalar> = Vec::with_capacity(n);
+    // The first coefficient can safely be set to 1 (see https://github.com/MystenLabs/fastcrypto/issues/120)
+    rands.push(get_one());
+    let mut rng = rand::thread_rng();
+    (1..n).into_iter().for_each(|_| rands.push(get_random_scalar(&mut rng)));
+    rands
+}
+
+//
+// Boilerplate code for [BLS12381PrivateKey].
+//
+
+impl PartialEq for BLS12381PrivateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for BLS12381PrivateKey {}
+
+// All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
+// ZeroizeOnDrop).
+impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
+
+impl AsRef<[u8]> for BLS12381PrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_init::<_>(|| zeroize::Zeroizing::new(self.privkey.to_bytes())).as_ref()
+    }
+}
+
+impl ToFromBytes for BLS12381PrivateKey {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // from_bytes() validates that the key is in the right group.
+        let privkey =
+            blst::SecretKey::from_bytes(bytes).map_err(|_e| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381PrivateKey {
+            privkey,
+            bytes: OnceCell::new(),
+        })
+    }
+}
+
+//
+// Custom code for [BLS12381PrivateKey].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
+
+impl SigningKey for BLS12381PrivateKey {
+    type PubKey = BLS12381PublicKey;
+    type Sig = BLS12381Signature;
+    const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
+}
+
+impl Signer<BLS12381Signature> for BLS12381PrivateKey {
+    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+        BLS12381Signature {
+            sig: self.privkey.sign(msg, $dst_string, &[]),
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+//
+// Boilerplate code for [BLS12381Signature].
+//
+
+impl PartialEq for BLS12381Signature {
+    fn eq(&self, other: &Self) -> bool {
+        self.sig == other.sig
+    }
+}
+
+impl Eq for BLS12381Signature {}
+
+impl std::hash::Hash for BLS12381Signature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl AsRef<[u8]> for BLS12381Signature {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_init::<_>(|| self.sig.to_bytes())
+    }
+}
+
+impl ToFromBytes for BLS12381Signature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // from_bytes() does NOT check if the signature is in the right group. We check that when
+        // verifying the signature.
+        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381Signature {
+            sig,
+            bytes: OnceCell::new(),
+        })
+    }
+}
+
+impl_base64_display_fmt!(BLS12381Signature);
+
+//
+// Custom code for [BLS12381Signature].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
+
+impl Default for BLS12381Signature {
+    fn default() -> Self {
+        // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
+        // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
+        let mut infinity: [u8; $sig_length] = [0; $sig_length];
+        infinity[0] = 0xc0;
+
+        BLS12381Signature {
+            sig: blst::Signature::from_bytes(&infinity).expect("Should decode infinity signature"),
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+impl Authenticator for BLS12381Signature {
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
+    const LENGTH: usize = $sig_length;
+}
+
+//
+// Boilerplate code for [BLS12381KeyPair].
+//
+
+impl From<BLS12381PrivateKey> for BLS12381KeyPair {
+    fn from(private: BLS12381PrivateKey) -> Self {
+        let public = BLS12381PublicKey::from(&private);
+        BLS12381KeyPair { public, private }
+    }
+}
+
+/// The bytes form of the keypair only contain the private key bytes
+impl AsRef<[u8]> for BLS12381KeyPair {
+    fn as_ref(&self) -> &[u8] {
+        self.private.as_ref()
+    }
+}
+
+impl ToFromBytes for BLS12381KeyPair {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
+    }
+}
+
+//
+// Custom code for [BLS12381KeyPair].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
+
+impl KeyPair for BLS12381KeyPair {
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
+    type Sig = BLS12381Signature;
+
+    fn public(&'_ self) -> &'_ Self::PubKey {
+        &self.public
+    }
+
+    fn private(self) -> Self::PrivKey {
+        BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
+    }
+
+    #[cfg(feature = "copy_key")]
+    fn copy(&self) -> Self {
+        BLS12381KeyPair {
+            public: self.public.clone(),
+            private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+        }
+    }
+
+    fn generate<R: AllowedRng>(rng: &mut R) -> Self {
+        let mut ikm = [0u8; 32];
+        rng.fill_bytes(&mut ikm);
+        // TODO: Consider moving to key gen version 5.
+        let privkey = blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
+        let pubkey = privkey.sk_to_pk();
+        BLS12381KeyPair {
+            public: BLS12381PublicKey {
+                pubkey,
+                bytes: OnceCell::new(),
+            },
+            private: BLS12381PrivateKey {
+                privkey,
+                bytes: OnceCell::new(),
+            },
+        }
+    }
+}
+
+impl Signer<BLS12381Signature> for BLS12381KeyPair {
+    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+        self.private.sign(msg)
+    }
+}
+
+impl FromStr for BLS12381KeyPair {
+    type Err = FastCryptoError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::decode_base64(s)
+    }
+}
+
+//
+// Boilerplate code for [BLS12381AggregateSignature].
+//
+
+impl_base64_display_fmt!(BLS12381AggregateSignature);
+
+impl PartialEq for BLS12381AggregateSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.sig == other.sig
+    }
+}
+
+impl Eq for BLS12381AggregateSignature {}
+
+impl Default for BLS12381AggregateSignature {
+    fn default() -> Self {
+        BLS12381Signature::default().into()
+    }
+}
+
+impl AsRef<[u8]> for BLS12381AggregateSignature {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_init::<_>(|| self.sig.to_bytes())
+    }
+}
+
+impl From <BLS12381Signature> for BLS12381AggregateSignature {
+    fn from(sig: BLS12381Signature) -> Self {
+        BLS12381AggregateSignature {
+            sig: sig.sig,
+            bytes: OnceCell::new(),
+        }
+    }
+}
+
+//
+// Custom code for [BLS12381AggregateSignature].
+//
+
+serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
+generate_bytes_representation!(BLS12381AggregateSignature, {$sig_length}, BLS12381AggregateSignatureAsBytes);
+
+impl ToFromBytes for BLS12381AggregateSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // from_bytes does NOT validate the signature. We do that in verify.
+        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
+        Ok(BLS12381AggregateSignature {
+            sig,
+            bytes: OnceCell::new(),
+        })
+    }
+}
+
+impl AggregateAuthenticator for BLS12381AggregateSignature {
+    type Sig = BLS12381Signature;
+    type PubKey = BLS12381PublicKey;
+    type PrivKey = BLS12381PrivateKey;
+
+    fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
+        signatures: I,
+    ) -> Result<Self, FastCryptoError> {
+        // aggregate() below does not validate signatures.
+        blst::AggregateSignature::aggregate(
+            &signatures
+                .into_iter()
+                .map(|x| &x.borrow().sig)
+                .collect::<Vec<_>>(),
+            false,
+        )
+        .map(|sig| BLS12381AggregateSignature {
+            sig: sig.to_signature(),
+            bytes: OnceCell::new(),
+        })
+        .map_err(|_| FastCryptoError::InvalidInput)
+    }
+
+    fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
+        let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
+        // add_signature() does not validate the new signature.
+        aggr_sig.add_signature(&signature.sig, false).map_err(|_| FastCryptoError::InvalidInput)?;
+        self.sig = aggr_sig.to_signature();
+        self.bytes.take();
+        Ok(())
+    }
+
+    fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
+        // aggregate() does not validate the new signature.
+        let result = blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
+            .map_err(|_| FastCryptoError::InvalidInput)?.to_signature();
+        self.sig = result;
+        self.bytes.take();
+        Ok(())
+    }
+
+    // This function assumes that that all public keys were verified using a proof of possession.
+    // See comment above [BLS12381PublicKey].
+    fn verify(
+        &self,
+        pks: &[<Self::Sig as Authenticator>::PubKey],
+        message: &[u8],
+    ) -> Result<(), FastCryptoError> {
+        // Validate signatures but not public keys which the user must validate before calling this.
+        let result = self
+            .sig
+            .fast_aggregate_verify(
+                true,
+                message,
+                $dst_string,
+                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+            );
+        if result != BLST_ERROR::BLST_SUCCESS {
+            return Err(FastCryptoError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    // This function assumes that that all public keys were verified using a proof of possession.
+    // See comment above [BLS12381PublicKey].
+    fn verify_different_msg(
+        &self,
+        pks: &[<Self::Sig as Authenticator>::PubKey],
+        messages: &[&[u8]],
+    ) -> Result<(), FastCryptoError> {
+        // Validate signatures but not public keys which the user must validate before calling this.
+        let result = self
+            .sig
+            .aggregate_verify(
+                true,
+                messages,
+                $dst_string,
+                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+                false,
+            );
+        if result != BLST_ERROR::BLST_SUCCESS {
+            return Err(FastCryptoError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    fn batch_verify<'a>(
+        signatures: &[&Self],
+        pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
+        messages: &[&[u8]],
+    ) -> Result<(), FastCryptoError> {
+        if signatures.len() != pks.len() || signatures.len() != messages.len() {
+            return Err(FastCryptoError::InputLengthWrong(signatures.len()));
         }
 
-        impl AggregateAuthenticator for BLS12381AggregateSignature {
-            type Sig = BLS12381Signature;
-            type PubKey = BLS12381PublicKey;
-            type PrivKey = BLS12381PrivateKey;
-
-            fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
-                signatures: I,
-            ) -> Result<Self, FastCryptoError> {
-                // aggregate() below does not validate signatures.
-                blst::AggregateSignature::aggregate(
-                    &signatures
-                        .into_iter()
-                        .map(|x| &x.borrow().sig)
-                        .collect::<Vec<_>>(),
-                    false,
-                )
-                .map(|sig| BLS12381AggregateSignature {
-                    sig: sig.to_signature(),
-                    bytes: OnceCell::new(),
-                })
-                .map_err(|_| FastCryptoError::InvalidInput)
-            }
-
-            fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
-                let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
-                // add_signature() does not validate the new signature.
-                aggr_sig
-                    .add_signature(&signature.sig, false)
-                    .map_err(|_| FastCryptoError::InvalidInput)?;
-                self.sig = aggr_sig.to_signature();
-                self.bytes.take();
-                Ok(())
-            }
-
-            fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
-                // aggregate() does not validate the new signature.
-                let result =
-                    blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
-                        .map_err(|_| FastCryptoError::InvalidInput)?
-                        .to_signature();
-                self.sig = result;
-                self.bytes.take();
-                Ok(())
-            }
-
-            // This function assumes that that all public keys were verified using a proof of possession.
-            // See comment above [BLS12381PublicKey].
-            fn verify(
-                &self,
-                pks: &[<Self::Sig as Authenticator>::PubKey],
-                message: &[u8],
-            ) -> Result<(), FastCryptoError> {
-                // Validate signatures but not public keys which the user must validate before calling this.
-                let result = self.sig.fast_aggregate_verify(
-                    true,
-                    message,
-                    $dst_string,
-                    &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-                );
-                if result != BLST_ERROR::BLST_SUCCESS {
-                    return Err(FastCryptoError::InvalidSignature);
-                }
-                Ok(())
-            }
-
-            // This function assumes that that all public keys were verified using a proof of possession.
-            // See comment above [BLS12381PublicKey].
-            fn verify_different_msg(
-                &self,
-                pks: &[<Self::Sig as Authenticator>::PubKey],
-                messages: &[&[u8]],
-            ) -> Result<(), FastCryptoError> {
-                // Validate signatures but not public keys which the user must validate before calling this.
-                let result = self.sig.aggregate_verify(
-                    true,
-                    messages,
-                    $dst_string,
-                    &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-                    false,
-                );
-                if result != BLST_ERROR::BLST_SUCCESS {
-                    return Err(FastCryptoError::InvalidSignature);
-                }
-                Ok(())
-            }
-
-            fn batch_verify<'a>(
-                signatures: &[&Self],
-                pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
-                messages: &[&[u8]],
-            ) -> Result<(), FastCryptoError> {
-                if signatures.len() != pks.len() || signatures.len() != messages.len() {
-                    return Err(FastCryptoError::InputLengthWrong(signatures.len()));
-                }
-
-                if signatures.is_empty() {
-                    // verify_multiple_aggregate_signatures fails on empty input, but we accept here.
-                    return Ok(());
-                }
-
-                let mut agg_pks: Vec<blst::PublicKey> = Vec::with_capacity(signatures.len());
-                for keys in pks {
-                    let keys_as_vec = keys.map(|x| x.pubkey.borrow()).collect::<Vec<_>>();
-                    agg_pks.push(
-                        blst::AggregatePublicKey::aggregate(&keys_as_vec, false)
-                            .unwrap()
-                            .to_public_key(),
-                    );
-                }
-
-                // Validate signatures but not public keys which the user must validate before calling this.
-                let result = blst::Signature::verify_multiple_aggregate_signatures(
-                    &messages,
-                    $dst_string,
-                    &agg_pks.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
-                    false,
-                    &signatures
-                        .iter()
-                        .map(|agg_sig| &agg_sig.sig)
-                        .collect::<Vec<_>>(),
-                    true,
-                    &get_random_scalars(signatures.len()),
-                    BLS_BATCH_RANDOM_SCALAR_LENGTH,
-                );
-                if result == BLST_ERROR::BLST_SUCCESS {
-                    Ok(())
-                } else {
-                    Err(FastCryptoError::GeneralOpaqueError)
-                }
-            }
+        if signatures.is_empty() {
+            // verify_multiple_aggregate_signatures fails on empty input, but we accept here.
+            return Ok(())
         }
-    };
+
+        let mut agg_pks: Vec<blst::PublicKey> = Vec::with_capacity(signatures.len());
+        for keys in pks {
+             let keys_as_vec = keys.map(|x| x.pubkey.borrow()).collect::<Vec<_>>();
+             agg_pks.push(blst::AggregatePublicKey::aggregate(&keys_as_vec, false).unwrap().to_public_key()
+             );
+         }
+
+        // Validate signatures but not public keys which the user must validate before calling this.
+        let result = blst::Signature::verify_multiple_aggregate_signatures(
+            &messages,
+            $dst_string,
+            &agg_pks.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+            false,
+            &signatures.iter().map(|agg_sig| &agg_sig.sig).collect::<Vec<_>>(),
+            true,
+            &get_random_scalars(signatures.len()),
+            BLS_BATCH_RANDOM_SCALAR_LENGTH,
+        );
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(FastCryptoError::GeneralOpaqueError)
+        }
+    }
+}
+
+};
+
 } // macro_rules! define_bls12381.
 
 /// The length of a private key in bytes.

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -23,6 +23,8 @@ use crate::{
     serialize_deserialize_with_to_from_bytes,
 };
 use crate::{generate_bytes_representation, impl_base64_display_fmt};
+#[cfg(any(test, feature = "experimental"))]
+use crate::error::{FastCryptoResult, FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature}};
 use blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 use once_cell::sync::OnceCell;
@@ -32,10 +34,6 @@ use std::{
     mem::MaybeUninit,
     str::FromStr,
 };
-#[cfg(any(test, feature = "experimental"))]
-use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature};
-#[cfg(any(test, feature = "experimental"))]
-use crate::error::FastCryptoResult;
 
 /// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
 /// and of the second using 96 bytes. BLS supports two modes:

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -13,6 +13,11 @@
 //! assert!(kp.public().verify(message, &signature).is_ok());
 //! ```
 
+#[cfg(any(test, feature = "experimental"))]
+use crate::error::{
+    FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature},
+    FastCryptoResult,
+};
 use crate::serde_helpers::BytesRepresentation;
 use crate::traits::{
     AggregateAuthenticator, AllowedRng, Authenticator, EncodeDecodeBase64, InsecureDefault,
@@ -23,8 +28,6 @@ use crate::{
     serialize_deserialize_with_to_from_bytes,
 };
 use crate::{generate_bytes_representation, impl_base64_display_fmt};
-#[cfg(any(test, feature = "experimental"))]
-use crate::error::{FastCryptoResult, FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature}};
 use blst::{blst_scalar, blst_scalar_from_le_bytes, blst_scalar_from_uint64, BLST_ERROR};
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 use once_cell::sync::OnceCell;
@@ -43,658 +46,664 @@ use std::{
 /// Below we define BLS related objects for each of the modes, see instantiations
 /// [fastcrypto::bls12381::min_sig] and [fastcrypto::bls12381::min_pk].
 macro_rules! define_bls12381 {
-(
+    (
     $pk_length:expr,
     $sig_length:expr,
     $dst_string:expr
 ) => {
-
-/// BLS 12-381 public key.
-///
-/// For optimizing performance, throughout this module we assume that before being used, public keys
-/// are:
-/// * Validated by calling [BLS12381PublicKey::validate]), and,
-/// * Proof-of-Possession (PoP) is performed on them as a protection against rough key attacks.
-#[readonly::make]
-#[derive(Clone)]
-pub struct BLS12381PublicKey {
-    pub pubkey: blst::PublicKey,
-    pub bytes: OnceCell<[u8; $pk_length]>,
-}
-
-/// BLS 12-381 private key.
-#[readonly::make]
-#[derive(SilentDebug, SilentDisplay)]
-pub struct BLS12381PrivateKey {
-    pub privkey: blst::SecretKey,
-    pub bytes: OnceCell<zeroize::Zeroizing<[u8; BLS_PRIVATE_KEY_LENGTH]>>,
-}
-
-/// BLS 12-381 key pair.
-#[derive(Debug, PartialEq, Eq)]
-pub struct BLS12381KeyPair {
-    public: BLS12381PublicKey,
-    private: BLS12381PrivateKey,
-}
-
-/// BLS 12-381 signature.
-#[readonly::make]
-#[derive(Debug, Clone)]
-pub struct BLS12381Signature {
-    pub sig: blst::Signature,
-    pub bytes: OnceCell<[u8; $sig_length]>,
-}
-
-/// Aggregation of multiple BLS 12-381 signatures.
-#[readonly::make]
-#[derive(Debug, Clone)]
-pub struct BLS12381AggregateSignature {
-    pub sig: blst::Signature,
-    pub bytes: OnceCell<[u8; $sig_length]>,
-}
-
-//
-// Boilerplate code for [BLS12381PublicKey].
-//
-
-impl std::hash::Hash for BLS12381PublicKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state);
-    }
-}
-
-impl PartialEq for BLS12381PublicKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.pubkey == other.pubkey
-    }
-}
-
-impl Eq for BLS12381PublicKey {}
-
-impl PartialOrd for BLS12381PublicKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for BLS12381PublicKey {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.as_ref().cmp(other.as_ref())
-    }
-}
-
-impl_base64_display_fmt!(BLS12381PublicKey);
-
-impl Debug for BLS12381PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", Base64::encode(self.as_ref()))
-    }
-}
-
-impl AsRef<[u8]> for BLS12381PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| self.pubkey.to_bytes())
-    }
-}
-
-impl ToFromBytes for BLS12381PublicKey {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // key_validate() does NOT validate the public key. Please use validate() where needed.
-        let pubkey =
-            blst::PublicKey::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381PublicKey {
-            pubkey,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-//
-// Custom code for [BLS12381PublicKey].
-//
-
-// Needed since the current NW implementation requires default public keys.
-// Note that deserialization of this object will fail if we validate it is a valid public key.
-impl InsecureDefault for BLS12381PublicKey {
-    fn insecure_default() -> Self {
-        BLS12381PublicKey {
-            pubkey: blst::PublicKey::default(),
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
-generate_bytes_representation!(BLS12381PublicKey, {$pk_length}, BLS12381PublicKeyAsBytes);
-
-impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
-    fn from(secret: &'a BLS12381PrivateKey) -> Self {
-        let inner = &secret.privkey;
-        let pubkey = inner.sk_to_pk();
-        BLS12381PublicKey {
-            pubkey,
-            bytes: OnceCell::new(),
-        }
-    }
-}
-
-// TODO: Once NW does not need to ser/deser public keys in many places we should call validate
-// during deserialization and get rid of this function.
-impl BLS12381PublicKey {
-    pub fn validate(&self) -> Result<(), FastCryptoError> {
-        self.pubkey.validate().map_err(|_e| FastCryptoError::InvalidInput)
-    }
-}
-
-impl VerifyingKey for BLS12381PublicKey {
-    type PrivKey = BLS12381PrivateKey;
-    type Sig = BLS12381Signature;
-    const LENGTH: usize = $pk_length;
-
-    fn verify(&self, msg: &[u8], signature: &BLS12381Signature) -> Result<(), FastCryptoError> {
-        // verify() only validates the signature. Please use pk that was validated.
-        let err = signature
-            .sig
-            .verify(true, msg, $dst_string, &[], &self.pubkey, false);
-        if err == BLST_ERROR::BLST_SUCCESS {
-            Ok(())
-        } else {
-            Err(FastCryptoError::InvalidSignature)
-        }
-    }
-
-    #[cfg(any(test, feature = "experimental"))]
-    fn verify_batch_empty_fail(
-        msg: &[u8],
-        pks: &[Self],
-        sigs: &[Self::Sig],
-    ) -> FastCryptoResult<()> {
-        if sigs.is_empty() {
-            // This behaviour can signal something dangerous, and that someone may be trying to
-            // bypass signature verification through providing empty batches.
-            return Err(GeneralOpaqueError);
-        }
-        if sigs.len() != pks.len() {
-            return Err(InvalidInput);
-        }
-        let aggregated_sig =
-            BLS12381AggregateSignature::aggregate(sigs)?;
-        aggregated_sig
-            .verify(pks, msg)
-    }
-
-    #[cfg(any(test, feature = "experimental"))]
-    fn verify_batch_empty_fail_different_msg<'a, M>(
-        msgs: &[M],
-        pks: &[Self],
-        sigs: &[Self::Sig],
-    ) -> FastCryptoResult<()>
-    where
-        M: Borrow<[u8]> + 'a,
-    {
-        if sigs.is_empty() {
-            // This behaviour can signal something dangerous, and that someone may be trying to
-            // bypass signature verification through providing empty batches.
-            return Err(GeneralOpaqueError);
-        }
-        if sigs.len() != pks.len() {
-            return Err(InvalidInput);
+        /// BLS 12-381 public key.
+        ///
+        /// For optimizing performance, throughout this module we assume that before being used, public keys
+        /// are:
+        /// * Validated by calling [BLS12381PublicKey::validate]), and,
+        /// * Proof-of-Possession (PoP) is performed on them as a protection against rough key attacks.
+        #[readonly::make]
+        #[derive(Clone)]
+        pub struct BLS12381PublicKey {
+            pub pubkey: blst::PublicKey,
+            pub bytes: OnceCell<[u8; $pk_length]>,
         }
 
-        let rands = get_random_scalars(sigs.len());
-
-        let result = blst::Signature::verify_multiple_aggregate_signatures(
-            &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
-            $dst_string,
-            &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
-            false,
-            &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
-            true,
-            &rands,
-            BLS_BATCH_RANDOM_SCALAR_LENGTH,
-        );
-        if result == BLST_ERROR::BLST_SUCCESS {
-            Ok(())
-        } else {
-            Err(InvalidSignature)
+        /// BLS 12-381 private key.
+        #[readonly::make]
+        #[derive(SilentDebug, SilentDisplay)]
+        pub struct BLS12381PrivateKey {
+            pub privkey: blst::SecretKey,
+            pub bytes: OnceCell<zeroize::Zeroizing<[u8; BLS_PRIVATE_KEY_LENGTH]>>,
         }
-    }
-}
 
-fn get_random_scalar<Rng: AllowedRng>(rng: &mut Rng) -> blst_scalar {
-    static_assertions::const_assert!(
-        64 <= BLS_BATCH_RANDOM_SCALAR_LENGTH && BLS_BATCH_RANDOM_SCALAR_LENGTH <= 128
-    );
-
-    let mut vals = [0u64; 4];
-    loop {
-        vals[0] = rng.next_u64();
-        vals[1] = rng.next_u64();
-
-        // Reject zero as it is used for multiplication.
-        let vals1_lsb = vals[1] & (((1u128 << (BLS_BATCH_RANDOM_SCALAR_LENGTH - 64)) - 1) as u64);
-        if vals[0] | vals1_lsb != 0 {
-            break;
+        /// BLS 12-381 key pair.
+        #[derive(Debug, PartialEq, Eq)]
+        pub struct BLS12381KeyPair {
+            public: BLS12381PublicKey,
+            private: BLS12381PrivateKey,
         }
-    }
-    let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
-    unsafe {
-        blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
-        return rand_i.assume_init();
-    }
-}
 
-fn get_one() -> blst_scalar {
-    let mut one = blst_scalar::default();
-    let mut vals = [0u8; 32];
-    vals[0] = 1;
-    unsafe {
-        blst_scalar_from_le_bytes(&mut one, vals.as_ptr(), 32);
-    }
-    one
-}
-
-// Always generates 128bit numbers though not all the bits must be used.
-fn get_random_scalars(n: usize) -> Vec<blst_scalar> {
-    if n == 0 {
-        return Vec::new();
-    }
-    let mut rands: Vec<blst_scalar> = Vec::with_capacity(n);
-    // The first coefficient can safely be set to 1 (see https://github.com/MystenLabs/fastcrypto/issues/120)
-    rands.push(get_one());
-    let mut rng = rand::thread_rng();
-    (1..n).into_iter().for_each(|_| rands.push(get_random_scalar(&mut rng)));
-    rands
-}
-
-//
-// Boilerplate code for [BLS12381PrivateKey].
-//
-
-impl PartialEq for BLS12381PrivateKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl Eq for BLS12381PrivateKey {}
-
-// All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
-// ZeroizeOnDrop).
-impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
-
-impl AsRef<[u8]> for BLS12381PrivateKey {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| zeroize::Zeroizing::new(self.privkey.to_bytes())).as_ref()
-    }
-}
-
-impl ToFromBytes for BLS12381PrivateKey {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // from_bytes() validates that the key is in the right group.
-        let privkey =
-            blst::SecretKey::from_bytes(bytes).map_err(|_e| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381PrivateKey {
-            privkey,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-//
-// Custom code for [BLS12381PrivateKey].
-//
-
-serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
-
-impl SigningKey for BLS12381PrivateKey {
-    type PubKey = BLS12381PublicKey;
-    type Sig = BLS12381Signature;
-    const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
-}
-
-impl Signer<BLS12381Signature> for BLS12381PrivateKey {
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        BLS12381Signature {
-            sig: self.privkey.sign(msg, $dst_string, &[]),
-            bytes: OnceCell::new(),
+        /// BLS 12-381 signature.
+        #[readonly::make]
+        #[derive(Debug, Clone)]
+        pub struct BLS12381Signature {
+            pub sig: blst::Signature,
+            pub bytes: OnceCell<[u8; $sig_length]>,
         }
-    }
-}
 
-//
-// Boilerplate code for [BLS12381Signature].
-//
-
-impl PartialEq for BLS12381Signature {
-    fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
-    }
-}
-
-impl Eq for BLS12381Signature {}
-
-impl std::hash::Hash for BLS12381Signature {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state);
-    }
-}
-
-impl AsRef<[u8]> for BLS12381Signature {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| self.sig.to_bytes())
-    }
-}
-
-impl ToFromBytes for BLS12381Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // from_bytes() does NOT check if the signature is in the right group. We check that when
-        // verifying the signature.
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381Signature {
-            sig,
-            bytes: OnceCell::new(),
-        })
-    }
-}
-
-impl_base64_display_fmt!(BLS12381Signature);
-
-//
-// Custom code for [BLS12381Signature].
-//
-
-serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
-
-impl Default for BLS12381Signature {
-    fn default() -> Self {
-        // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
-        // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
-        let mut infinity: [u8; $sig_length] = [0; $sig_length];
-        infinity[0] = 0xc0;
-
-        BLS12381Signature {
-            sig: blst::Signature::from_bytes(&infinity).expect("Should decode infinity signature"),
-            bytes: OnceCell::new(),
+        /// Aggregation of multiple BLS 12-381 signatures.
+        #[readonly::make]
+        #[derive(Debug, Clone)]
+        pub struct BLS12381AggregateSignature {
+            pub sig: blst::Signature,
+            pub bytes: OnceCell<[u8; $sig_length]>,
         }
-    }
-}
 
-impl Authenticator for BLS12381Signature {
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-    const LENGTH: usize = $sig_length;
-}
+        //
+        // Boilerplate code for [BLS12381PublicKey].
+        //
 
-//
-// Boilerplate code for [BLS12381KeyPair].
-//
-
-impl From<BLS12381PrivateKey> for BLS12381KeyPair {
-    fn from(private: BLS12381PrivateKey) -> Self {
-        let public = BLS12381PublicKey::from(&private);
-        BLS12381KeyPair { public, private }
-    }
-}
-
-/// The bytes form of the keypair only contain the private key bytes
-impl AsRef<[u8]> for BLS12381KeyPair {
-    fn as_ref(&self) -> &[u8] {
-        self.private.as_ref()
-    }
-}
-
-impl ToFromBytes for BLS12381KeyPair {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
-    }
-}
-
-//
-// Custom code for [BLS12381KeyPair].
-//
-
-serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
-
-impl KeyPair for BLS12381KeyPair {
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
-    type Sig = BLS12381Signature;
-
-    fn public(&'_ self) -> &'_ Self::PubKey {
-        &self.public
-    }
-
-    fn private(self) -> Self::PrivKey {
-        BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
-    }
-
-    #[cfg(feature = "copy_key")]
-    fn copy(&self) -> Self {
-        BLS12381KeyPair {
-            public: self.public.clone(),
-            private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+        impl std::hash::Hash for BLS12381PublicKey {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.as_ref().hash(state);
+            }
         }
-    }
 
-    fn generate<R: AllowedRng>(rng: &mut R) -> Self {
-        let mut ikm = [0u8; 32];
-        rng.fill_bytes(&mut ikm);
-        // TODO: Consider moving to key gen version 5.
-        let privkey = blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
-        let pubkey = privkey.sk_to_pk();
-        BLS12381KeyPair {
-            public: BLS12381PublicKey {
-                pubkey,
-                bytes: OnceCell::new(),
-            },
-            private: BLS12381PrivateKey {
-                privkey,
-                bytes: OnceCell::new(),
-            },
+        impl PartialEq for BLS12381PublicKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.pubkey == other.pubkey
+            }
         }
-    }
-}
 
-impl Signer<BLS12381Signature> for BLS12381KeyPair {
-    fn sign(&self, msg: &[u8]) -> BLS12381Signature {
-        self.private.sign(msg)
-    }
-}
+        impl Eq for BLS12381PublicKey {}
 
-impl FromStr for BLS12381KeyPair {
-    type Err = FastCryptoError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::decode_base64(s)
-    }
-}
-
-//
-// Boilerplate code for [BLS12381AggregateSignature].
-//
-
-impl_base64_display_fmt!(BLS12381AggregateSignature);
-
-impl PartialEq for BLS12381AggregateSignature {
-    fn eq(&self, other: &Self) -> bool {
-        self.sig == other.sig
-    }
-}
-
-impl Eq for BLS12381AggregateSignature {}
-
-impl Default for BLS12381AggregateSignature {
-    fn default() -> Self {
-        BLS12381Signature::default().into()
-    }
-}
-
-impl AsRef<[u8]> for BLS12381AggregateSignature {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes
-            .get_or_init::<_>(|| self.sig.to_bytes())
-    }
-}
-
-impl From <BLS12381Signature> for BLS12381AggregateSignature {
-    fn from(sig: BLS12381Signature) -> Self {
-        BLS12381AggregateSignature {
-            sig: sig.sig,
-            bytes: OnceCell::new(),
+        impl PartialOrd for BLS12381PublicKey {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
         }
-    }
-}
 
-//
-// Custom code for [BLS12381AggregateSignature].
-//
+        impl Ord for BLS12381PublicKey {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                self.as_ref().cmp(other.as_ref())
+            }
+        }
 
-serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
-generate_bytes_representation!(BLS12381AggregateSignature, {$sig_length}, BLS12381AggregateSignatureAsBytes);
+        impl_base64_display_fmt!(BLS12381PublicKey);
 
-impl ToFromBytes for BLS12381AggregateSignature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // from_bytes does NOT validate the signature. We do that in verify.
-        let sig = blst::Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidInput)?;
-        Ok(BLS12381AggregateSignature {
-            sig,
-            bytes: OnceCell::new(),
-        })
-    }
-}
+        impl Debug for BLS12381PublicKey {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                write!(f, "{}", Base64::encode(self.as_ref()))
+            }
+        }
 
-impl AggregateAuthenticator for BLS12381AggregateSignature {
-    type Sig = BLS12381Signature;
-    type PubKey = BLS12381PublicKey;
-    type PrivKey = BLS12381PrivateKey;
+        impl AsRef<[u8]> for BLS12381PublicKey {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes.get_or_init::<_>(|| self.pubkey.to_bytes())
+            }
+        }
 
-    fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
-        signatures: I,
-    ) -> Result<Self, FastCryptoError> {
-        // aggregate() below does not validate signatures.
-        blst::AggregateSignature::aggregate(
-            &signatures
+        impl ToFromBytes for BLS12381PublicKey {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // key_validate() does NOT validate the public key. Please use validate() where needed.
+                let pubkey = blst::PublicKey::from_bytes(bytes)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381PublicKey {
+                    pubkey,
+                    bytes: OnceCell::new(),
+                })
+            }
+        }
+
+        //
+        // Custom code for [BLS12381PublicKey].
+        //
+
+        // Needed since the current NW implementation requires default public keys.
+        // Note that deserialization of this object will fail if we validate it is a valid public key.
+        impl InsecureDefault for BLS12381PublicKey {
+            fn insecure_default() -> Self {
+                BLS12381PublicKey {
+                    pubkey: blst::PublicKey::default(),
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381PublicKey, $pk_length);
+        generate_bytes_representation!(BLS12381PublicKey, { $pk_length }, BLS12381PublicKeyAsBytes);
+
+        impl<'a> From<&'a BLS12381PrivateKey> for BLS12381PublicKey {
+            fn from(secret: &'a BLS12381PrivateKey) -> Self {
+                let inner = &secret.privkey;
+                let pubkey = inner.sk_to_pk();
+                BLS12381PublicKey {
+                    pubkey,
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        // TODO: Once NW does not need to ser/deser public keys in many places we should call validate
+        // during deserialization and get rid of this function.
+        impl BLS12381PublicKey {
+            pub fn validate(&self) -> Result<(), FastCryptoError> {
+                self.pubkey
+                    .validate()
+                    .map_err(|_e| FastCryptoError::InvalidInput)
+            }
+        }
+
+        impl VerifyingKey for BLS12381PublicKey {
+            type PrivKey = BLS12381PrivateKey;
+            type Sig = BLS12381Signature;
+            const LENGTH: usize = $pk_length;
+
+            fn verify(
+                &self,
+                msg: &[u8],
+                signature: &BLS12381Signature,
+            ) -> Result<(), FastCryptoError> {
+                // verify() only validates the signature. Please use pk that was validated.
+                let err = signature
+                    .sig
+                    .verify(true, msg, $dst_string, &[], &self.pubkey, false);
+                if err == BLST_ERROR::BLST_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(FastCryptoError::InvalidSignature)
+                }
+            }
+
+            #[cfg(any(test, feature = "experimental"))]
+            fn verify_batch_empty_fail(
+                msg: &[u8],
+                pks: &[Self],
+                sigs: &[Self::Sig],
+            ) -> FastCryptoResult<()> {
+                if sigs.is_empty() || sigs.len() != pks.len() {
+                    return Err(InvalidInput);
+                }
+                let aggregated_sig = BLS12381AggregateSignature::aggregate(sigs)?;
+                aggregated_sig.verify(pks, msg)
+            }
+
+            #[cfg(any(test, feature = "experimental"))]
+            fn verify_batch_empty_fail_different_msg<'a, M>(
+                msgs: &[M],
+                pks: &[Self],
+                sigs: &[Self::Sig],
+            ) -> FastCryptoResult<()>
+            where
+                M: Borrow<[u8]> + 'a,
+            {
+                if sigs.is_empty() || sigs.len() != pks.len() {
+                    return Err(InvalidInput);
+                }
+
+                let rands = get_random_scalars(sigs.len());
+
+                let result = blst::Signature::verify_multiple_aggregate_signatures(
+                    &msgs.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+                    $dst_string,
+                    &pks.iter().map(|pk| &pk.pubkey).collect::<Vec<_>>(),
+                    false,
+                    &sigs.iter().map(|sig| &sig.sig).collect::<Vec<_>>(),
+                    true,
+                    &rands,
+                    BLS_BATCH_RANDOM_SCALAR_LENGTH,
+                );
+                if result == BLST_ERROR::BLST_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(InvalidSignature)
+                }
+            }
+        }
+
+        fn get_random_scalar<Rng: AllowedRng>(rng: &mut Rng) -> blst_scalar {
+            static_assertions::const_assert!(
+                64 <= BLS_BATCH_RANDOM_SCALAR_LENGTH && BLS_BATCH_RANDOM_SCALAR_LENGTH <= 128
+            );
+
+            let mut vals = [0u64; 4];
+            loop {
+                vals[0] = rng.next_u64();
+                vals[1] = rng.next_u64();
+
+                // Reject zero as it is used for multiplication.
+                let vals1_lsb =
+                    vals[1] & (((1u128 << (BLS_BATCH_RANDOM_SCALAR_LENGTH - 64)) - 1) as u64);
+                if vals[0] | vals1_lsb != 0 {
+                    break;
+                }
+            }
+            let mut rand_i = MaybeUninit::<blst_scalar>::uninit();
+            unsafe {
+                blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
+                return rand_i.assume_init();
+            }
+        }
+
+        fn get_one() -> blst_scalar {
+            let mut one = blst_scalar::default();
+            let mut vals = [0u8; 32];
+            vals[0] = 1;
+            unsafe {
+                blst_scalar_from_le_bytes(&mut one, vals.as_ptr(), 32);
+            }
+            one
+        }
+
+        // Always generates 128bit numbers though not all the bits must be used.
+        fn get_random_scalars(n: usize) -> Vec<blst_scalar> {
+            if n == 0 {
+                return Vec::new();
+            }
+            let mut rands: Vec<blst_scalar> = Vec::with_capacity(n);
+            // The first coefficient can safely be set to 1 (see https://github.com/MystenLabs/fastcrypto/issues/120)
+            rands.push(get_one());
+            let mut rng = rand::thread_rng();
+            (1..n)
                 .into_iter()
-                .map(|x| &x.borrow().sig)
-                .collect::<Vec<_>>(),
-            false,
-        )
-        .map(|sig| BLS12381AggregateSignature {
-            sig: sig.to_signature(),
-            bytes: OnceCell::new(),
-        })
-        .map_err(|_| FastCryptoError::InvalidInput)
-    }
-
-    fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
-        let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
-        // add_signature() does not validate the new signature.
-        aggr_sig.add_signature(&signature.sig, false).map_err(|_| FastCryptoError::InvalidInput)?;
-        self.sig = aggr_sig.to_signature();
-        self.bytes.take();
-        Ok(())
-    }
-
-    fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
-        // aggregate() does not validate the new signature.
-        let result = blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
-            .map_err(|_| FastCryptoError::InvalidInput)?.to_signature();
-        self.sig = result;
-        self.bytes.take();
-        Ok(())
-    }
-
-    // This function assumes that that all public keys were verified using a proof of possession.
-    // See comment above [BLS12381PublicKey].
-    fn verify(
-        &self,
-        pks: &[<Self::Sig as Authenticator>::PubKey],
-        message: &[u8],
-    ) -> Result<(), FastCryptoError> {
-        // Validate signatures but not public keys which the user must validate before calling this.
-        let result = self
-            .sig
-            .fast_aggregate_verify(
-                true,
-                message,
-                $dst_string,
-                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-            );
-        if result != BLST_ERROR::BLST_SUCCESS {
-            return Err(FastCryptoError::InvalidSignature);
-        }
-        Ok(())
-    }
-
-    // This function assumes that that all public keys were verified using a proof of possession.
-    // See comment above [BLS12381PublicKey].
-    fn verify_different_msg(
-        &self,
-        pks: &[<Self::Sig as Authenticator>::PubKey],
-        messages: &[&[u8]],
-    ) -> Result<(), FastCryptoError> {
-        // Validate signatures but not public keys which the user must validate before calling this.
-        let result = self
-            .sig
-            .aggregate_verify(
-                true,
-                messages,
-                $dst_string,
-                &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
-                false,
-            );
-        if result != BLST_ERROR::BLST_SUCCESS {
-            return Err(FastCryptoError::InvalidSignature);
-        }
-        Ok(())
-    }
-
-    fn batch_verify<'a>(
-        signatures: &[&Self],
-        pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
-        messages: &[&[u8]],
-    ) -> Result<(), FastCryptoError> {
-        if signatures.len() != pks.len() || signatures.len() != messages.len() {
-            return Err(FastCryptoError::InputLengthWrong(signatures.len()));
+                .for_each(|_| rands.push(get_random_scalar(&mut rng)));
+            rands
         }
 
-        if signatures.is_empty() {
-            // verify_multiple_aggregate_signatures fails on empty input, but we accept here.
-            return Ok(())
+        //
+        // Boilerplate code for [BLS12381PrivateKey].
+        //
+
+        impl PartialEq for BLS12381PrivateKey {
+            fn eq(&self, other: &Self) -> bool {
+                self.as_ref() == other.as_ref()
+            }
         }
 
-        let mut agg_pks: Vec<blst::PublicKey> = Vec::with_capacity(signatures.len());
-        for keys in pks {
-             let keys_as_vec = keys.map(|x| x.pubkey.borrow()).collect::<Vec<_>>();
-             agg_pks.push(blst::AggregatePublicKey::aggregate(&keys_as_vec, false).unwrap().to_public_key()
-             );
-         }
+        impl Eq for BLS12381PrivateKey {}
 
-        // Validate signatures but not public keys which the user must validate before calling this.
-        let result = blst::Signature::verify_multiple_aggregate_signatures(
-            &messages,
-            $dst_string,
-            &agg_pks.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
-            false,
-            &signatures.iter().map(|agg_sig| &agg_sig.sig).collect::<Vec<_>>(),
-            true,
-            &get_random_scalars(signatures.len()),
-            BLS_BATCH_RANDOM_SCALAR_LENGTH,
+        // All fields impl zeroize::ZeroizeOnDrop directly or indirectly (OnceCell's drop will call
+        // ZeroizeOnDrop).
+        impl zeroize::ZeroizeOnDrop for BLS12381PrivateKey {}
+
+        impl AsRef<[u8]> for BLS12381PrivateKey {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes
+                    .get_or_init::<_>(|| zeroize::Zeroizing::new(self.privkey.to_bytes()))
+                    .as_ref()
+            }
+        }
+
+        impl ToFromBytes for BLS12381PrivateKey {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // from_bytes() validates that the key is in the right group.
+                let privkey = blst::SecretKey::from_bytes(bytes)
+                    .map_err(|_e| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381PrivateKey {
+                    privkey,
+                    bytes: OnceCell::new(),
+                })
+            }
+        }
+
+        //
+        // Custom code for [BLS12381PrivateKey].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381PrivateKey, BLS_PRIVATE_KEY_LENGTH);
+
+        impl SigningKey for BLS12381PrivateKey {
+            type PubKey = BLS12381PublicKey;
+            type Sig = BLS12381Signature;
+            const LENGTH: usize = BLS_PRIVATE_KEY_LENGTH;
+        }
+
+        impl Signer<BLS12381Signature> for BLS12381PrivateKey {
+            fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+                BLS12381Signature {
+                    sig: self.privkey.sign(msg, $dst_string, &[]),
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        //
+        // Boilerplate code for [BLS12381Signature].
+        //
+
+        impl PartialEq for BLS12381Signature {
+            fn eq(&self, other: &Self) -> bool {
+                self.sig == other.sig
+            }
+        }
+
+        impl Eq for BLS12381Signature {}
+
+        impl std::hash::Hash for BLS12381Signature {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.as_ref().hash(state);
+            }
+        }
+
+        impl AsRef<[u8]> for BLS12381Signature {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes.get_or_init::<_>(|| self.sig.to_bytes())
+            }
+        }
+
+        impl ToFromBytes for BLS12381Signature {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // from_bytes() does NOT check if the signature is in the right group. We check that when
+                // verifying the signature.
+                let sig = blst::Signature::from_bytes(bytes)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381Signature {
+                    sig,
+                    bytes: OnceCell::new(),
+                })
+            }
+        }
+
+        impl_base64_display_fmt!(BLS12381Signature);
+
+        //
+        // Custom code for [BLS12381Signature].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381Signature, $sig_length);
+
+        impl Default for BLS12381Signature {
+            fn default() -> Self {
+                // Setting the first byte to 0xc0 (1100), the first bit represents its in compressed form,
+                // the second bit represents its infinity point. See more: https://github.com/supranational/blst#serialization-format
+                let mut infinity: [u8; $sig_length] = [0; $sig_length];
+                infinity[0] = 0xc0;
+
+                BLS12381Signature {
+                    sig: blst::Signature::from_bytes(&infinity)
+                        .expect("Should decode infinity signature"),
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        impl Authenticator for BLS12381Signature {
+            type PubKey = BLS12381PublicKey;
+            type PrivKey = BLS12381PrivateKey;
+            const LENGTH: usize = $sig_length;
+        }
+
+        //
+        // Boilerplate code for [BLS12381KeyPair].
+        //
+
+        impl From<BLS12381PrivateKey> for BLS12381KeyPair {
+            fn from(private: BLS12381PrivateKey) -> Self {
+                let public = BLS12381PublicKey::from(&private);
+                BLS12381KeyPair { public, private }
+            }
+        }
+
+        /// The bytes form of the keypair only contain the private key bytes
+        impl AsRef<[u8]> for BLS12381KeyPair {
+            fn as_ref(&self) -> &[u8] {
+                self.private.as_ref()
+            }
+        }
+
+        impl ToFromBytes for BLS12381KeyPair {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                BLS12381PrivateKey::from_bytes(bytes).map(|private| private.into())
+            }
+        }
+
+        //
+        // Custom code for [BLS12381KeyPair].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381KeyPair, BLS_KEYPAIR_LENGTH);
+
+        impl KeyPair for BLS12381KeyPair {
+            type PubKey = BLS12381PublicKey;
+            type PrivKey = BLS12381PrivateKey;
+            type Sig = BLS12381Signature;
+
+            fn public(&'_ self) -> &'_ Self::PubKey {
+                &self.public
+            }
+
+            fn private(self) -> Self::PrivKey {
+                BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
+            }
+
+            #[cfg(feature = "copy_key")]
+            fn copy(&self) -> Self {
+                BLS12381KeyPair {
+                    public: self.public.clone(),
+                    private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+                }
+            }
+
+            fn generate<R: AllowedRng>(rng: &mut R) -> Self {
+                let mut ikm = [0u8; 32];
+                rng.fill_bytes(&mut ikm);
+                // TODO: Consider moving to key gen version 5.
+                let privkey =
+                    blst::SecretKey::key_gen(&ikm, &[]).expect("ikm length should be higher");
+                let pubkey = privkey.sk_to_pk();
+                BLS12381KeyPair {
+                    public: BLS12381PublicKey {
+                        pubkey,
+                        bytes: OnceCell::new(),
+                    },
+                    private: BLS12381PrivateKey {
+                        privkey,
+                        bytes: OnceCell::new(),
+                    },
+                }
+            }
+        }
+
+        impl Signer<BLS12381Signature> for BLS12381KeyPair {
+            fn sign(&self, msg: &[u8]) -> BLS12381Signature {
+                self.private.sign(msg)
+            }
+        }
+
+        impl FromStr for BLS12381KeyPair {
+            type Err = FastCryptoError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::decode_base64(s)
+            }
+        }
+
+        //
+        // Boilerplate code for [BLS12381AggregateSignature].
+        //
+
+        impl_base64_display_fmt!(BLS12381AggregateSignature);
+
+        impl PartialEq for BLS12381AggregateSignature {
+            fn eq(&self, other: &Self) -> bool {
+                self.sig == other.sig
+            }
+        }
+
+        impl Eq for BLS12381AggregateSignature {}
+
+        impl Default for BLS12381AggregateSignature {
+            fn default() -> Self {
+                BLS12381Signature::default().into()
+            }
+        }
+
+        impl AsRef<[u8]> for BLS12381AggregateSignature {
+            fn as_ref(&self) -> &[u8] {
+                self.bytes.get_or_init::<_>(|| self.sig.to_bytes())
+            }
+        }
+
+        impl From<BLS12381Signature> for BLS12381AggregateSignature {
+            fn from(sig: BLS12381Signature) -> Self {
+                BLS12381AggregateSignature {
+                    sig: sig.sig,
+                    bytes: OnceCell::new(),
+                }
+            }
+        }
+
+        //
+        // Custom code for [BLS12381AggregateSignature].
+        //
+
+        serialize_deserialize_with_to_from_bytes!(BLS12381AggregateSignature, $sig_length);
+        generate_bytes_representation!(
+            BLS12381AggregateSignature,
+            { $sig_length },
+            BLS12381AggregateSignatureAsBytes
         );
-        if result == BLST_ERROR::BLST_SUCCESS {
-            Ok(())
-        } else {
-            Err(FastCryptoError::GeneralOpaqueError)
+
+        impl ToFromBytes for BLS12381AggregateSignature {
+            fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+                // from_bytes does NOT validate the signature. We do that in verify.
+                let sig = blst::Signature::from_bytes(bytes)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                Ok(BLS12381AggregateSignature {
+                    sig,
+                    bytes: OnceCell::new(),
+                })
+            }
         }
-    }
-}
 
-};
+        impl AggregateAuthenticator for BLS12381AggregateSignature {
+            type Sig = BLS12381Signature;
+            type PubKey = BLS12381PublicKey;
+            type PrivKey = BLS12381PrivateKey;
 
+            fn aggregate<'a, K: Borrow<Self::Sig> + 'a, I: IntoIterator<Item = &'a K>>(
+                signatures: I,
+            ) -> Result<Self, FastCryptoError> {
+                // aggregate() below does not validate signatures.
+                blst::AggregateSignature::aggregate(
+                    &signatures
+                        .into_iter()
+                        .map(|x| &x.borrow().sig)
+                        .collect::<Vec<_>>(),
+                    false,
+                )
+                .map(|sig| BLS12381AggregateSignature {
+                    sig: sig.to_signature(),
+                    bytes: OnceCell::new(),
+                })
+                .map_err(|_| FastCryptoError::InvalidInput)
+            }
+
+            fn add_signature(&mut self, signature: Self::Sig) -> Result<(), FastCryptoError> {
+                let mut aggr_sig = blst::AggregateSignature::from_signature(&self.sig);
+                // add_signature() does not validate the new signature.
+                aggr_sig
+                    .add_signature(&signature.sig, false)
+                    .map_err(|_| FastCryptoError::InvalidInput)?;
+                self.sig = aggr_sig.to_signature();
+                self.bytes.take();
+                Ok(())
+            }
+
+            fn add_aggregate(&mut self, signature: Self) -> Result<(), FastCryptoError> {
+                // aggregate() does not validate the new signature.
+                let result =
+                    blst::AggregateSignature::aggregate(&[&self.sig, &signature.sig], false)
+                        .map_err(|_| FastCryptoError::InvalidInput)?
+                        .to_signature();
+                self.sig = result;
+                self.bytes.take();
+                Ok(())
+            }
+
+            // This function assumes that that all public keys were verified using a proof of possession.
+            // See comment above [BLS12381PublicKey].
+            fn verify(
+                &self,
+                pks: &[<Self::Sig as Authenticator>::PubKey],
+                message: &[u8],
+            ) -> Result<(), FastCryptoError> {
+                // Validate signatures but not public keys which the user must validate before calling this.
+                let result = self.sig.fast_aggregate_verify(
+                    true,
+                    message,
+                    $dst_string,
+                    &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+                );
+                if result != BLST_ERROR::BLST_SUCCESS {
+                    return Err(FastCryptoError::InvalidSignature);
+                }
+                Ok(())
+            }
+
+            // This function assumes that that all public keys were verified using a proof of possession.
+            // See comment above [BLS12381PublicKey].
+            fn verify_different_msg(
+                &self,
+                pks: &[<Self::Sig as Authenticator>::PubKey],
+                messages: &[&[u8]],
+            ) -> Result<(), FastCryptoError> {
+                // Validate signatures but not public keys which the user must validate before calling this.
+                let result = self.sig.aggregate_verify(
+                    true,
+                    messages,
+                    $dst_string,
+                    &pks.iter().map(|x| &x.pubkey).collect::<Vec<_>>()[..],
+                    false,
+                );
+                if result != BLST_ERROR::BLST_SUCCESS {
+                    return Err(FastCryptoError::InvalidSignature);
+                }
+                Ok(())
+            }
+
+            fn batch_verify<'a>(
+                signatures: &[&Self],
+                pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
+                messages: &[&[u8]],
+            ) -> Result<(), FastCryptoError> {
+                if signatures.len() != pks.len() || signatures.len() != messages.len() {
+                    return Err(FastCryptoError::InputLengthWrong(signatures.len()));
+                }
+
+                if signatures.is_empty() {
+                    // verify_multiple_aggregate_signatures fails on empty input, but we accept here.
+                    return Ok(());
+                }
+
+                let mut agg_pks: Vec<blst::PublicKey> = Vec::with_capacity(signatures.len());
+                for keys in pks {
+                    let keys_as_vec = keys.map(|x| x.pubkey.borrow()).collect::<Vec<_>>();
+                    agg_pks.push(
+                        blst::AggregatePublicKey::aggregate(&keys_as_vec, false)
+                            .unwrap()
+                            .to_public_key(),
+                    );
+                }
+
+                // Validate signatures but not public keys which the user must validate before calling this.
+                let result = blst::Signature::verify_multiple_aggregate_signatures(
+                    &messages,
+                    $dst_string,
+                    &agg_pks.iter().map(|m| m.borrow()).collect::<Vec<_>>(),
+                    false,
+                    &signatures
+                        .iter()
+                        .map(|agg_sig| &agg_sig.sig)
+                        .collect::<Vec<_>>(),
+                    true,
+                    &get_random_scalars(signatures.len()),
+                    BLS_BATCH_RANDOM_SCALAR_LENGTH,
+                );
+                if result == BLST_ERROR::BLST_SUCCESS {
+                    Ok(())
+                } else {
+                    Err(FastCryptoError::GeneralOpaqueError)
+                }
+            }
+        }
+    };
 } // macro_rules! define_bls12381.
 
 /// The length of a private key in bytes.

--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -33,8 +33,12 @@ use std::{
     str::FromStr,
 };
 
-use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature};
+#[cfg(any(test, feature = "experimental"))]
+use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput};
+#[cfg(any(test, feature = "experimental"))]
 use crate::error::FastCryptoResult;
+
+use crate::error::FastCryptoError::InvalidSignature;
 
 /// BLS signatures use two groups G1, G2, where elements of the first can be encoded using 48 bytes
 /// and of the second using 96 bytes. BLS supports two modes:

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -127,7 +127,7 @@ impl ToFromBytes for Ed25519PrivateKey {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         ed25519_consensus::SigningKey::try_from(bytes)
             .map(Ed25519PrivateKey)
-            .map_err(|_| FastCryptoError::InvalidInput)
+            .map_err(|_| InvalidInput)
     }
 }
 
@@ -247,7 +247,7 @@ impl ToFromBytes for Ed25519Signature {
                 sig,
                 bytes: OnceCell::new(),
             })
-            .map_err(|_| FastCryptoError::InvalidInput)
+            .map_err(|_| InvalidInput)
     }
 }
 
@@ -279,7 +279,7 @@ impl ToFromBytes for Ed25519PublicKey {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         ed25519_consensus::VerificationKey::try_from(bytes)
             .map(Ed25519PublicKey)
-            .map_err(|_| FastCryptoError::InvalidInput)
+            .map_err(|_| InvalidInput)
     }
 }
 
@@ -331,7 +331,7 @@ impl VerifyingKey for Ed25519PublicKey {
     fn verify(&self, msg: &[u8], signature: &Ed25519Signature) -> Result<(), FastCryptoError> {
         self.0
             .verify(&signature.sig, msg)
-            .map_err(|_| FastCryptoError::InvalidSignature)
+            .map_err(|_| InvalidSignature)
     }
 
     #[cfg(any(test, feature = "experimental"))]
@@ -501,7 +501,7 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
 
         batch
             .verify(OsRng)
-            .map_err(|_| FastCryptoError::GeneralOpaqueError)
+            .map_err(|_| GeneralOpaqueError)
     }
 
     fn batch_verify<'a>(
@@ -527,7 +527,7 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         }
         batch
             .verify(OsRng)
-            .map_err(|_| FastCryptoError::GeneralOpaqueError)
+            .map_err(|_| GeneralOpaqueError)
     }
 }
 

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -34,9 +34,10 @@ use zeroize::ZeroizeOnDrop;
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 
 #[cfg(any(test, feature = "experimental"))]
-use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature};
+use crate::error::FastCryptoError::{GeneralOpaqueError};
 #[cfg(any(test, feature = "experimental"))]
 use crate::error::FastCryptoResult;
+use crate::error::FastCryptoError::{InvalidInput, InvalidSignature};
 use crate::serde_helpers::{to_custom_error, BytesRepresentation};
 #[cfg(any(test, feature = "experimental"))]
 use crate::traits::AggregateAuthenticator;

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -33,7 +33,9 @@ use zeroize::ZeroizeOnDrop;
 
 use fastcrypto_derive::{SilentDebug, SilentDisplay};
 
+#[cfg(any(test, feature = "experimental"))]
 use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidSignature};
+#[cfg(any(test, feature = "experimental"))]
 use crate::error::FastCryptoResult;
 use crate::serde_helpers::{to_custom_error, BytesRepresentation};
 #[cfg(any(test, feature = "experimental"))]

--- a/fastcrypto/src/encoding.rs
+++ b/fastcrypto/src/encoding.rs
@@ -148,11 +148,15 @@ impl Hex {
     }
     /// Encode bytes as a hex string with a "0x" prefix.
     pub fn encode_with_format<T: AsRef<[u8]>>(bytes: T) -> String {
-        Self::from_bytes(bytes.as_ref()).encoded_with_format()
+        Self::format(&Self::encode(bytes))
     }
     /// Get a string representation of this Hex encoding with a "0x" prefix.
     pub fn encoded_with_format(&self) -> String {
-        format!("0x{}", self.0)
+        Self::format(&self.0)
+    }
+    /// Add "0x" prefix to a hex string.
+    fn format(hex_string: &str) -> String {
+        format!("0x{}", hex_string)
     }
 }
 

--- a/fastcrypto/src/encoding.rs
+++ b/fastcrypto/src/encoding.rs
@@ -160,6 +160,12 @@ impl Hex {
     }
 }
 
+/// Decodes a hex string to bytes. Both upper and lower case characters are allowed in the hex string.
+pub fn decode_bytes_hex<T: for<'a> TryFrom<&'a [u8]>>(s: &str) -> FastCryptoResult<T> {
+    let value = Hex::decode(s)?;
+    T::try_from(&value[..]).map_err(|_| InvalidInput)
+}
+
 impl Encoding for Hex {
     /// Decodes a hex string to bytes. Both upper and lower case characters are accepted, and the
     /// string may have a "0x" prefix or not.

--- a/fastcrypto/src/secp256k1/mod.rs
+++ b/fastcrypto/src/secp256k1/mod.rs
@@ -339,11 +339,10 @@ impl KeyPair for Secp256k1KeyPair {
 }
 
 impl FromStr for Secp256k1KeyPair {
-    type Err = eyre::Report;
+    type Err = FastCryptoError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
-        Ok(kp)
+        Self::decode_base64(s)
     }
 }
 

--- a/fastcrypto/src/secp256r1/mod.rs
+++ b/fastcrypto/src/secp256r1/mod.rs
@@ -483,11 +483,10 @@ impl KeyPair for Secp256r1KeyPair {
 }
 
 impl FromStr for Secp256r1KeyPair {
-    type Err = eyre::Report;
+    type Err = FastCryptoError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let kp = Self::decode_base64(s).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
-        Ok(kp)
+        Self::decode_base64(s)
     }
 }
 

--- a/fastcrypto/src/serde_helpers.rs
+++ b/fastcrypto/src/serde_helpers.rs
@@ -30,7 +30,7 @@ pub fn keypair_decode_base64<T: KeyPair>(value: &str) -> FastCryptoResult<T> {
     let sk_length = <<T as KeyPair>::PrivKey as SigningKey>::LENGTH;
     let pk_length = <<T as KeyPair>::PubKey as VerifyingKey>::LENGTH;
     if bytes.len() != pk_length + sk_length {
-        return Err(FastCryptoError::InvalidInput);
+        return Err(FastCryptoError::InputLengthWrong(pk_length + sk_length));
     }
     let secret = <T as KeyPair>::PrivKey::from_bytes(&bytes[..sk_length])?;
     // Read only sk bytes for privkey, and derive pubkey from privkey and returns keypair

--- a/fastcrypto/src/serde_helpers.rs
+++ b/fastcrypto/src/serde_helpers.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use base64ct::Encoding as _;
 use schemars::JsonSchema;
 use serde::{
     de,
@@ -12,7 +11,7 @@ use serde_with::serde_as;
 use std::fmt;
 use std::fmt::{Debug, Display};
 
-use crate::error::FastCryptoError;
+use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::{
     encoding::{Base64, Encoding},
     traits::{KeyPair, SigningKey, ToFromBytes, VerifyingKey},
@@ -26,13 +25,12 @@ where
     Error::custom(format!("byte deserialization failed, cause by: {:?}", e))
 }
 
-pub fn keypair_decode_base64<T: KeyPair>(value: &str) -> Result<T, eyre::Report> {
-    let bytes =
-        base64ct::Base64::decode_vec(value).map_err(|e| eyre::eyre!("{}", e.to_string()))?;
+pub fn keypair_decode_base64<T: KeyPair>(value: &str) -> FastCryptoResult<T> {
+    let bytes = Base64::decode(value)?;
     let sk_length = <<T as KeyPair>::PrivKey as SigningKey>::LENGTH;
     let pk_length = <<T as KeyPair>::PubKey as VerifyingKey>::LENGTH;
     if bytes.len() != pk_length + sk_length {
-        return Err(eyre::eyre!("Invalid keypair length"));
+        return Err(FastCryptoError::InvalidInput);
     }
     let secret = <T as KeyPair>::PrivKey::from_bytes(&bytes[..sk_length])?;
     // Read only sk bytes for privkey, and derive pubkey from privkey and returns keypair

--- a/fastcrypto/src/tests/encoding_tests.rs
+++ b/fastcrypto/src/tests/encoding_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::encoding::{encode_with_format, Base58, Base64, Bech32, Encoding, Hex};
+use crate::encoding::{Base58, Base64, Bech32, Encoding, Hex};
 use proptest::{arbitrary::Arbitrary, prop_assert_eq};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -36,8 +36,11 @@ fn test_hex_decode_err() {
 
 #[test]
 fn test_hex_encode_format() {
-    assert_eq!(encode_with_format([1]), "0x01");
-    assert_eq!(encode_with_format(Hex::decode("0x01").unwrap()), "0x01");
+    assert_eq!(Hex::encode_with_format([1]), "0x01");
+    assert_eq!(
+        Hex::encode_with_format(Hex::decode("0x01").unwrap()),
+        "0x01"
+    );
 }
 
 #[test]

--- a/fastcrypto/src/traits.rs
+++ b/fastcrypto/src/traits.rs
@@ -111,12 +111,7 @@ pub trait VerifyingKey:
     /// ```
     #[cfg(any(test, feature = "experimental"))]
     fn verify_batch_empty_fail(msg: &[u8], pks: &[Self], sigs: &[Self::Sig]) -> FastCryptoResult<()> {
-        if sigs.is_empty() {
-            // This behaviour can signal something dangerous, and that someone may be trying to bypass
-            // signature verification through providing empty batches.
-            return Err(FastCryptoError::GeneralOpaqueError);
-        }
-        if pks.len() != sigs.len() {
+        if sigs.is_empty() || pks.len() != sigs.len() {
             return Err(FastCryptoError::InvalidInput);
         }
         pks.iter()
@@ -148,12 +143,7 @@ pub trait VerifyingKey:
     #[cfg(any(test, feature = "experimental"))]
     fn verify_batch_empty_fail_different_msg<'a, M>(msgs: &[M], pks: &[Self], sigs: &[Self::Sig])
         -> FastCryptoResult<()> where M: Borrow<[u8]> + 'a {
-        if sigs.is_empty() {
-            // This behaviour can signal something dangerous, and that someone may be trying to bypass
-            // signature verification through providing empty batches.
-            return Err(FastCryptoError::GeneralOpaqueError);
-        }
-        if pks.len() != sigs.len() || pks.len() != msgs.len() {
+        if sigs.is_empty() || pks.len() != sigs.len() || pks.len() != msgs.len() {
             return Err(FastCryptoError::InvalidInput);
         }
         pks.iter()

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -22,11 +22,11 @@ use crate::traits::{
 };
 
 use super::hash::Fast256HashUnsecure;
+use crate::error::FastCryptoError::InvalidSignature;
+use crate::error::FastCryptoResult;
 use crate::serde_helpers::BytesRepresentation;
 use crate::traits::AllowedRng;
 use crate::{generate_bytes_representation, serialize_deserialize_with_to_from_bytes};
-use crate::error::FastCryptoError::InvalidSignature;
-use crate::error::FastCryptoResult;
 
 ///
 /// Define Structs

--- a/fastcrypto/src/unsecure/signature.rs
+++ b/fastcrypto/src/unsecure/signature.rs
@@ -6,7 +6,6 @@ use crate::{
     hash::{Digest, HashFunction},
 };
 use base64ct::{Base64, Encoding};
-use eyre::eyre;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
@@ -26,6 +25,8 @@ use super::hash::Fast256HashUnsecure;
 use crate::serde_helpers::BytesRepresentation;
 use crate::traits::AllowedRng;
 use crate::{generate_bytes_representation, serialize_deserialize_with_to_from_bytes};
+use crate::error::FastCryptoError::InvalidSignature;
+use crate::error::FastCryptoResult;
 
 ///
 /// Define Structs
@@ -133,7 +134,7 @@ impl VerifyingKey for UnsecurePublicKey {
         if ToFromBytes::as_bytes(signature) == digest.0 {
             return Ok(());
         }
-        Err(FastCryptoError::InvalidSignature)
+        Err(InvalidSignature)
     }
 
     #[cfg(any(test, feature = "experimental"))]
@@ -141,7 +142,7 @@ impl VerifyingKey for UnsecurePublicKey {
         _msg: &[u8],
         pks: &[Self],
         sigs: &[Self::Sig],
-    ) -> Result<(), eyre::Report> {
+    ) -> FastCryptoResult<()> {
         if pks
             .iter()
             .zip(sigs.iter())
@@ -150,7 +151,7 @@ impl VerifyingKey for UnsecurePublicKey {
         {
             return Ok(());
         }
-        Err(eyre!("Verification failed!"))
+        Err(InvalidSignature)
     }
 }
 


### PR DESCRIPTION
Clean up the `encoding` module:
* Use FastCryptoError throughout and make error messages opaque.
* Use macros for common code.
* Functionality is the same as before: Hex encoding is without 0x but serialization is with.

These changes requires some minor changes to Sui: https://github.com/MystenLabs/sui/pull/17495.

The PR changes the indention of fastcrypto/src/bls12381/mod.rs (entire file), so the fmt check is broken. I'll run a fmt before merge to make the review easier.