### PR TITLE
Hex: Remove "0x" on deserialization

### DIFF
--- a/fastcrypto/src/encoding.rs
+++ b/fastcrypto/src/encoding.rs
@@ -115,9 +115,17 @@ impl Base64 {
 }
 
 /// Hex string encoding.
-#[derive(Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Deserialize, Debug, JsonSchema, Clone, PartialEq)]
 #[serde(try_from = "String")]
 pub struct Hex(String);
+
+impl TryFrom<String> for Hex {
+    type Error = FastCryptoError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let s = value.strip_prefix("0x").unwrap_or(&value);
+        Ok(Self(s.to_string()))
+    }
+}
 
 impl Serialize for Hex {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -130,7 +138,6 @@ impl Serialize for Hex {
 }
 
 impl_serde_as_for_encoding!(Hex);
-impl_try_from_string!(Hex);
 
 impl Hex {
     /// Create a hex encoding from a string.

--- a/fastcrypto/src/tests/encoding_tests.rs
+++ b/fastcrypto/src/tests/encoding_tests.rs
@@ -50,7 +50,10 @@ fn test_serde() {
 
     let encoded_str = serde_json::to_string(&encoded).unwrap();
     let decoded: Hex = serde_json::from_str(&encoded_str).unwrap();
+    let encoded_str2 = serde_json::to_string(&decoded).unwrap();
     assert_eq!("\"0x01\"", encoded_str);
+    assert_eq!(encoded, decoded);
+    assert_eq!(encoded_str, encoded_str2);
     assert_eq!(
         decoded.to_vec().as_ref().unwrap(),
         encoded.to_vec().as_ref().unwrap()


### PR DESCRIPTION
- Hex currently stores unprefixed hex string 
- serialization adds "0x", but deser does not remove it  (as a result serialize(deserialize(serialize(x)) has "0x0x" prefix)
This PR fixed deser