### PR TITLE
[DKG] ECIES v1

### DIFF
--- a/fastcrypto-tbls/benches/dkg.rs
+++ b/fastcrypto-tbls/benches/dkg.rs
@@ -3,8 +3,8 @@
 
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 use fastcrypto::groups::{bls12381, ristretto255};
-use fastcrypto_tbls::dkg_v0::Party;
-use fastcrypto_tbls::ecies_v0;
+use fastcrypto_tbls::dkg::Party;
+use fastcrypto_tbls::ecies;
 use fastcrypto_tbls::nodes::{Node, Nodes, PartyId};
 use fastcrypto_tbls::random_oracle::RandomOracle;
 use itertools::iproduct;
@@ -13,11 +13,11 @@ use rand::thread_rng;
 type G = bls12381::G2Element;
 type EG = ristretto255::RistrettoPoint;
 
-fn gen_ecies_keys(n: u16) -> Vec<(PartyId, ecies_v0::PrivateKey<EG>, ecies_v0::PublicKey<EG>)> {
+fn gen_ecies_keys(n: u16) -> Vec<(PartyId, ecies::PrivateKey<EG>, ecies::PublicKey<EG>)> {
     (0..n)
         .map(|id| {
-            let sk = ecies_v0::PrivateKey::<EG>::new(&mut thread_rng());
-            let pk = ecies_v0::PublicKey::<EG>::from_private_key(&sk);
+            let sk = ecies::PrivateKey::<EG>::new(&mut thread_rng());
+            let pk = ecies::PublicKey::<EG>::from_private_key(&sk);
             (id, sk, pk)
         })
         .collect()
@@ -27,7 +27,7 @@ pub fn setup_party(
     id: PartyId,
     threshold: u16,
     weight: u16,
-    keys: &[(PartyId, ecies_v0::PrivateKey<EG>, ecies_v0::PublicKey<EG>)],
+    keys: &[(PartyId, ecies::PrivateKey<EG>, ecies::PublicKey<EG>)],
 ) -> Party<G, EG> {
     let nodes = keys
         .iter()

--- a/fastcrypto-tbls/src/dkg.rs
+++ b/fastcrypto-tbls/src/dkg.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Some of the code below is based on code from https://github.com/celo-org/celo-threshold-bls-rs,
+// modified for our needs.
+//
+
+use crate::ecies;
+use crate::ecies::RecoveryPackage;
+use crate::nodes::{Nodes, PartyId};
+use crate::polynomial::{Poly, PrivatePoly};
+use crate::random_oracle::RandomOracle;
+use crate::tbls::Share;
+use fastcrypto::groups::GroupElement;
+use serde::{Deserialize, Serialize};
+
+/// Generics below use `G: GroupElement' for the group of the VSS public key, and `EG: GroupElement'
+/// for the group of the ECIES public key.
+
+/// Party in the DKG protocol.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Party<G: GroupElement, EG: GroupElement> {
+    pub id: PartyId,
+    pub(crate) nodes: Nodes<EG>,
+    pub t: u16,
+    pub random_oracle: RandomOracle,
+    pub(crate) enc_sk: ecies::PrivateKey<EG>,
+    pub(crate) vss_sk: PrivatePoly<G>,
+}
+
+/// Assumptions:
+/// - The high-level protocol is responsible for verifying that the 'sender' is correct in the
+///   following messages (based on the chain's authentication).
+/// - The high-level protocol is responsible that all parties see the same order of messages.
+
+/// A complaint/fraud claim against a dealer that created invalid encrypted share.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Complaint<EG: GroupElement> {
+    pub(crate) accused_sender: PartyId,
+    pub(crate) proof: RecoveryPackage<EG>,
+}
+
+/// A [Confirmation] is sent during the second phase of the protocol. It includes complaints
+/// created by receiver of invalid encrypted shares (if any).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Confirmation<EG: GroupElement> {
+    pub sender: PartyId,
+    /// List of complaints against other parties. Empty if there are none.
+    pub complaints: Vec<Complaint<EG>>,
+}
+
+// Upper bound on the size of binary serialized incoming messages assuming <=3333 shares, <=400
+// parties, and using G2Element for encryption. This is a safe upper bound since:
+// - Message is O(96*t + 32*n) bytes.
+// - Confirmation is O((96*3 + 32) * k) bytes.
+// Could be used as a sanity safety check before deserializing an incoming message.
+pub const DKG_MESSAGES_MAX_SIZE: usize = 400_000; // 400 KB
+
+/// [Output] is the final output of the DKG protocol in case it runs
+/// successfully. It can be used later with [ThresholdBls], see examples in tests.
+///
+/// If shares is None, the object can only be used for verifying (partial and full) signatures.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Output<G: GroupElement, EG: GroupElement> {
+    pub nodes: Nodes<EG>,
+    pub vss_pk: Poly<G>,
+    pub shares: Option<Vec<Share<G::ScalarType>>>, // None if some shares are missing or weight is zero.
+}

--- a/fastcrypto-tbls/src/dkg_v1.rs
+++ b/fastcrypto-tbls/src/dkg_v1.rs
@@ -6,19 +6,20 @@
 //
 
 use crate::dl_verification::verify_poly_evals;
-use crate::ecies_v0;
-use crate::ecies_v0::{MultiRecipientEncryption, RecoveryPackage};
-use crate::nodes::{Nodes, PartyId};
-use crate::polynomial::{Eval, Poly, PrivatePoly, PublicPoly};
+use crate::nodes::PartyId;
+use crate::polynomial::{Eval, PublicPoly};
 use crate::random_oracle::RandomOracle;
 use crate::tbls::Share;
 use crate::types::ShareIndex;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
-use fastcrypto::groups::{FiatShamirChallenge, GroupElement, MultiScalarMul};
+use fastcrypto::groups::{FiatShamirChallenge, GroupElement, HashToGroupElement, MultiScalarMul};
 use fastcrypto::traits::AllowedRng;
 use itertools::Itertools;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+
+use crate::dkg_v0::{Complaint, Confirmation, Output, Party};
+use crate::{ecies_v0, ecies_v1};
 
 use tap::prelude::*;
 use tracing::{debug, error, info, warn};
@@ -26,21 +27,12 @@ use tracing::{debug, error, info, warn};
 /// Generics below use `G: GroupElement' for the group of the VSS public key, and `EG: GroupElement'
 /// for the group of the ECIES public key.
 
-/// Party in the DKG protocol.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Party<G: GroupElement, EG: GroupElement> {
-    pub id: PartyId,
-    pub(crate) nodes: Nodes<EG>,
-    pub t: u16,
-    pub random_oracle: RandomOracle,
-    pub(crate) enc_sk: ecies_v0::PrivateKey<EG>,
-    pub(crate) vss_sk: PrivatePoly<G>,
-}
-
 /// Assumptions:
 /// - The high-level protocol is responsible for verifying that the 'sender' is correct in the
 ///   following messages (based on the chain's authentication).
 /// - The high-level protocol is responsible that all parties see the same order of messages.
+
+// TODO: Move Party, Complaint, Confirmation, Output here and remove old APIs
 
 /// [Message] holds all encrypted shares a dealer sends during the first phase of the
 /// protocol.
@@ -50,31 +42,8 @@ pub struct Message<G: GroupElement, EG: GroupElement> {
     /// The commitment of the secret polynomial created by the sender.
     pub vss_pk: PublicPoly<G>,
     /// The encrypted shares created by the sender. Sorted according to the receivers.
-    pub encrypted_shares: MultiRecipientEncryption<EG>,
+    pub encrypted_shares: ecies_v1::MultiRecipientEncryption<EG>,
 }
-
-/// A complaint/fraud claim against a dealer that created invalid encrypted share.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Complaint<EG: GroupElement> {
-    pub(crate) accused_sender: PartyId,
-    pub(crate) proof: RecoveryPackage<EG>,
-}
-
-/// A [Confirmation] is sent during the second phase of the protocol. It includes complaints
-/// created by receiver of invalid encrypted shares (if any).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Confirmation<EG: GroupElement> {
-    pub sender: PartyId,
-    /// List of complaints against other parties. Empty if there are none.
-    pub complaints: Vec<Complaint<EG>>,
-}
-
-// Upper bound on the size of binary serialized incoming messages assuming <=3333 shares, <=400
-// parties, and using G2Element for encryption. This is a safe upper bound since:
-// - Message is O(96*t + 32*n) bytes.
-// - Confirmation is O((96*3 + 32) * k) bytes.
-// Could be used as a sanity safety check before deserializing an incoming message.
-pub const DKG_MESSAGES_MAX_SIZE: usize = 400_000; // 400 KB
 
 /// Wrapper for collecting everything related to a processed message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -135,96 +104,40 @@ impl<G: GroupElement, EG: GroupElement> VerifiedProcessedMessages<G, EG> {
     }
 }
 
-/// [Output] is the final output of the DKG protocol in case it runs
-/// successfully. It can be used later with [ThresholdBls], see examples in tests.
-///
-/// If shares is None, the object can only be used for verifying (partial and full) signatures.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Output<G: GroupElement, EG: GroupElement> {
-    pub nodes: Nodes<EG>,
-    pub vss_pk: Poly<G>,
-    pub shares: Option<Vec<Share<G::ScalarType>>>, // None if some shares are missing or weight is zero.
-}
-
 /// A dealer in the DKG ceremony.
 ///
 /// Can be instantiated with G1Curve or G2Curve.
 impl<G, EG> Party<G, EG>
 where
     G: GroupElement + MultiScalarMul + Serialize + DeserializeOwned,
-    EG: GroupElement + Serialize + DeserializeOwned,
+    EG: GroupElement + Serialize + HashToGroupElement + DeserializeOwned,
     EG::ScalarType: FiatShamirChallenge,
 {
     /// 1. Create a new ECIES private key and send the public key to all parties.
     /// 2. After *all* parties have sent their ECIES public keys, create the (same) set of nodes.
 
     /// 3. Create a new Party instance with the ECIES private key and the set of nodes.
-    pub fn new<R: AllowedRng>(
-        enc_sk: ecies_v0::PrivateKey<EG>,
-        nodes: Nodes<EG>,
-        t: u16, // The number of parties that are needed to reconstruct the full key/signature (f+1).
-        random_oracle: RandomOracle, // Should be unique for each invocation, but the same for all parties.
-        rng: &mut R,
-    ) -> FastCryptoResult<Self> {
-        // Confirm that my ecies pk is in the nodes.
-        let enc_pk = ecies_v0::PublicKey::<EG>::from_private_key(&enc_sk);
-        let my_node = nodes
-            .iter()
-            .find(|n| n.pk == enc_pk)
-            .ok_or(FastCryptoError::InvalidInput)?;
-        // Sanity check that the threshold makes sense (t <= n/2 since we later wait for 2t-1).
-        if t > (nodes.total_weight() / 2) || t == 0 {
-            return Err(FastCryptoError::InvalidInput);
-        }
-        // TODO: [comm opt] Instead of generating the polynomial at random, use PRF generated values
-        // to reduce communication.
-        let vss_sk = PrivatePoly::<G>::rand(t - 1, rng);
-
-        // TODO: remove once the protocol is stable since it's a non negligible computation.
-        let vss_pk = vss_sk.commit::<G>();
-        info!(
-            "DKG: Creating party {} with weight {}, nodes hash {:?}, t {}, n {}, ro {:?}, enc pk {:?}, vss pk c0 {:?}",
-            my_node.id,
-            my_node.weight,
-            nodes.hash(),
-            t,
-            nodes.total_weight(),
-            random_oracle,
-            enc_pk,
-            vss_pk.c0(),
-        );
-
-        Ok(Self {
-            id: my_node.id,
-            nodes,
-            t,
-            random_oracle,
-            enc_sk,
-            vss_sk,
-        })
-    }
-
-    /// The threshold needed to reconstruct the full key/signature.
-    pub fn t(&self) -> u16 {
-        self.t
-    }
+    // TODO: Move new() and t() here
 
     /// 4. Create the first message to be broadcasted.
     ///
     ///    Returns IgnoredMessage if the party has zero weight (so no need to create a message).
-    pub fn create_message<R: AllowedRng>(&self, rng: &mut R) -> FastCryptoResult<Message<G, EG>> {
+    pub fn create_message_v1<R: AllowedRng>(
+        &self,
+        rng: &mut R,
+    ) -> FastCryptoResult<Message<G, EG>> {
         let node = self.nodes.node_id_to_node(self.id).expect("my id is valid");
         if node.weight == 0 {
             return Err(FastCryptoError::IgnoredMessage);
         }
 
         let vss_pk = self.vss_sk.commit();
-        let ro_for_enc = self.random_oracle.extend(&format!("encs {}", self.id));
+        let encryption_ro = self.encryption_random_oracle(self.id);
         info!(
             "DKG: Creating message for party {} with vss pk c0 {:?}, ro {:?}",
             self.id,
             vss_pk.c0(),
-            ro_for_enc,
+            encryption_ro,
         );
         // Create a vector of a public key and shares per receiver.
         let pk_and_shares = self
@@ -245,11 +158,12 @@ where
             })
             .collect::<Vec<_>>();
         // Encrypt everything.
-        let encrypted_shares = MultiRecipientEncryption::encrypt(&pk_and_shares, &ro_for_enc, rng);
+        let encrypted_shares =
+            ecies_v1::MultiRecipientEncryption::encrypt(&pk_and_shares, &encryption_ro, rng);
 
         debug!(
             "DKG: Created message using {:?}, with eph key {:?} nizk {:?}",
-            ro_for_enc,
+            encryption_ro,
             encrypted_shares.ephemeral_key(),
             encrypted_shares.proof(),
         );
@@ -262,7 +176,7 @@ where
     }
 
     // Sanity checks that can be done by any party on a received message.
-    fn sanity_check_message(&self, msg: &Message<G, EG>) -> FastCryptoResult<()> {
+    fn sanity_check_message_v1(&self, msg: &Message<G, EG>) -> FastCryptoResult<()> {
         let node = self
             .nodes
             .node_id_to_node(msg.sender)
@@ -309,13 +223,13 @@ where
             return Err(FastCryptoError::InvalidMessage);
         }
 
-        let ro_for_enc = self.random_oracle.extend(&format!("encs {}", msg.sender));
+        let encryption_ro = self.encryption_random_oracle(msg.sender);
         msg.encrypted_shares
-            .verify(&ro_for_enc)
+            .verify(&encryption_ro)
             .tap_err(|e| {
                 warn!("DKG: Message sanity check failed for id {}, verify with RO {:?}, eph key {:?} and proof {:?}, returned err: {:?}",
                     msg.sender,
-                    ro_for_enc,
+                    encryption_ro,
                     msg.encrypted_shares.ephemeral_key(),
                     msg.encrypted_shares.proof(),
                     e)
@@ -337,7 +251,7 @@ where
     ///    and just wait for f+1 valid messages).
     ///
     ///    Assumptions: Called only once per sender (the high level protocol is responsible for deduplication).
-    pub fn process_message<R: AllowedRng>(
+    pub fn process_message_v1<R: AllowedRng>(
         &self,
         message: Message<G, EG>,
         rng: &mut R,
@@ -348,14 +262,17 @@ where
             message.vss_pk.c0()
         );
         // Ignore if invalid (and other honest parties will ignore as well).
-        self.sanity_check_message(&message)?;
+        self.sanity_check_message_v1(&message)?;
 
         let my_share_ids = self.nodes.share_ids_of(self.id).expect("my id is valid");
-        let encrypted_shares = &message
-            .encrypted_shares
-            .get_encryption(self.id as usize)
-            .expect("checked in sanity_check_message that there are enough encryptions");
-        let decrypted_shares = Self::decrypt_and_get_share(&self.enc_sk, encrypted_shares).ok();
+        let encryption_ro = self.encryption_random_oracle(message.sender);
+        let buffer =
+            message
+                .encrypted_shares
+                .decrypt(&self.enc_sk, &encryption_ro, self.id as usize);
+        let decrypted_shares: Option<Vec<G::ScalarType>> = bcs::from_bytes(buffer.as_slice())
+            .map_err(|_| FastCryptoError::InvalidInput)
+            .ok();
 
         if decrypted_shares.is_none()
             || decrypted_shares.as_ref().unwrap().len() != my_share_ids.len()
@@ -366,12 +283,9 @@ where
             );
             let complaint = Complaint {
                 accused_sender: message.sender,
-                proof: self.enc_sk.create_recovery_package(
-                    encrypted_shares,
-                    &self.random_oracle.extend(&format!(
-                        "recovery of id {} received from {}",
-                        self.id, message.sender
-                    )),
+                proof: message.encrypted_shares.create_recovery_package(
+                    &self.enc_sk,
+                    &self.recovery_random_oracle(self.id, message.sender),
                     rng,
                 ),
             };
@@ -403,12 +317,9 @@ where
             );
             let complaint = Complaint {
                 accused_sender: message.sender,
-                proof: self.enc_sk.create_recovery_package(
-                    encrypted_shares,
-                    &self.random_oracle.extend(&format!(
-                        "recovery of id {} received from {}",
-                        self.id, message.sender
-                    )),
+                proof: message.encrypted_shares.create_recovery_package(
+                    &self.enc_sk,
+                    &self.recovery_random_oracle(self.id, message.sender),
                     rng,
                 ),
             };
@@ -436,7 +347,7 @@ where
     ///
     ///    Assumptions: processed_messages is the result of process_message on the same set of messages
     ///    on all parties.
-    pub fn merge(
+    pub fn merge_v1(
         &self,
         processed_messages: &[ProcessedMessage<G, EG>],
     ) -> FastCryptoResult<(Confirmation<EG>, UsedProcessedMessages<G, EG>)> {
@@ -496,7 +407,7 @@ where
     ///    Returns NotEnoughInputs if the threshold minimal_threshold is not met.
     ///
     ///    Assumptions: All parties use the same set of confirmations (and outputs from merge).
-    pub(crate) fn process_confirmations<R: AllowedRng>(
+    pub(crate) fn process_confirmations_v1<R: AllowedRng>(
         &self,
         messages: &UsedProcessedMessages<G, EG>,
         confirmations: &[Confirmation<EG>],
@@ -555,28 +466,21 @@ where
                     .expect("checked above that accuser is valid id");
                 // If the claim refers to a non existing message, it's an invalid complaint.
                 let valid_complaint = match id_to_m1.get(&accused) {
-                    Some(related_m1) => {
-                        let encrypted_shares = &related_m1
-                            .encrypted_shares
-                            .get_encryption(accuser as usize)
-                            .expect("checked earlier that there are enough encryptions");
-                        Self::check_complaint_proof(
-                            &complaint.proof,
-                            accuser_pk,
-                            &self
-                                .nodes
-                                .share_ids_of(accuser)
-                                .expect("checked above the accuser is valid id"),
-                            &related_m1.vss_pk,
-                            encrypted_shares,
-                            &self.random_oracle.extend(&format!(
-                                "recovery of id {} received from {}",
-                                accuser, accused
-                            )),
-                            rng,
-                        )
-                        .is_ok()
-                    }
+                    Some(related_m1) => Self::check_complaint_proof_v1(
+                        &complaint.proof,
+                        accuser_pk,
+                        accuser,
+                        &self
+                            .nodes
+                            .share_ids_of(accuser)
+                            .expect("checked above the accuser is valid id"),
+                        &related_m1.vss_pk,
+                        &related_m1.encrypted_shares,
+                        &self.recovery_random_oracle(accuser, accused),
+                        &self.encryption_random_oracle(accused),
+                        rng,
+                    )
+                    .is_ok(),
                     None => false,
                 };
                 match valid_complaint {
@@ -628,7 +532,10 @@ where
     }
 
     /// 8. Aggregate the valid shares (as returned from the previous step) and the public key.
-    pub(crate) fn aggregate(&self, messages: &VerifiedProcessedMessages<G, EG>) -> Output<G, EG> {
+    pub(crate) fn aggregate_v1(
+        &self,
+        messages: &VerifiedProcessedMessages<G, EG>,
+    ) -> Output<G, EG> {
         debug!(
             "Aggregating shares from {} verified messages",
             messages.0.len()
@@ -701,38 +608,37 @@ where
     }
 
     /// Execute the previous two steps together.
-    pub fn complete<R: AllowedRng>(
+    pub fn complete_v1<R: AllowedRng>(
         &self,
         messages: &UsedProcessedMessages<G, EG>,
         confirmations: &[Confirmation<EG>],
         rng: &mut R,
     ) -> FastCryptoResult<Output<G, EG>> {
-        let verified_messages = self.process_confirmations(messages, confirmations, rng)?;
-        Ok(self.aggregate(&verified_messages))
-    }
-
-    fn decrypt_and_get_share(
-        sk: &ecies_v0::PrivateKey<EG>,
-        encrypted_shares: &ecies_v0::Encryption<EG>,
-    ) -> FastCryptoResult<Vec<G::ScalarType>> {
-        let buffer = sk.decrypt(encrypted_shares);
-        bcs::from_bytes(buffer.as_slice()).map_err(|_| FastCryptoError::InvalidInput)
+        let verified_messages = self.process_confirmations_v1(messages, confirmations, rng)?;
+        Ok(self.aggregate_v1(&verified_messages))
     }
 
     // Returns an error if the *complaint* is invalid (counterintuitive).
-    fn check_complaint_proof<R: AllowedRng>(
-        recovery_pkg: &RecoveryPackage<EG>,
-        ecies_pk: &ecies_v0::PublicKey<EG>,
+    fn check_complaint_proof_v1<R: AllowedRng>(
+        recovery_pkg: &ecies_v0::RecoveryPackage<EG>,
+        receiver_pk: &ecies_v0::PublicKey<EG>,
+        receiver_id: PartyId,
         share_ids: &[ShareIndex],
         vss_pk: &PublicPoly<G>,
-        encrypted_share: &ecies_v0::Encryption<EG>,
-        random_oracle: &RandomOracle,
+        encryption: &ecies_v1::MultiRecipientEncryption<EG>,
+        recovery_random_oracle: &RandomOracle,
+        encryption_random_oracle: &RandomOracle,
         rng: &mut R,
     ) -> FastCryptoResult<()> {
         // Check that the recovery package is valid, and if not, return an error since the complaint
         // is invalid.
-        let buffer =
-            ecies_pk.decrypt_with_recovery_package(recovery_pkg, random_oracle, encrypted_share)?;
+        let buffer = encryption.decrypt_with_recovery_package(
+            recovery_pkg,
+            recovery_random_oracle,
+            encryption_random_oracle,
+            receiver_pk,
+            receiver_id as usize,
+        )?;
 
         let decrypted_shares: Vec<G::ScalarType> = match bcs::from_bytes(buffer.as_slice()) {
             Ok(s) => s,
@@ -764,21 +670,15 @@ where
             }
         }
     }
-}
 
-#[cfg(test)]
-pub fn create_fake_complaint<EG>() -> Complaint<EG>
-where
-    EG: GroupElement + Serialize + DeserializeOwned,
-    <EG as GroupElement>::ScalarType: FiatShamirChallenge,
-{
-    let sk = ecies_v0::PrivateKey::<EG>::new(&mut rand::thread_rng());
-    let pk = ecies_v0::PublicKey::<EG>::from_private_key(&sk);
-    let encryption = pk.encrypt(b"test", &mut rand::thread_rng());
-    let ro = RandomOracle::new("test");
-    let pkg = sk.create_recovery_package(&encryption, &ro, &mut rand::thread_rng());
-    Complaint {
-        accused_sender: 1,
-        proof: pkg,
+    fn encryption_random_oracle(&self, sender: PartyId) -> RandomOracle {
+        self.random_oracle.extend(&format!("encs {}", sender))
+    }
+
+    fn recovery_random_oracle(&self, accuser: PartyId, accused: PartyId) -> RandomOracle {
+        self.random_oracle.extend(&format!(
+            "recovery of id {} received from {}",
+            accuser, accused
+        ))
     }
 }

--- a/fastcrypto-tbls/src/dkg_v1.rs
+++ b/fastcrypto-tbls/src/dkg_v1.rs
@@ -24,14 +24,6 @@ use crate::{ecies, ecies_v1};
 use tap::prelude::*;
 use tracing::{debug, error, info, warn};
 
-/// Generics below use `G: GroupElement' for the group of the VSS public key, and `EG: GroupElement'
-/// for the group of the ECIES public key.
-
-/// Assumptions:
-/// - The high-level protocol is responsible for verifying that the 'sender' is correct in the
-///   following messages (based on the chain's authentication).
-/// - The high-level protocol is responsible that all parties see the same order of messages.
-
 // TODO: Move Party, Complaint, Confirmation, Output here and remove old APIs
 
 /// [Message] holds all encrypted shares a dealer sends during the first phase of the
@@ -677,7 +669,7 @@ where
 
     fn recovery_random_oracle(&self, accuser: PartyId, accused: PartyId) -> RandomOracle {
         self.random_oracle.extend(&format!(
-            "recovery of id {} received from {}",
+            "recovery of {} received from {}",
             accuser, accused
         ))
     }

--- a/fastcrypto-tbls/src/dkg_v1.rs
+++ b/fastcrypto-tbls/src/dkg_v1.rs
@@ -611,6 +611,7 @@ where
     }
 
     // Returns an error if the *complaint* is invalid (counterintuitive).
+    #[allow(clippy::too_many_arguments)]
     fn check_complaint_proof_v1<R: AllowedRng>(
         recovery_pkg: &ecies::RecoveryPackage<EG>,
         receiver_pk: &ecies::PublicKey<EG>,

--- a/fastcrypto-tbls/src/dkg_v1.rs
+++ b/fastcrypto-tbls/src/dkg_v1.rs
@@ -18,8 +18,8 @@ use itertools::Itertools;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-use crate::dkg_v0::{Complaint, Confirmation, Output, Party};
-use crate::{ecies_v0, ecies_v1};
+use crate::dkg::{Complaint, Confirmation, Output, Party};
+use crate::{ecies, ecies_v1};
 
 use tap::prelude::*;
 use tracing::{debug, error, info, warn};
@@ -620,8 +620,8 @@ where
 
     // Returns an error if the *complaint* is invalid (counterintuitive).
     fn check_complaint_proof_v1<R: AllowedRng>(
-        recovery_pkg: &ecies_v0::RecoveryPackage<EG>,
-        receiver_pk: &ecies_v0::PublicKey<EG>,
+        recovery_pkg: &ecies::RecoveryPackage<EG>,
+        receiver_pk: &ecies::PublicKey<EG>,
         receiver_id: PartyId,
         share_ids: &[ShareIndex],
         vss_pk: &PublicPoly<G>,

--- a/fastcrypto-tbls/src/ecies.rs
+++ b/fastcrypto-tbls/src/ecies.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::nizk::DdhTupleNizk;
+use fastcrypto::groups::GroupElement;
+use serde::{Deserialize, Serialize};
+
+// TODO: Use ZeroizeOnDrop.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivateKey<G: GroupElement>(pub(crate) G::ScalarType);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicKey<G: GroupElement>(pub(crate) G);
+
+/// A recovery package that allows decrypting a *specific* ECIES Encryption.
+/// It also includes a NIZK proof of correctness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryPackage<G: GroupElement> {
+    pub(crate) ephemeral_key: G,
+    pub(crate) proof: DdhTupleNizk<G>,
+}
+
+pub const AES_KEY_LENGTH: usize = 32;

--- a/fastcrypto-tbls/src/ecies_v0.rs
+++ b/fastcrypto-tbls/src/ecies_v0.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ecies::{PrivateKey, PublicKey, RecoveryPackage, AES_KEY_LENGTH};
 use crate::nizk::{DLNizk, DdhTupleNizk};
 use crate::random_oracle::RandomOracle;
 use fastcrypto::aes::{Aes256Ctr, AesKey, Cipher, InitializationVector};
@@ -24,13 +25,6 @@ use typenum::consts::{U16, U32};
 ///
 /// The encryption uses AES Counter mode and is not CCA secure as is.
 
-// TODO: Use ZeroizeOnDrop.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PrivateKey<G: GroupElement>(pub(crate) G::ScalarType);
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PublicKey<G: GroupElement>(pub(crate) G);
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Encryption<G: GroupElement> {
     ephemeral_key: G,
@@ -42,16 +36,6 @@ pub struct Encryption<G: GroupElement> {
 /// valid).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MultiRecipientEncryption<G: GroupElement>(G, Vec<Vec<u8>>, DLNizk<G>);
-
-/// A recovery package that allows decrypting a *specific* ECIES Encryption.
-/// It also includes a NIZK proof of correctness.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RecoveryPackage<G: GroupElement> {
-    pub(crate) ephemeral_key: G,
-    pub(crate) proof: DdhTupleNizk<G>,
-}
-
-const AES_KEY_LENGTH: usize = 32;
 
 impl<G> PrivateKey<G>
 where

--- a/fastcrypto-tbls/src/ecies_v0.rs
+++ b/fastcrypto-tbls/src/ecies_v0.rs
@@ -47,8 +47,8 @@ pub struct MultiRecipientEncryption<G: GroupElement>(G, Vec<Vec<u8>>, DLNizk<G>)
 /// It also includes a NIZK proof of correctness.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecoveryPackage<G: GroupElement> {
-    ephemeral_key: G,
-    proof: DdhTupleNizk<G>,
+    pub(crate) ephemeral_key: G,
+    pub(crate) proof: DdhTupleNizk<G>,
 }
 
 const AES_KEY_LENGTH: usize = 32;

--- a/fastcrypto-tbls/src/ecies_v0.rs
+++ b/fastcrypto-tbls/src/ecies_v0.rs
@@ -26,10 +26,10 @@ use typenum::consts::{U16, U32};
 
 // TODO: Use ZeroizeOnDrop.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PrivateKey<G: GroupElement>(G::ScalarType);
+pub struct PrivateKey<G: GroupElement>(pub(crate) G::ScalarType);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PublicKey<G: GroupElement>(G);
+pub struct PublicKey<G: GroupElement>(pub(crate) G);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Encryption<G: GroupElement> {

--- a/fastcrypto-tbls/src/ecies_v1.rs
+++ b/fastcrypto-tbls/src/ecies_v1.rs
@@ -1,0 +1,238 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ecies_v0::RecoveryPackage;
+use crate::nizk::DdhTupleNizk;
+use crate::random_oracle::RandomOracle;
+use fastcrypto::aes::{Aes256Ctr, AesKey, Cipher, InitializationVector};
+use fastcrypto::error::{FastCryptoError, FastCryptoResult};
+use fastcrypto::groups::{FiatShamirChallenge, GroupElement, HashToGroupElement, Scalar};
+use fastcrypto::traits::{AllowedRng, ToFromBytes};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use typenum::consts::{U16, U32};
+use typenum::Unsigned;
+
+/// Simple ECIES encryption using a generic group and AES-256-counter.
+///
+/// APIs that use a random oracle must receive one as an argument. That RO must be unique and thus
+/// the caller should initialize/derive it using a unique prefix.
+///
+/// The encryption uses AES Counter mode and is not CCA secure as is.
+///
+/// Random oracles are extended from two oracles provided by the caller, one for
+/// encryptions/decryptions and one for recovery packages.
+
+// TODO: Use ZeroizeOnDrop.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivateKey<G: GroupElement>(G::ScalarType);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicKey<G: GroupElement>(G);
+
+/// Multi-recipient encryption with a proof-of-knowledge of the plaintexts (when the encryption is
+/// valid).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiRecipientEncryption<G: GroupElement> {
+    c: G,
+    c_hat: G,
+    encs: Vec<Vec<u8>>,
+    proof: DdhTupleNizk<G>,
+}
+
+impl<G> PrivateKey<G>
+where
+    G: GroupElement + Serialize,
+    <G as GroupElement>::ScalarType: FiatShamirChallenge,
+{
+    pub fn new<R: AllowedRng>(rng: &mut R) -> Self {
+        Self(G::ScalarType::rand(rng))
+    }
+
+    pub fn from(sc: G::ScalarType) -> Self {
+        Self(sc)
+    }
+
+    // We assume that MultiRecipientEncryption::verify is called before decrypt.
+    pub fn decrypt(
+        &self,
+        enc: &MultiRecipientEncryption<G>,
+        encryption_random_oracle: &RandomOracle,
+        receiver_index: usize,
+    ) -> Vec<u8> {
+        let enc_ro = encryption_random_oracle.extend("encs");
+        let ephemeral_key = enc.c * self.0;
+        let k = enc_ro.evaluate(&(receiver_index, ephemeral_key));
+        let cipher = sym_cipher(&k);
+        cipher
+            .decrypt(&fixed_zero_nonce(), &enc.encs[receiver_index])
+            .expect("Decrypt should never fail for CTR mode")
+    }
+
+    pub fn create_recovery_package<R: AllowedRng>(
+        &self,
+        enc: &MultiRecipientEncryption<G>,
+        recovery_random_oracle: &RandomOracle,
+        rng: &mut R,
+    ) -> RecoveryPackage<G> {
+        let pk = G::generator() * self.0;
+        let ephemeral_key = enc.c * self.0;
+
+        let proof = DdhTupleNizk::<G>::create(
+            &self.0,
+            &enc.c,
+            &pk,
+            &ephemeral_key,
+            &recovery_random_oracle,
+            rng,
+        );
+
+        RecoveryPackage {
+            ephemeral_key,
+            proof,
+        }
+    }
+}
+
+impl<G> PublicKey<G>
+where
+    G: GroupElement + Serialize + DeserializeOwned,
+    <G as GroupElement>::ScalarType: FiatShamirChallenge,
+{
+    pub fn from_private_key(sk: &PrivateKey<G>) -> Self {
+        Self(G::generator() * sk.0)
+    }
+
+    pub fn as_element(&self) -> &G {
+        &self.0
+    }
+}
+
+impl<G: GroupElement> From<G> for PublicKey<G> {
+    fn from(p: G) -> Self {
+        Self(p)
+    }
+}
+
+impl<G: GroupElement + Serialize> MultiRecipientEncryption<G>
+where
+    <G as GroupElement>::ScalarType: FiatShamirChallenge,
+    G: HashToGroupElement,
+{
+    pub fn encrypt<R: AllowedRng>(
+        pk_and_msgs: &[(PublicKey<G>, Vec<u8>)],
+        encryption_random_oracle: &RandomOracle,
+        rng: &mut R,
+    ) -> MultiRecipientEncryption<G> {
+        let r = G::ScalarType::rand(rng);
+        let c = G::generator() * r;
+        let g_hat =
+            G::hash_to_group_element(&encryption_random_oracle.extend("g_hat").evaluate(&c));
+        let c_hat = g_hat * r;
+        let proof = DdhTupleNizk::<G>::create(
+            &r,
+            &g_hat,
+            &c,
+            &c_hat,
+            &encryption_random_oracle.extend("zk"),
+            rng,
+        );
+
+        let encs_ro = encryption_random_oracle.extend("encs");
+        let encs = pk_and_msgs
+            .iter()
+            .enumerate()
+            .map(|(receiver_index, (receiver_pk, msg))| {
+                let pk_r = receiver_pk.0 * r;
+                let k = encs_ro.evaluate(&(receiver_index, pk_r));
+                let cipher = sym_cipher(&k);
+                cipher.encrypt(&fixed_zero_nonce(), msg)
+            })
+            .collect::<Vec<_>>();
+
+        MultiRecipientEncryption {
+            c,
+            c_hat,
+            encs,
+            proof,
+        }
+    }
+
+    pub fn decrypt_with_recovery_package(
+        &self,
+        pkg: &RecoveryPackage<G>,
+        recovery_random_oracle: &RandomOracle,
+        encryption_random_oracle: &RandomOracle,
+        receiver_pk: &PublicKey<G>,
+        receiver_index: usize,
+    ) -> FastCryptoResult<Vec<u8>> {
+        pkg.proof.verify(
+            &self.c,
+            &receiver_pk.0,
+            &pkg.ephemeral_key,
+            recovery_random_oracle,
+        )?;
+        let encs_ro = encryption_random_oracle.extend("encs");
+        let k = encs_ro.evaluate(&(receiver_index, pkg.ephemeral_key));
+        let cipher = sym_cipher(&k);
+        Ok(cipher
+            .decrypt(&fixed_zero_nonce(), &self.encs[receiver_index])
+            .expect("Decrypt should never fail for CTR mode"))
+    }
+
+    pub fn len(&self) -> usize {
+        self.encs.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.encs.is_empty()
+    }
+
+    pub fn verify(&self, encryption_random_oracle: &RandomOracle) -> FastCryptoResult<()> {
+        let g_hat =
+            G::hash_to_group_element(&encryption_random_oracle.extend("g_hat").evaluate(&self.c));
+        self.proof.verify(
+            &g_hat,
+            &self.c,
+            &self.c_hat,
+            &encryption_random_oracle.extend("zk"),
+        )?;
+        // Encryptions should not be empty.
+        self.encs
+            .iter()
+            .all(|e| !e.is_empty())
+            .then_some(())
+            .ok_or(FastCryptoError::InvalidInput)
+    }
+
+    // Used for debugging
+    pub fn ephemeral_key(&self) -> &G {
+        &self.c
+    }
+
+    // Used for debugging
+    pub fn proof(&self) -> &DdhTupleNizk<G> {
+        &self.proof
+    }
+
+    #[cfg(test)]
+    pub fn swap_for_testing(&mut self, i: usize, j: usize) {
+        self.encs.swap(i, j);
+    }
+
+    #[cfg(test)]
+    pub fn copy_for_testing(&mut self, src: usize, dst: usize) {
+        self.encs[dst] = self.encs[src].clone();
+    }
+}
+
+fn fixed_zero_nonce() -> InitializationVector<U16> {
+    InitializationVector::<U16>::from_bytes(&[0u8; 16])
+        .expect("U16 could always be set from a 16 bytes array of zeros")
+}
+
+fn sym_cipher(k: &[u8; 64]) -> Aes256Ctr {
+    Aes256Ctr::new(
+        AesKey::<U32>::from_bytes(&k[0..U32::USIZE])
+            .expect("New shouldn't fail as use fixed size key is used"),
+    )
+}

--- a/fastcrypto-tbls/src/ecies_v1.rs
+++ b/fastcrypto-tbls/src/ecies_v1.rs
@@ -126,7 +126,7 @@ where
             &self.c,
             &pk,
             &ephemeral_key,
-            &recovery_random_oracle,
+            recovery_random_oracle,
             rng,
         );
 

--- a/fastcrypto-tbls/src/ecies_v1.rs
+++ b/fastcrypto-tbls/src/ecies_v1.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ecies_v0::{PrivateKey, PublicKey, RecoveryPackage};
+use crate::ecies::{PrivateKey, PublicKey, RecoveryPackage};
 use crate::nizk::DdhTupleNizk;
 use crate::random_oracle::RandomOracle;
 use fastcrypto::aes::{Aes256Ctr, AesKey, Cipher, InitializationVector};
@@ -31,7 +31,7 @@ pub struct MultiRecipientEncryption<G: GroupElement> {
     c: G,
     c_hat: G,
     encs: Vec<Vec<u8>>,
-    proof: DdhTupleNizk<G>,
+    pub proof: DdhTupleNizk<G>,
 }
 
 impl<G: GroupElement + Serialize> MultiRecipientEncryption<G>

--- a/fastcrypto-tbls/src/ecies_v1.rs
+++ b/fastcrypto-tbls/src/ecies_v1.rs
@@ -1,14 +1,13 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ecies_v0::RecoveryPackage;
+use crate::ecies_v0::{PrivateKey, PublicKey, RecoveryPackage};
 use crate::nizk::DdhTupleNizk;
 use crate::random_oracle::RandomOracle;
 use fastcrypto::aes::{Aes256Ctr, AesKey, Cipher, InitializationVector};
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{FiatShamirChallenge, GroupElement, HashToGroupElement, Scalar};
 use fastcrypto::traits::{AllowedRng, ToFromBytes};
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use typenum::consts::{U16, U32};
 use typenum::Unsigned;
@@ -23,12 +22,7 @@ use typenum::Unsigned;
 /// Random oracles are extended from two oracles provided by the caller, one for
 /// encryptions/decryptions and one for recovery packages.
 
-// TODO: Use ZeroizeOnDrop.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PrivateKey<G: GroupElement>(G::ScalarType);
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PublicKey<G: GroupElement>(G);
+// TODO: move PrivateKey and PublicKey here and remove old APIs
 
 /// Multi-recipient encryption with a proof-of-knowledge of the plaintexts (when the encryption is
 /// valid).
@@ -38,80 +32,6 @@ pub struct MultiRecipientEncryption<G: GroupElement> {
     c_hat: G,
     encs: Vec<Vec<u8>>,
     proof: DdhTupleNizk<G>,
-}
-
-impl<G> PrivateKey<G>
-where
-    G: GroupElement + Serialize,
-    <G as GroupElement>::ScalarType: FiatShamirChallenge,
-{
-    pub fn new<R: AllowedRng>(rng: &mut R) -> Self {
-        Self(G::ScalarType::rand(rng))
-    }
-
-    pub fn from(sc: G::ScalarType) -> Self {
-        Self(sc)
-    }
-
-    // We assume that MultiRecipientEncryption::verify is called before decrypt.
-    pub fn decrypt(
-        &self,
-        enc: &MultiRecipientEncryption<G>,
-        encryption_random_oracle: &RandomOracle,
-        receiver_index: usize,
-    ) -> Vec<u8> {
-        let enc_ro = encryption_random_oracle.extend("encs");
-        let ephemeral_key = enc.c * self.0;
-        let k = enc_ro.evaluate(&(receiver_index, ephemeral_key));
-        let cipher = sym_cipher(&k);
-        cipher
-            .decrypt(&fixed_zero_nonce(), &enc.encs[receiver_index])
-            .expect("Decrypt should never fail for CTR mode")
-    }
-
-    pub fn create_recovery_package<R: AllowedRng>(
-        &self,
-        enc: &MultiRecipientEncryption<G>,
-        recovery_random_oracle: &RandomOracle,
-        rng: &mut R,
-    ) -> RecoveryPackage<G> {
-        let pk = G::generator() * self.0;
-        let ephemeral_key = enc.c * self.0;
-
-        let proof = DdhTupleNizk::<G>::create(
-            &self.0,
-            &enc.c,
-            &pk,
-            &ephemeral_key,
-            &recovery_random_oracle,
-            rng,
-        );
-
-        RecoveryPackage {
-            ephemeral_key,
-            proof,
-        }
-    }
-}
-
-impl<G> PublicKey<G>
-where
-    G: GroupElement + Serialize + DeserializeOwned,
-    <G as GroupElement>::ScalarType: FiatShamirChallenge,
-{
-    pub fn from_private_key(sk: &PrivateKey<G>) -> Self {
-        Self(G::generator() * sk.0)
-    }
-
-    pub fn as_element(&self) -> &G {
-        &self.0
-    }
-}
-
-impl<G: GroupElement> From<G> for PublicKey<G> {
-    fn from(p: G) -> Self {
-        Self(p)
-    }
 }
 
 impl<G: GroupElement + Serialize> MultiRecipientEncryption<G>
@@ -154,6 +74,46 @@ where
             c,
             c_hat,
             encs,
+            proof,
+        }
+    }
+
+    // We assume that MultiRecipientEncryption::verify is called before decrypt.
+    pub fn decrypt(
+        &self,
+        sk: &PrivateKey<G>,
+        encryption_random_oracle: &RandomOracle,
+        receiver_index: usize,
+    ) -> Vec<u8> {
+        let enc_ro = encryption_random_oracle.extend("encs");
+        let ephemeral_key = self.c * sk.0;
+        let k = enc_ro.evaluate(&(receiver_index, ephemeral_key));
+        let cipher = sym_cipher(&k);
+        cipher
+            .decrypt(&fixed_zero_nonce(), &self.encs[receiver_index])
+            .expect("Decrypt should never fail for CTR mode")
+    }
+
+    pub fn create_recovery_package<R: AllowedRng>(
+        &self,
+        sk: &PrivateKey<G>,
+        recovery_random_oracle: &RandomOracle,
+        rng: &mut R,
+    ) -> RecoveryPackage<G> {
+        let pk = G::generator() * sk.0;
+        let ephemeral_key = self.c * sk.0;
+
+        let proof = DdhTupleNizk::<G>::create(
+            &sk.0,
+            &self.c,
+            &pk,
+            &ephemeral_key,
+            &recovery_random_oracle,
+            rng,
+        );
+
+        RecoveryPackage {
+            ephemeral_key,
             proof,
         }
     }
@@ -215,8 +175,8 @@ where
     }
 
     #[cfg(test)]
-    pub fn swap_for_testing(&mut self, i: usize, j: usize) {
-        self.encs.swap(i, j);
+    pub fn modify_c_hat_for_testing(&mut self, c_hat: G) {
+        self.c_hat = c_hat;
     }
 
     #[cfg(test)]

--- a/fastcrypto-tbls/src/lib.rs
+++ b/fastcrypto-tbls/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod dkg_v0;
 pub mod dl_verification;
 pub mod ecies_v0;
+pub mod ecies_v1;
 pub mod mocked_dkg;
 pub mod nizk;
 pub mod nodes;
@@ -36,6 +37,10 @@ pub mod polynomial_tests;
 #[cfg(test)]
 #[path = "tests/ecies_v0_tests.rs"]
 pub mod ecies_v0_tests;
+
+#[cfg(test)]
+#[path = "tests/ecies_v1_tests.rs"]
+pub mod ecies_v1_tests;
 
 #[cfg(test)]
 #[path = "tests/random_oracle_tests.rs"]

--- a/fastcrypto-tbls/src/lib.rs
+++ b/fastcrypto-tbls/src/lib.rs
@@ -12,6 +12,7 @@
 //! protocols.
 
 pub mod dkg_v0;
+pub mod dkg_v1;
 pub mod dl_verification;
 pub mod ecies_v0;
 pub mod ecies_v1;
@@ -49,6 +50,10 @@ pub mod random_oracle_tests;
 #[cfg(test)]
 #[path = "tests/dkg_v0_tests.rs"]
 pub mod dkg_v0_tests;
+
+#[cfg(test)]
+#[path = "tests/dkg_v1_tests.rs"]
+pub mod dkg_v1_tests;
 
 #[cfg(test)]
 #[path = "tests/nodes_tests.rs"]

--- a/fastcrypto-tbls/src/lib.rs
+++ b/fastcrypto-tbls/src/lib.rs
@@ -11,9 +11,11 @@
 //! A crate that implements threshold BLS (tBLS) and distributed key generation (DKG)
 //! protocols.
 
+pub mod dkg;
 pub mod dkg_v0;
 pub mod dkg_v1;
 pub mod dl_verification;
+pub mod ecies;
 pub mod ecies_v0;
 pub mod ecies_v1;
 pub mod mocked_dkg;

--- a/fastcrypto-tbls/src/mocked_dkg.rs
+++ b/fastcrypto-tbls/src/mocked_dkg.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::dkg_v0::Output;
+use crate::dkg::Output;
 use crate::nodes::{Nodes, PartyId};
 use crate::polynomial::PrivatePoly;
 use fastcrypto::groups::GroupElement;

--- a/fastcrypto-tbls/src/nidkg.rs
+++ b/fastcrypto-tbls/src/nidkg.rs
@@ -5,12 +5,12 @@
 use crate::dl_verification::{
     verify_deg_t_poly, verify_equal_exponents, verify_pairs, verify_triplets,
 };
-use crate::ecies_v0;
-use crate::ecies_v0::{PublicKey, RecoveryPackage};
+use crate::ecies::{PublicKey, RecoveryPackage};
 use crate::nodes::{Node, Nodes, PartyId};
 use crate::polynomial::{Eval, Poly, PrivatePoly};
 use crate::random_oracle::RandomOracle;
 use crate::types::ShareIndex;
+use crate::{ecies, ecies_v0};
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{bls12381, FiatShamirChallenge, GroupElement, MultiScalarMul, Scalar};
 use fastcrypto::hmac::{hmac_sha3_256, HmacKey};
@@ -29,7 +29,7 @@ where
     nodes: Nodes<G>,
     t: u16,
     random_oracle: RandomOracle,
-    ecies_sk: ecies_v0::PrivateKey<G>,
+    ecies_sk: ecies::PrivateKey<G>,
     vss_sk: PrivatePoly<G>,
     // Precomputed values to be used when verifying messages.
     precomputed_dual_code_coefficients: Vec<G::ScalarType>,
@@ -92,13 +92,13 @@ where
     ///
     /// 3. Create a new Party instance with the private key and the set of nodes.
     pub fn new<R: AllowedRng>(
-        ecies_sk: ecies_v0::PrivateKey<G>,
+        ecies_sk: ecies::PrivateKey<G>,
         nodes: Vec<Node<G>>,
         t: u16, // The number of shares that are needed to reconstruct the full signature.
         random_oracle: RandomOracle,
         rng: &mut R,
     ) -> Result<Self, FastCryptoError> {
-        let ecies_pk = ecies_v0::PublicKey::<G>::from_private_key(&ecies_sk);
+        let ecies_pk = ecies::PublicKey::<G>::from_private_key(&ecies_sk);
         let my_id = nodes
             .iter()
             .find(|n| n.pk == ecies_pk)

--- a/fastcrypto-tbls/src/nizk.rs
+++ b/fastcrypto-tbls/src/nizk.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 /// - Verifier checks that zG=A+c(xG) and zH=B+c(xH).
 /// The NIZK is (A, B, z) where c is implicitly computed using a random oracle.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct DdhTupleNizk<G: GroupElement>(G, G, G::ScalarType);
+pub struct DdhTupleNizk<G: GroupElement>(G, G, G::ScalarType);
 
 impl<G: GroupElement> DdhTupleNizk<G>
 where

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ecies_v0;
+use crate::ecies;
 use crate::types::ShareIndex;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::GroupElement;
@@ -15,7 +15,7 @@ pub type PartyId = u16;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Node<G: GroupElement> {
     pub id: PartyId,
-    pub pk: ecies_v0::PublicKey<G>,
+    pub pk: ecies::PublicKey<G>,
     pub weight: u16, // May be zero after reduce()
 }
 

--- a/fastcrypto-tbls/src/tests/dkg_v0_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_v0_tests.rs
@@ -1,11 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::dkg_v0::{
-    create_fake_complaint, Confirmation, Message, Output, Party, ProcessedMessage,
-    DKG_MESSAGES_MAX_SIZE,
-};
-use crate::ecies_v0::{MultiRecipientEncryption, PrivateKey, PublicKey};
+use crate::dkg::{Confirmation, Output, Party, DKG_MESSAGES_MAX_SIZE};
+use crate::dkg_v0::{create_fake_complaint, Message, ProcessedMessage};
+use crate::ecies::{PrivateKey, PublicKey};
+use crate::ecies_v0::MultiRecipientEncryption;
 use crate::mocked_dkg::generate_mocked_output;
 use crate::nodes::{Node, Nodes, PartyId};
 use crate::polynomial::Poly;

--- a/fastcrypto-tbls/src/tests/dkg_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_v1_tests.rs
@@ -416,7 +416,7 @@ fn test_process_message_failures() {
     let mut msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
     // Switch the encrypted shares of two receivers.
     msg1.encrypted_shares
-        .modify_c_hat_for_testing(msg1.encrypted_shares.ephemeral_key().clone());
+        .modify_c_hat_for_testing(*msg1.encrypted_shares.ephemeral_key());
     assert!(d0.process_message_v1(msg1, &mut thread_rng()).is_err());
 
     // invalid number of encrypted shares for specific receiver

--- a/fastcrypto-tbls/src/tests/dkg_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_v1_tests.rs
@@ -1,9 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::dkg_v0::{create_fake_complaint, Confirmation, Party, DKG_MESSAGES_MAX_SIZE};
+use crate::dkg::{Confirmation, Party, DKG_MESSAGES_MAX_SIZE};
+use crate::dkg_v0::create_fake_complaint;
 use crate::dkg_v1::{Message, ProcessedMessage};
-use crate::ecies_v0::{PrivateKey, PublicKey};
+use crate::ecies::{PrivateKey, PublicKey};
 use crate::ecies_v1::MultiRecipientEncryption;
 use crate::nodes::{Node, Nodes, PartyId};
 use crate::polynomial::Poly;

--- a/fastcrypto-tbls/src/tests/dkg_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/dkg_v1_tests.rs
@@ -1,0 +1,656 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::dkg_v0::{create_fake_complaint, Confirmation, Party, DKG_MESSAGES_MAX_SIZE};
+use crate::dkg_v1::{Message, ProcessedMessage};
+use crate::ecies_v0::{PrivateKey, PublicKey};
+use crate::ecies_v1::MultiRecipientEncryption;
+use crate::nodes::{Node, Nodes, PartyId};
+use crate::polynomial::Poly;
+use crate::random_oracle::RandomOracle;
+use crate::tbls::ThresholdBls;
+use crate::types::ThresholdBls12381MinSig;
+use fastcrypto::error::FastCryptoError;
+use fastcrypto::groups::bls12381::G2Element;
+use fastcrypto::groups::GroupElement;
+use rand::thread_rng;
+
+const MSG: [u8; 4] = [1, 2, 3, 4];
+
+type G = G2Element;
+type S = ThresholdBls12381MinSig;
+type EG = G2Element;
+
+type KeyNodePair<EG> = (PartyId, PrivateKey<EG>, PublicKey<EG>);
+
+fn gen_keys_and_nodes(n: usize) -> (Vec<KeyNodePair<EG>>, Nodes<EG>) {
+    let keys = (0..n)
+        .map(|id| {
+            let sk = PrivateKey::<EG>::new(&mut thread_rng());
+            let pk = PublicKey::<EG>::from_private_key(&sk);
+            (id as u16, sk, pk)
+        })
+        .collect::<Vec<_>>();
+    let nodes = keys
+        .iter()
+        .map(|(id, _sk, pk)| Node::<EG> {
+            id: *id,
+            pk: pk.clone(),
+            weight: if *id == 2 { 0 } else { 2 + id },
+        })
+        .collect();
+    let nodes = Nodes::new(nodes).unwrap();
+    (keys, nodes)
+}
+
+// Enable if logs are needed
+// #[traced_test]
+#[test]
+fn test_dkg_e2e_5_parties_min_weight_2_threshold_3() {
+    let ro = RandomOracle::new("dkg");
+    let t = 3;
+    let (keys, nodes) = gen_keys_and_nodes(6);
+
+    // Create the parties
+    let d0 = Party::<G, EG>::new(
+        keys.first().unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    assert_eq!(d0.t(), t);
+    let d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    // Party with weight 0
+    let d2 = Party::<G, EG>::new(
+        keys.get(2_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let d3 = Party::<G, EG>::new(
+        keys.get(3_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let d4 = Party::<G, EG>::new(
+        keys.get(4_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let d5 = Party::<G, EG>::new(
+        keys.get(5_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+
+    // Only the first messages of d0, d4, d5 will pass all tests. d4's messages will be excluded
+    // later because of an invalid complaint
+    let msg4 = d4.create_message_v1(&mut thread_rng()).unwrap();
+    let msg5 = d5.create_message_v1(&mut thread_rng()).unwrap();
+    // zero weight
+    assert_eq!(
+        d2.create_message_v1(&mut thread_rng()).err(),
+        Some(FastCryptoError::IgnoredMessage)
+    );
+    // d5 will receive invalid shares from d0, but its complaint will not be processed on time.
+    let mut msg0 = d0.create_message_v1(&mut thread_rng()).unwrap();
+    let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg0, &ro);
+    pk_and_msgs[5] = pk_and_msgs[0].clone();
+    msg0.encrypted_shares =
+        MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 0"), &mut thread_rng());
+
+    // We will modify d1's message to make it invalid (emulating a cheating party). d0 and d1
+    // should detect that and send complaints.
+    let mut msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg1, &ro);
+    pk_and_msgs.swap(0, 1);
+    msg1.encrypted_shares =
+        MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 1"), &mut thread_rng());
+    // d2 and d3 are ignored here (emulating slow parties).
+
+    let all_messages = vec![msg0.clone(), msg1, msg0.clone(), msg4.clone(), msg5.clone()]; // duplicates should be ignored
+
+    // expect failure - merge() requires t messages (even if some are duplicated)
+    let proc0 = d0
+        .process_message_v1(msg0.clone(), &mut thread_rng())
+        .unwrap();
+    assert_eq!(
+        d0.merge_v1(&[proc0.clone()]).err(),
+        Some(FastCryptoError::NotEnoughInputs)
+    );
+    assert_eq!(
+        d0.merge_v1(&[proc0.clone(), proc0.clone()]).err(),
+        Some(FastCryptoError::NotEnoughInputs)
+    );
+
+    // merge() should succeed and ignore duplicates and include 1 complaint
+    let proc_msg0 = &all_messages
+        .iter()
+        .map(|m| d0.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf0, used_msgs0) = d0.merge_v1(proc_msg0).unwrap();
+    assert_eq!(conf0.complaints.len(), 1);
+    assert_eq!(used_msgs0.0.len(), 4);
+    assert_eq!(proc0.message, msg0);
+
+    let proc_msg1 = &all_messages
+        .iter()
+        .map(|m| d1.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf1, used_msgs1) = d1.merge_v1(proc_msg1).unwrap();
+
+    let proc_msg2 = &all_messages
+        .iter()
+        .map(|m| d2.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf2, used_msgs2) = d2.merge_v1(proc_msg2).unwrap();
+    assert!(conf2.complaints.is_empty());
+
+    // Note that d3's first round message is not included but it should still be able to receive
+    // shares and post complaints.
+    let proc_msg3 = &all_messages
+        .iter()
+        .map(|m| d3.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf3, used_msgs3) = d3.merge_v1(proc_msg3).unwrap();
+
+    let proc_msg5 = &all_messages
+        .iter()
+        .map(|m| d5.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf5, used_msgs5) = d5.merge_v1(proc_msg5).unwrap();
+    assert_eq!(conf5.complaints.len(), 1);
+
+    // There should be some complaints on the first messages of d1.
+    assert!(
+        !conf0.complaints.is_empty()
+            || !conf1.complaints.is_empty()
+            || !conf3.complaints.is_empty()
+    );
+    // But also no complaints from one of the parties (since we switched only 2 encryptions)
+    assert!(
+        conf0.complaints.is_empty() || conf1.complaints.is_empty() || conf3.complaints.is_empty()
+    );
+
+    // create a simple invalid complaint from d4.
+    let mut conf4 = conf1.clone();
+    conf4.sender = 4;
+
+    let all_confirmations = vec![
+        conf0.clone(),
+        conf2.clone(),
+        conf1.clone(),
+        conf3,
+        conf1.clone(),
+        conf4,
+    ]; // duplicates and zero weights should be ignored
+
+    // expect failure - process_confirmations() should receive enough messages (non duplicated).
+    assert_eq!(
+        d1.process_confirmations_v1(
+            &used_msgs0,
+            &[conf0.clone(), conf0.clone(), conf0.clone()],
+            &mut thread_rng(),
+        )
+        .err(),
+        Some(FastCryptoError::NotEnoughInputs)
+    );
+
+    // back to the happy case
+    let ver_msg0 = d1
+        .process_confirmations_v1(&used_msgs0, &all_confirmations, &mut thread_rng())
+        .unwrap();
+    let ver_msg1 = d1
+        .process_confirmations_v1(&used_msgs1, &all_confirmations, &mut thread_rng())
+        .unwrap();
+    let ver_msg2 = d2
+        .process_confirmations_v1(&used_msgs2, &all_confirmations, &mut thread_rng())
+        .unwrap();
+    let ver_msg3 = d3
+        .process_confirmations_v1(&used_msgs3, &all_confirmations, &mut thread_rng())
+        .unwrap();
+    let ver_msg5 = d5
+        .process_confirmations_v1(&used_msgs5, &all_confirmations, &mut thread_rng())
+        .unwrap();
+    assert_eq!(ver_msg0.len(), 2); // only msg0, msg5 were valid and didn't send invalid complaints
+    assert_eq!(ver_msg1.len(), 2);
+    assert_eq!(ver_msg2.len(), 2);
+    assert_eq!(ver_msg3.len(), 2);
+    assert_eq!(ver_msg5.len(), 2);
+
+    let o0 = d0.aggregate_v1(&ver_msg0);
+    let _o1 = d1.aggregate_v1(&ver_msg1);
+    let o2 = d2.aggregate_v1(&ver_msg2);
+    let o3 = d3.aggregate_v1(&ver_msg3);
+    let o5 = d5.aggregate_v1(&ver_msg5);
+    assert!(o0.shares.is_some());
+    assert!(o2.shares.is_none());
+    assert!(o3.shares.is_some());
+    assert!(o5.shares.is_none()); // recall that it didn't receive valid share from msg0
+    assert_eq!(o0.vss_pk, o2.vss_pk);
+    assert_eq!(o0.vss_pk, o3.vss_pk);
+    assert_eq!(o0.vss_pk, o5.vss_pk);
+
+    // check the resulting vss pk
+    let mut poly = msg0.vss_pk.clone();
+    poly.add(&msg5.vss_pk);
+    assert_eq!(poly, o0.vss_pk);
+
+    // Use the shares to sign the message.
+    let sig00 = S::partial_sign(&o0.shares.as_ref().unwrap()[0], &MSG);
+    let sig30 = S::partial_sign(&o3.shares.as_ref().unwrap()[0], &MSG);
+    let sig31 = S::partial_sign(&o3.shares.as_ref().unwrap()[1], &MSG);
+
+    S::partial_verify(&o0.vss_pk, &MSG, &sig00).unwrap();
+    S::partial_verify(&o3.vss_pk, &MSG, &sig30).unwrap();
+    S::partial_verify(&o3.vss_pk, &MSG, &sig31).unwrap();
+
+    let sigs = vec![sig00, sig30, sig31];
+    let sig = S::aggregate(d0.t(), sigs.iter()).unwrap();
+    S::verify(o0.vss_pk.c0(), &MSG, &sig).unwrap();
+}
+
+fn decrypt_and_prepare_for_reenc(
+    keys: &[KeyNodePair<EG>],
+    nodes: &Nodes<EG>,
+    msg0: &Message<G, EG>,
+    ro: &RandomOracle,
+) -> Vec<(PublicKey<EG>, Vec<u8>)> {
+    nodes
+        .iter()
+        .map(|n| {
+            let key = keys[n.id as usize].1.clone();
+            (
+                n.pk.clone(),
+                msg0.encrypted_shares.decrypt(
+                    &key,
+                    &ro.extend(&format!("encs {}", msg0.sender)),
+                    n.id as usize,
+                ),
+            )
+        })
+        .collect::<Vec<_>>()
+}
+
+#[test]
+fn test_party_new_errors() {
+    let ro = RandomOracle::new("dkg");
+    let (keys, nodes) = gen_keys_and_nodes(4);
+
+    // t is zero
+    assert!(Party::<G, EG>::new(
+        keys.first().unwrap().1.clone(),
+        nodes.clone(),
+        0,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .is_err());
+    // t is too large
+    assert!(Party::<G, EG>::new(
+        keys.first().unwrap().1.clone(),
+        nodes.clone(),
+        6,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .is_err());
+    // Invalid pk
+    assert!(Party::<G, EG>::new(
+        PrivateKey::<EG>::new(&mut thread_rng()),
+        nodes.clone(),
+        3,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .is_err());
+}
+
+#[test]
+fn test_process_message_failures() {
+    let ro = RandomOracle::new("dkg");
+    let t = 3;
+    let (keys, nodes) = gen_keys_and_nodes(4);
+
+    let d0 = Party::<G, EG>::new(
+        keys.first().unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+
+    // invalid sender
+    let d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let mut invalid_msg = d1.create_message_v1(&mut thread_rng()).unwrap();
+    invalid_msg.sender = 50;
+    assert!(d0
+        .process_message_v1(invalid_msg, &mut thread_rng())
+        .is_err());
+
+    // zero weight
+    let d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let mut fake_msg_from_d2 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    fake_msg_from_d2.sender = 2;
+    assert!(d0
+        .process_message_v1(fake_msg_from_d2, &mut thread_rng())
+        .is_err());
+
+    // invalid degree
+    let d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t - 1,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let invalid_msg = d1.create_message_v1(&mut thread_rng()).unwrap();
+    assert!(d0
+        .process_message_v1(invalid_msg, &mut thread_rng())
+        .is_err());
+
+    // invalid c0
+    let d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let mut invalid_msg = d1.create_message_v1(&mut thread_rng()).unwrap();
+    let mut poly: Vec<G> = invalid_msg.vss_pk.as_vec().clone();
+    poly[0] = G::zero();
+    invalid_msg.vss_pk = poly.into();
+    assert!(d0
+        .process_message_v1(invalid_msg, &mut thread_rng())
+        .is_err());
+
+    // invalid total number of encrypted shares
+    let mut msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    // Switch the encrypted shares of two receivers.
+    let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg1, &ro);
+    pk_and_msgs.pop();
+    msg1.encrypted_shares =
+        MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 1"), &mut thread_rng());
+    assert!(d0.process_message_v1(msg1, &mut thread_rng()).is_err());
+
+    // invalid encryption's proof
+    let mut msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    // Switch the encrypted shares of two receivers.
+    msg1.encrypted_shares
+        .modify_c_hat_for_testing(msg1.encrypted_shares.ephemeral_key().clone());
+    assert!(d0.process_message_v1(msg1, &mut thread_rng()).is_err());
+
+    // invalid number of encrypted shares for specific receiver
+    let mut msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    // Switch the encrypted shares of two receivers.
+    let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg1, &ro);
+    pk_and_msgs.swap(0, 1);
+    msg1.encrypted_shares =
+        MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 1"), &mut thread_rng());
+    let ProcessedMessage {
+        message: _,
+        shares,
+        complaint,
+    } = d0.process_message_v1(msg1, &mut thread_rng()).unwrap();
+    if !shares.is_empty() || complaint.is_none() {
+        panic!("expected complaint");
+    };
+
+    // invalid share
+    // use another d1 with a different vss_sk to create an encryption with "invalid" shares
+    let another_d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let msg1_from_another_d1 = another_d1.create_message_v1(&mut thread_rng()).unwrap();
+    let mut msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    msg1.encrypted_shares = msg1_from_another_d1.encrypted_shares;
+    let ProcessedMessage {
+        message: _,
+        shares,
+        complaint,
+    } = d0.process_message_v1(msg1, &mut thread_rng()).unwrap();
+    if !shares.is_empty() || complaint.is_none() {
+        panic!("expected complaint");
+    };
+}
+
+#[test]
+fn test_test_process_confirmations() {
+    let ro = RandomOracle::new("dkg");
+    let t = 3;
+    let (keys, nodes) = gen_keys_and_nodes(6);
+
+    let d0 = Party::<G, EG>::new(
+        keys.first().unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let d1 = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let d2 = Party::<G, EG>::new(
+        keys.get(2_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let d3 = Party::<G, EG>::new(
+        keys.get(3_usize).unwrap().1.clone(),
+        nodes.clone(),
+        t,
+        ro.clone(),
+        &mut thread_rng(),
+    )
+    .unwrap();
+
+    let msg0 = d0.create_message_v1(&mut thread_rng()).unwrap();
+    let msg1 = d1.create_message_v1(&mut thread_rng()).unwrap();
+    // zero weight
+    assert_eq!(
+        d2.create_message_v1(&mut thread_rng()).err(),
+        Some(FastCryptoError::IgnoredMessage)
+    );
+    let mut msg3 = d3.create_message_v1(&mut thread_rng()).unwrap();
+    let mut pk_and_msgs = decrypt_and_prepare_for_reenc(&keys, &nodes, &msg3, &ro);
+    pk_and_msgs.swap(0, 1);
+    msg3.encrypted_shares =
+        MultiRecipientEncryption::encrypt(&pk_and_msgs, &ro.extend("encs 3"), &mut thread_rng());
+
+    let all_messages = vec![msg0, msg1, msg3];
+
+    let proc_msg0 = &all_messages
+        .iter()
+        .map(|m| d0.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf0, used_msgs0) = d0.merge_v1(proc_msg0).unwrap();
+
+    let proc_msg1 = &all_messages
+        .iter()
+        .map(|m| d1.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf1, _used_msgs1) = d1.merge_v1(proc_msg1).unwrap();
+
+    let proc_msg2 = &all_messages
+        .iter()
+        .map(|m| d2.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf2, _used_msgs2) = d2.merge_v1(proc_msg2).unwrap();
+
+    let proc_msg3 = &all_messages
+        .iter()
+        .map(|m| d3.process_message_v1(m.clone(), &mut thread_rng()).unwrap())
+        .collect::<Vec<_>>();
+    let (conf3, _used_msgs3) = d3.merge_v1(proc_msg3).unwrap();
+
+    // sanity check that with the current confirmations, all messages are in
+    let ver_msg = d1
+        .process_confirmations_v1(
+            &used_msgs0,
+            &[conf0.clone(), conf1.clone(), conf2.clone(), conf3.clone()],
+            &mut thread_rng(),
+        )
+        .unwrap();
+    // d3 is ignored because it sent an invalid message, d2 is ignored because it's weight is 0
+    assert_eq!(
+        ver_msg
+            .data()
+            .iter()
+            .map(|m| m.message.sender)
+            .collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+
+    // invalid senders should be ignored
+    let mut conf7 = conf3.clone();
+    conf7.sender = 7; // Should be ignored since it's an invalid sender
+    let ver_msg = d1
+        .process_confirmations_v1(
+            &used_msgs0,
+            &[conf2.clone(), conf3.clone(), conf7],
+            &mut thread_rng(),
+        )
+        .unwrap();
+
+    // d3 is not ignored since conf7 is ignored, d2 is ignored because it's weight is 0
+    assert_eq!(
+        ver_msg
+            .data()
+            .iter()
+            .map(|m| m.message.sender)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 3]
+    );
+
+    // create an invalid complaint from d4 (invalid recovery package)
+    assert!(conf2.complaints.is_empty()); // since only d0, d1 received invalid shares
+    let mut conf2 = conf1.clone();
+    conf2.sender = 2;
+    let ver_msg = d1
+        .process_confirmations_v1(
+            &used_msgs0,
+            &[conf0.clone(), conf1.clone(), conf2.clone(), conf3.clone()],
+            &mut thread_rng(),
+        )
+        .unwrap();
+    // now also d2 is ignored because it sent an invalid complaint
+    assert_eq!(
+        ver_msg
+            .data()
+            .iter()
+            .map(|m| m.message.sender)
+            .collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+}
+
+#[test]
+fn create_message_generates_valid_message() {
+    let (keys, nodes) = gen_keys_and_nodes(4);
+    let d = Party::<G, EG>::new(
+        keys.get(1_usize).unwrap().1.clone(),
+        nodes.clone(),
+        3,
+        RandomOracle::new("dkg"),
+        &mut thread_rng(),
+    )
+    .unwrap();
+    let msg = d.create_message_v1(&mut thread_rng()).unwrap();
+
+    assert_eq!(msg.sender, 1);
+    assert_eq!(msg.encrypted_shares.len(), 4);
+    assert_eq!(msg.vss_pk.degree(), 2);
+}
+
+#[test]
+fn test_size_limits() {
+    // Confirm that messages sizes are within the limit for the extreme expected parameters.
+    let n = 3333;
+    let t = n / 3;
+    let k = 400;
+
+    let p = Poly::<<G2Element as GroupElement>::ScalarType>::rand(t as u16, &mut thread_rng());
+    let ro = RandomOracle::new("test");
+    let keys_and_msg = (0..k)
+        .map(|i| {
+            let sk = PrivateKey::<EG>::new(&mut thread_rng());
+            let pk = PublicKey::<EG>::from_private_key(&sk);
+            (sk, pk, format!("test {}", i))
+        })
+        .collect::<Vec<_>>();
+    let encrypted_shares = MultiRecipientEncryption::encrypt(
+        &keys_and_msg
+            .iter()
+            .map(|(_, pk, msg)| (pk.clone(), msg.as_bytes().to_vec()))
+            .collect::<Vec<_>>(),
+        &ro,
+        &mut thread_rng(),
+    );
+    let msg = Message {
+        sender: 0,
+        vss_pk: p.commit::<EG>(),
+        encrypted_shares,
+    };
+    assert!(bcs::to_bytes(&msg).unwrap().len() <= DKG_MESSAGES_MAX_SIZE);
+
+    let complaints = (0..k)
+        .map(|_| create_fake_complaint::<EG>())
+        .collect::<Vec<_>>();
+    let conf = Confirmation {
+        sender: 0,
+        complaints,
+    };
+    assert!(bcs::to_bytes(&conf).unwrap().len() <= DKG_MESSAGES_MAX_SIZE);
+}

--- a/fastcrypto-tbls/src/tests/ecies_v0_tests.rs
+++ b/fastcrypto-tbls/src/tests/ecies_v0_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ecies::{PrivateKey, PublicKey};
 use crate::ecies_v0::*;
 use crate::random_oracle::RandomOracle;
 use fastcrypto::bls12381::min_sig::BLS12381KeyPair;
@@ -17,6 +18,7 @@ const MSG: &[u8; 4] = b"test";
 #[generic_tests::define]
 mod point_tests {
     use super::*;
+    use crate::ecies::{PrivateKey, PublicKey};
 
     #[test]
     fn test_decryption<Group: GroupElement + Serialize + DeserializeOwned>()

--- a/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
@@ -53,7 +53,7 @@ mod point_tests {
         assert!(mr_enc.verify(&ro.extend("bla")).is_err());
 
         for (i, (sk, _, msg)) in keys_and_msg.iter().enumerate() {
-            let decrypted = mr_enc.decrypt(&sk, &ro, i);
+            let decrypted = mr_enc.decrypt(sk, &ro, i);
             assert_eq!(msg.as_bytes(), &decrypted);
         }
 
@@ -80,20 +80,20 @@ mod point_tests {
         );
 
         for (i, (sk, pk, msg)) in keys_and_msg.iter().enumerate() {
-            let pkg = mr_enc.create_recovery_package(&sk, &recovery_ro, &mut thread_rng());
+            let pkg = mr_enc.create_recovery_package(sk, &recovery_ro, &mut thread_rng());
             let decrypted = mr_enc
-                .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, &pk, i)
+                .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, pk, i)
                 .unwrap();
             assert_eq!(msg.as_bytes(), &decrypted);
 
             // Should fail for a different RO.
             assert!(mr_enc
-                .decrypt_with_recovery_package(&pkg, &recovery_ro.extend("bla"), &ro, &pk, i)
+                .decrypt_with_recovery_package(&pkg, &recovery_ro.extend("bla"), &ro, pk, i)
                 .is_err());
 
             // Same package will fail on a different encryption
             assert!(mr_enc2
-                .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, &pk, i)
+                .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, pk, i)
                 .is_err());
         }
     }

--- a/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ecies_v1::*;
+use crate::random_oracle::RandomOracle;
+use fastcrypto::bls12381::min_sig::BLS12381KeyPair;
+use fastcrypto::groups::bls12381::{G1Element, G2Element, Scalar};
+use fastcrypto::groups::{FiatShamirChallenge, GroupElement};
+use fastcrypto::traits::KeyPair;
+use rand::thread_rng;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+#[generic_tests::define]
+mod point_tests {
+    use super::*;
+    use fastcrypto::groups::HashToGroupElement;
+
+    #[test]
+    fn test_multi_rec<Group: GroupElement + Serialize + DeserializeOwned>()
+    where
+        Group::ScalarType: FiatShamirChallenge,
+        Group: HashToGroupElement,
+    {
+        let ro = RandomOracle::new("test");
+        let keys_and_msg = (0..10u32)
+            .map(|i| {
+                let sk = PrivateKey::<Group>::new(&mut thread_rng());
+                let pk = PublicKey::<Group>::from_private_key(&sk);
+                (
+                    sk,
+                    pk,
+                    format!(
+                        "test {} 12345678901234567890123456789012345678901234567890",
+                        i
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mr_enc = MultiRecipientEncryption::encrypt(
+            &keys_and_msg
+                .iter()
+                .map(|(_, pk, msg)| (pk.clone(), msg.as_bytes().to_vec()))
+                .collect::<Vec<_>>(),
+            &ro,
+            &mut thread_rng(),
+        );
+
+        assert!(mr_enc.verify(&ro).is_ok());
+        assert!(mr_enc.verify(&ro.extend("bla")).is_err());
+
+        for (i, (sk, _, msg)) in keys_and_msg.iter().enumerate() {
+            let decrypted = sk.decrypt(&mr_enc, &ro, i);
+            assert_eq!(msg.as_bytes(), &decrypted);
+        }
+
+        // test empty messages
+        let mr_enc2 = MultiRecipientEncryption::encrypt(
+            &keys_and_msg
+                .iter()
+                .map(|(_, pk, _)| (pk.clone(), vec![]))
+                .collect::<Vec<_>>(),
+            &ro,
+            &mut thread_rng(),
+        );
+        assert!(mr_enc2.verify(&ro).is_err());
+
+        // test recovery package
+        let recovery_ro = ro.extend("recovery");
+        let mr_enc2 = MultiRecipientEncryption::encrypt(
+            &keys_and_msg
+                .iter()
+                .map(|(_, pk, msg)| (pk.clone(), msg.as_bytes().to_vec()))
+                .collect::<Vec<_>>(),
+            &ro,
+            &mut thread_rng(),
+        );
+
+        for (i, (sk, pk, msg)) in keys_and_msg.iter().enumerate() {
+            let pkg = sk.create_recovery_package(&mr_enc, &recovery_ro, &mut thread_rng());
+            let decrypted = mr_enc
+                .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, &pk, i)
+                .unwrap();
+            assert_eq!(msg.as_bytes(), &decrypted);
+
+            // Should fail for a different RO.
+            assert!(mr_enc
+                .decrypt_with_recovery_package(&pkg, &recovery_ro.extend("bla"), &ro, &pk, i)
+                .is_err());
+
+            // Same package will fail on a different encryption
+            assert!(mr_enc2
+                .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, &pk, i)
+                .is_err());
+        }
+    }
+
+    #[instantiate_tests(<G1Element>)]
+    mod g1_element {}
+
+    #[instantiate_tests(<G2Element>)]
+    mod g2_element {}
+}
+
+#[test]
+fn test_blskeypair_to_group() {
+    let pair = BLS12381KeyPair::generate(&mut thread_rng());
+    let (pk, sk) = (pair.public().clone(), pair.private());
+    let pk: G2Element = bcs::from_bytes(pk.as_ref()).expect("should work");
+    let ecies_pk = PublicKey::<G2Element>::from(pk);
+    let sk: Scalar = bcs::from_bytes(sk.as_ref()).expect("should work");
+    let ecies_sk = PrivateKey::<G2Element>::from(sk);
+    assert_eq!(
+        ecies_pk,
+        PublicKey::<G2Element>::from_private_key(&ecies_sk)
+    );
+    assert_eq!(*ecies_pk.as_element(), G2Element::generator() * sk);
+}

--- a/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ecies_v0::{PrivateKey, PublicKey};
 use crate::ecies_v1::*;
 use crate::random_oracle::RandomOracle;
 use fastcrypto::bls12381::min_sig::BLS12381KeyPair;
@@ -14,6 +15,7 @@ use serde::Serialize;
 #[generic_tests::define]
 mod point_tests {
     use super::*;
+    use crate::ecies_v0::{PrivateKey, PublicKey};
     use fastcrypto::groups::HashToGroupElement;
 
     #[test]
@@ -51,7 +53,7 @@ mod point_tests {
         assert!(mr_enc.verify(&ro.extend("bla")).is_err());
 
         for (i, (sk, _, msg)) in keys_and_msg.iter().enumerate() {
-            let decrypted = sk.decrypt(&mr_enc, &ro, i);
+            let decrypted = mr_enc.decrypt(&sk, &ro, i);
             assert_eq!(msg.as_bytes(), &decrypted);
         }
 
@@ -78,7 +80,7 @@ mod point_tests {
         );
 
         for (i, (sk, pk, msg)) in keys_and_msg.iter().enumerate() {
-            let pkg = sk.create_recovery_package(&mr_enc, &recovery_ro, &mut thread_rng());
+            let pkg = mr_enc.create_recovery_package(&sk, &recovery_ro, &mut thread_rng());
             let decrypted = mr_enc
                 .decrypt_with_recovery_package(&pkg, &recovery_ro, &ro, &pk, i)
                 .unwrap();

--- a/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ecies_v0::{PrivateKey, PublicKey};
+use crate::ecies::{PrivateKey, PublicKey};
 use crate::ecies_v1::*;
 use crate::random_oracle::RandomOracle;
 use fastcrypto::bls12381::min_sig::BLS12381KeyPair;
@@ -15,7 +15,7 @@ use serde::Serialize;
 #[generic_tests::define]
 mod point_tests {
     use super::*;
-    use crate::ecies_v0::{PrivateKey, PublicKey};
+    use crate::ecies::{PrivateKey, PublicKey};
     use fastcrypto::groups::HashToGroupElement;
 
     #[test]

--- a/fastcrypto-tbls/src/tests/nidkg_tests.rs
+++ b/fastcrypto-tbls/src/tests/nidkg_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ecies_v0;
+use crate::ecies;
 use crate::nidkg::Party;
 use crate::nodes::Node;
 use crate::random_oracle::RandomOracle;
@@ -12,11 +12,11 @@ use rand::thread_rng;
 
 type G = G1Element;
 
-pub fn gen_ecies_keys(n: u16) -> Vec<(u16, ecies_v0::PrivateKey<G>, ecies_v0::PublicKey<G>)> {
+pub fn gen_ecies_keys(n: u16) -> Vec<(u16, ecies::PrivateKey<G>, ecies::PublicKey<G>)> {
     (0..n)
         .map(|id| {
-            let sk = ecies_v0::PrivateKey::<G>::new(&mut thread_rng());
-            let pk = ecies_v0::PublicKey::<G>::from_private_key(&sk);
+            let sk = ecies::PrivateKey::<G>::new(&mut thread_rng());
+            let pk = ecies::PublicKey::<G>::from_private_key(&sk);
             (id, sk, pk)
         })
         .collect()
@@ -25,7 +25,7 @@ pub fn gen_ecies_keys(n: u16) -> Vec<(u16, ecies_v0::PrivateKey<G>, ecies_v0::Pu
 pub fn setup_party(
     id: usize,
     threshold: u16,
-    keys: &[(u16, ecies_v0::PrivateKey<G>, ecies_v0::PublicKey<G>)],
+    keys: &[(u16, ecies::PrivateKey<G>, ecies::PublicKey<G>)],
 ) -> Party<G> {
     let nodes = keys
         .iter()

--- a/fastcrypto-tbls/src/tests/nodes_tests.rs
+++ b/fastcrypto-tbls/src/tests/nodes_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ecies_v0;
+use crate::ecies;
 use crate::nodes::{Node, Nodes};
 use fastcrypto::groups::bls12381::G2Element;
 use fastcrypto::groups::ristretto255::RistrettoPoint;
@@ -17,8 +17,8 @@ where
     G: GroupElement + Serialize + DeserializeOwned,
     G::ScalarType: FiatShamirChallenge,
 {
-    let sk = ecies_v0::PrivateKey::<G>::new(&mut thread_rng());
-    let pk = ecies_v0::PublicKey::<G>::from_private_key(&sk);
+    let sk = ecies::PrivateKey::<G>::new(&mut thread_rng());
+    let pk = ecies::PublicKey::<G>::from_private_key(&sk);
     (0..n)
         .map(|i| Node {
             id: i,

--- a/fastcrypto-tbls/src/types.rs
+++ b/fastcrypto-tbls/src/types.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::polynomial::{Eval, PublicPoly};
-use crate::{ecies_v0, tbls};
+use crate::tbls;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
-use fastcrypto::groups::ristretto255::RistrettoPoint;
 use fastcrypto::groups::{bls12381, GroupElement, HashToGroupElement, Pairing};
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU16;
@@ -84,10 +83,3 @@ impl<A> UnindexedValues<A> {
         Ok(values)
     }
 }
-
-/// ECIES related types with Ristretto points.
-///
-pub type PrivateEciesKey = ecies_v0::PrivateKey<RistrettoPoint>;
-pub type PublicEciesKey = ecies_v0::PublicKey<RistrettoPoint>;
-pub type EciesEncryption = ecies_v0::Encryption<RistrettoPoint>;
-pub type RecoveryPackage = ecies_v0::RecoveryPackage<RistrettoPoint>;


### PR DESCRIPTION
Adding v1 of the DKG that uses a different ecies encryption.

To simplify the transition, we do the following:
- old dkg & ecies were renamed to X_v0 (in a previous PR)
- moved shared structs to dkg and ecies files
- new ecies is called ecies_v1
- dkg_v1 was copied from dkg_v0 and modified to use ecies_v1 (both impl Party, when functions in dkg_v1 use the prefix _v1)
- unit tests of both was copied as well and updated to use the new interfaces

Once the transition is complete we will remove the X_v0 files.