### PR TITLE
Update codecov.yml

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Collect coverage data
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info -- --skip test_end_to_end_all_providers
       - name: Upload coverage data to codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
There's a test in zklogin that breaks the codecov. Probably because it requires network access. This PR simply skips this unit test in codecov.yml.