### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,8 @@ jobs:
       - name: build benches
         run: cargo build --benches --features experimental,copy_key,unsecure_schemes
       - name: cargo test
-        run: cargo nextest run --features experimental,copy_key,unsecure_schemes
+      # TODO: `cargo nextest run` doesn't work on windows, so we use `cargo test` instead
+        run: cargo test --features experimental,copy_key,unsecure_schemes
       - name: Doctests
         run: |
           cargo test --doc --features experimental,copy_key,unsecure_schemes


### PR DESCRIPTION
Use `cargo test` instead of `cargo nextest run` to run tests on CI because the latter is broken on windows. Using `cargo test` is slower, so using `nextest` should preferably be fixed instead.