### PR TITLE
Fix Poseidon public api + small refactor

### DIFF
--- a/fastcrypto-zkp/benches/poseidon.rs
+++ b/fastcrypto-zkp/benches/poseidon.rs
@@ -7,6 +7,7 @@ extern crate criterion;
 mod poseidon_benches {
     use ark_std::UniformRand;
     use criterion::*;
+    use fastcrypto_zkp::bn254::FieldElement;
 
     fn poseidon(c: &mut Criterion) {
         let mut group: BenchmarkGroup<_> = c.benchmark_group("Poseidon");
@@ -17,11 +18,10 @@ mod poseidon_benches {
                 &size,
                 |b, size| {
                     let mut rng = ark_std::test_rng();
-                    let inputs: Vec<ark_bn254::Fr> =
-                        (0..*size).map(|_| ark_bn254::Fr::rand(&mut rng)).collect();
-                    b.iter(|| {
-                        fastcrypto_zkp::bn254::poseidon::poseidon_merkle_tree(inputs.clone())
-                    });
+                    let inputs: Vec<FieldElement> = (0..*size)
+                        .map(|_| FieldElement::from(ark_bn254::Fr::rand(&mut rng)))
+                        .collect();
+                    b.iter(|| fastcrypto_zkp::bn254::poseidon::poseidon_merkle_tree(&inputs));
                 },
             );
         }

--- a/fastcrypto-zkp/src/bn254/mod.rs
+++ b/fastcrypto-zkp/src/bn254/mod.rs
@@ -7,7 +7,7 @@
 use crate::bn254::api::SCALAR_SIZE;
 use ark_bn254::{Bn254, Fr};
 use ark_serialize::CanonicalDeserialize;
-use derive_more::From;
+use derive_more::{Display, From, FromStr, Into};
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 
 /// API that takes in serialized inputs
@@ -28,13 +28,13 @@ pub mod zk_login_api;
 /// Zk login utils
 pub mod utils;
 
-/// A field element in the BN254 construction. Thin wrapper around `api::Bn254Fr`.
-#[derive(Debug, From)]
-pub struct FieldElement(pub(crate) ark_bn254::Fr);
+/// A field element in the BN254 construction. Thin wrapper around `ark_bn254::fields::fr::Fr`.
+#[derive(Clone, Debug, From, Into, PartialEq, Eq, Display, FromStr)]
+pub struct FieldElement(pub(crate) Fr);
 
 /// A Groth16 proof in the BN254 construction. Thin wrapper around `ark_groth16::Proof::<ark_bn254::Bn254>`.
 #[derive(Debug, From)]
-pub struct Proof(pub(crate) ark_groth16::Proof<ark_bn254::Bn254>);
+pub struct Proof(pub(crate) ark_groth16::Proof<Bn254>);
 
 /// A Groth16 verifying key in the BN254 construction. Thin wrapper around `ark_groth16::VerifyingKey::<ark_bn254::Bn254>`.
 #[derive(Debug, From)]

--- a/fastcrypto-zkp/src/bn254/poseidon/mod.rs
+++ b/fastcrypto-zkp/src/bn254/poseidon/mod.rs
@@ -83,7 +83,7 @@ pub fn poseidon_merkle_tree(inputs: &[FieldElement]) -> FastCryptoResult<FieldEl
         poseidon_merkle_tree(
             &inputs
                 .chunks(MERKLE_TREE_DEGREE)
-                .map(poseidon_merkle_tree)
+                .map(poseidon)
                 .collect::<FastCryptoResult<Vec<_>>>()?,
         )
     }

--- a/fastcrypto-zkp/src/bn254/poseidon/mod.rs
+++ b/fastcrypto-zkp/src/bn254/poseidon/mod.rs
@@ -83,7 +83,7 @@ pub fn poseidon_merkle_tree(inputs: &[FieldElement]) -> FastCryptoResult<FieldEl
         poseidon_merkle_tree(
             &inputs
                 .chunks(MERKLE_TREE_DEGREE)
-                .map(poseidon)
+                .map(poseidon_merkle_tree)
                 .collect::<FastCryptoResult<Vec<_>>>()?,
         )
     }

--- a/fastcrypto-zkp/src/bn254/poseidon/mod.rs
+++ b/fastcrypto-zkp/src/bn254/poseidon/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bn254::poseidon::constants::*;
+use crate::bn254::FieldElement;
 use crate::FrRepr;
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField};
@@ -28,7 +29,7 @@ macro_rules! define_poseidon_hash {
         let mut poseidon = Poseidon::new(&$poseidon_constants);
         poseidon.reset();
         for input in $inputs.iter() {
-            poseidon.input(bn254_to_fr(*input)).expect("The number of inputs must be aligned with the constants");
+            poseidon.input(field_element_to_fr(input)).expect("The number of inputs must be aligned with the constants");
         }
         poseidon.hash_in_mode(OptimizedStatic);
 
@@ -45,11 +46,10 @@ macro_rules! define_poseidon_hash {
 
 /// Poseidon hash function over BN254. The input vector cannot be empty and must contain at most 16
 /// elements, otherwise an error is returned.
-pub fn poseidon(inputs: Vec<Fr>) -> Result<Fr, FastCryptoError> {
+pub fn poseidon(inputs: &Vec<FieldElement>) -> Result<FieldElement, FastCryptoError> {
     if inputs.is_empty() || inputs.len() > 16 {
         return Err(FastCryptoError::InputLengthWrong(inputs.len()));
     }
-
     // Instances of Poseidon and PoseidonConstants from neptune have different types depending on
     // the number of inputs, so unfortunately we need to use a macro here.
     let result = match inputs.len() {
@@ -71,31 +71,19 @@ pub fn poseidon(inputs: Vec<Fr>) -> Result<Fr, FastCryptoError> {
         16 => define_poseidon_hash!(inputs, POSEIDON_CONSTANTS_U16),
         _ => return Err(InvalidInput),
     };
-    Ok(fr_to_bn254fr(result))
-}
-
-/// Calculate the poseidon hash of the field element inputs. If there are no inputs, return an error.
-/// If input length is <= 16, calculate H(inputs), if it is <= 32, calculate H(H(inputs[0..16]),
-/// H(inputs[16..])), otherwise return an error.
-///
-/// This functions must be equivalent with the one found in the zk_login circuit.
-pub(crate) fn poseidon_zk_login(inputs: Vec<Fr>) -> FastCryptoResult<Fr> {
-    if inputs.is_empty() || inputs.len() > 32 {
-        return Err(FastCryptoError::InputLengthWrong(inputs.len()));
-    }
-    poseidon_merkle_tree(inputs)
+    Ok(fr_to_field_element(result))
 }
 
 /// Calculate the poseidon hash of the field element inputs. If the input length is <= MERKLE_TREE_DEGREE, calculate
 /// H(inputs), otherwise chunk the inputs into groups of MERKLE_TREE_DEGREE, hash them and input the results recursively.
-pub fn poseidon_merkle_tree(inputs: Vec<Fr>) -> FastCryptoResult<Fr> {
+pub fn poseidon_merkle_tree(inputs: &Vec<FieldElement>) -> FastCryptoResult<FieldElement> {
     if inputs.len() <= MERKLE_TREE_DEGREE {
         poseidon(inputs)
     } else {
         poseidon_merkle_tree(
-            inputs
+            &inputs
                 .chunks(MERKLE_TREE_DEGREE)
-                .map(|chunk| poseidon(chunk.to_vec()))
+                .map(|chunk| poseidon(&chunk.to_vec()))
                 .collect::<FastCryptoResult<Vec<_>>>()?,
         )
     }
@@ -115,7 +103,7 @@ pub fn poseidon_bytes(inputs: &[Vec<u8>]) -> FastCryptoResult<[u8; FIELD_ELEMENT
         .iter()
         .map(|b| canonical_le_bytes_to_field_element(b))
         .collect::<Result<Vec<_>, _>>()?;
-    let output_as_field_element = poseidon_merkle_tree(field_elements)?;
+    let output_as_field_element = poseidon_merkle_tree(&field_elements)?;
     Ok(field_element_to_canonical_le_bytes(
         &output_as_field_element,
     ))
@@ -126,7 +114,7 @@ pub fn poseidon_bytes(inputs: &[Vec<u8>]) -> FastCryptoResult<[u8; FIELD_ELEMENT
 /// larger than the field size as an integer), an `FastCryptoError::InvalidInput` is returned.
 ///
 /// If more than 32 bytes is given, an `FastCryptoError::InputTooLong` is returned.
-fn canonical_le_bytes_to_field_element(bytes: &[u8]) -> FastCryptoResult<Fr> {
+fn canonical_le_bytes_to_field_element(bytes: &[u8]) -> FastCryptoResult<FieldElement> {
     match bytes.len().cmp(&FIELD_ELEMENT_SIZE_IN_BYTES) {
         Ordering::Less => Ok(Fr::from_le_bytes_mod_order(bytes)),
         Ordering::Equal => {
@@ -141,12 +129,16 @@ fn canonical_le_bytes_to_field_element(bytes: &[u8]) -> FastCryptoResult<Fr> {
         }
         Ordering::Greater => Err(InputTooLong(FIELD_ELEMENT_SIZE_IN_BYTES)),
     }
+    .map(FieldElement)
 }
 
 /// Convert a BN254 field element to a byte array as the little-endian representation of the
 /// underlying canonical integer representation of the element.
-fn field_element_to_canonical_le_bytes(field_element: &Fr) -> [u8; FIELD_ELEMENT_SIZE_IN_BYTES] {
+fn field_element_to_canonical_le_bytes(
+    field_element: &FieldElement,
+) -> [u8; FIELD_ELEMENT_SIZE_IN_BYTES] {
     field_element
+        .0
         .into_bigint()
         .to_bytes_le()
         .try_into()
@@ -154,16 +146,16 @@ fn field_element_to_canonical_le_bytes(field_element: &Fr) -> [u8; FIELD_ELEMENT
 }
 
 /// Convert an ff field element to an arkworks-ff field element.
-fn fr_to_bn254fr(fr: crate::Fr) -> Fr {
+fn fr_to_field_element(fr: crate::Fr) -> FieldElement {
     // We use big-endian as in the definition of the BN254 prime field (see fastcrypto-zkp/src/lib.rs).
-    Fr::from_be_bytes_mod_order(fr.to_repr().as_byte_slice())
+    FieldElement(Fr::from_be_bytes_mod_order(fr.to_repr().as_byte_slice()))
 }
 
 /// Convert an arkworks-ff field element to an ff field element.
-fn bn254_to_fr(fr: Fr) -> crate::Fr {
+fn field_element_to_fr(fr: &FieldElement) -> crate::Fr {
     let mut bytes = [0u8; 32];
     // We use big-endian as in the definition of the BN254 prime field (see fastcrypto-zkp/src/lib.rs).
-    bytes.clone_from_slice(&fr.into_bigint().to_bytes_be());
+    bytes.clone_from_slice(&fr.0.into_bigint().to_bytes_be());
     crate::Fr::from_repr_vartime(FrRepr(bytes))
         .expect("The bytes of fr are guaranteed to be canonical here")
 }
@@ -172,7 +164,7 @@ fn bn254_to_fr(fr: Fr) -> crate::Fr {
 mod test {
     use crate::bn254::poseidon::poseidon_bytes;
     use crate::bn254::poseidon::{poseidon, poseidon_merkle_tree};
-    use crate::bn254::{poseidon::poseidon_zk_login, zk_login::Bn254Fr};
+    use crate::bn254::FieldElement;
     use ark_bn254::Fr;
     use ark_ff::{BigInteger, PrimeField};
     use lazy_static::lazy_static;
@@ -180,23 +172,23 @@ mod test {
     use proptest::collection;
     use std::str::FromStr;
 
-    fn to_bigint_arr(vals: Vec<u8>) -> Vec<Bn254Fr> {
-        vals.into_iter().map(Bn254Fr::from).collect()
+    fn to_bigint_arr(vals: Vec<u8>) -> Vec<FieldElement> {
+        vals.into_iter().map(Fr::from).map(FieldElement).collect()
     }
 
     #[test]
     fn poseidon_test() {
-        let input1 = Fr::from_str("134696963602902907403122104327765350261").unwrap();
-        let input2 = Fr::from_str("17932473587154777519561053972421347139").unwrap();
-        let input3 = Fr::from_str("10000").unwrap();
-        let input4 = Fr::from_str(
+        let input1 = FieldElement::from_str("134696963602902907403122104327765350261").unwrap();
+        let input2 = FieldElement::from_str("17932473587154777519561053972421347139").unwrap();
+        let input3 = FieldElement::from_str("10000").unwrap();
+        let input4 = FieldElement::from_str(
             "50683480294434968413708503290439057629605340925620961559740848568164438166",
         )
         .unwrap();
-        let hash = poseidon(vec![input1, input2, input3, input4]).unwrap();
+        let hash = poseidon(&vec![input1, input2, input3, input4]).unwrap();
         assert_eq!(
             hash,
-            Fr::from_str(
+            FieldElement::from_str(
                 "2272550810841985018139126931041192927190568084082399473943239080305281957330"
             )
             .unwrap()
@@ -204,21 +196,21 @@ mod test {
     }
     #[test]
     fn test_to_poseidon_hash() {
-        assert!(poseidon_merkle_tree(to_bigint_arr(vec![])).is_err());
+        assert!(poseidon_merkle_tree(&to_bigint_arr(vec![])).is_err());
         assert_eq!(
-            poseidon_merkle_tree(to_bigint_arr(vec![1]))
+            poseidon_merkle_tree(&to_bigint_arr(vec![1]))
                 .unwrap()
                 .to_string(),
             "18586133768512220936620570745912940619677854269274689475585506675881198879027"
         );
         assert_eq!(
-            poseidon_merkle_tree(to_bigint_arr(vec![1, 2]))
+            poseidon_merkle_tree(&to_bigint_arr(vec![1, 2]))
                 .unwrap()
                 .to_string(),
             "7853200120776062878684798364095072458815029376092732009249414926327459813530"
         );
         assert_eq!(
-            poseidon_merkle_tree(to_bigint_arr(vec![
+            poseidon_merkle_tree(&to_bigint_arr(vec![
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
             ]))
             .unwrap()
@@ -226,7 +218,7 @@ mod test {
             "4203130618016961831408770638653325366880478848856764494148034853759773445968"
         );
         assert_eq!(
-            poseidon_merkle_tree(to_bigint_arr(vec![
+            poseidon_merkle_tree(&to_bigint_arr(vec![
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
             ]))
             .unwrap()
@@ -234,7 +226,7 @@ mod test {
             "9989051620750914585850546081941653841776809718687451684622678807385399211877"
         );
         assert_eq!(
-            poseidon_merkle_tree(to_bigint_arr(vec![
+            poseidon_merkle_tree(&to_bigint_arr(vec![
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                 23, 24, 25, 26, 27, 28, 29
             ]))
@@ -243,7 +235,7 @@ mod test {
             "4123755143677678663754455867798672266093104048057302051129414708339780424023"
         );
         assert_eq!(
-            poseidon_merkle_tree(to_bigint_arr(vec![
+            poseidon_merkle_tree(&to_bigint_arr(vec![
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
             ]))
@@ -251,11 +243,6 @@ mod test {
             .to_string(),
             "15368023340287843142129781602124963668572853984788169144128906033251913623349"
         );
-        assert!(poseidon_zk_login(to_bigint_arr(vec![
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-            24, 25, 26, 27, 28, 29, 30, 31, 32
-        ]))
-        .is_err());
     }
 
     #[test]

--- a/fastcrypto-zkp/src/bn254/unit_tests/zk_login_tests.rs
+++ b/fastcrypto-zkp/src/bn254/unit_tests/zk_login_tests.rs
@@ -3,12 +3,12 @@
 
 use std::str::FromStr;
 
-use crate::bn254::poseidon::poseidon_zk_login;
 use crate::bn254::utils::{
     gen_address_seed, gen_address_seed_with_salt_hash, get_nonce, get_zk_login_address,
 };
 use crate::bn254::zk_login::big_int_array_to_bits;
 use crate::bn254::zk_login::bitarray_to_bytearray;
+use crate::bn254::zk_login::poseidon_zk_login;
 use crate::bn254::zk_login::{
     base64_to_bitarray, convert_base, decode_base64_url, hash_ascii_str_to_field, hash_to_field,
     parse_jwks, trim, verify_extended_claim, Claim, JWTDetails, JwkId,

--- a/fastcrypto-zkp/src/bn254/unit_tests/zk_login_tests.rs
+++ b/fastcrypto-zkp/src/bn254/unit_tests/zk_login_tests.rs
@@ -508,7 +508,7 @@ fn test_verify_zk_login() {
     let aud = "575519204237-msop9ep45u2uo98hapqmngv8d84qdc8k.apps.googleusercontent.com";
     let salt = "6588741469050502421550140105345050859";
     let iss = "https://accounts.google.com";
-    let salt_hash = poseidon_zk_login(vec![(&Bn254FrElement::from_str(salt).unwrap()).into()])
+    let salt_hash = poseidon_zk_login(&[(&Bn254FrElement::from_str(salt).unwrap()).into()])
         .unwrap()
         .to_string();
     assert!(verify_zk_login_id(&address, name, value, aud, iss, &salt_hash).is_ok());
@@ -576,7 +576,7 @@ fn test_all_inputs_hash() {
     )
     .unwrap();
 
-    let hash = poseidon_zk_login(vec![
+    let hash = poseidon_zk_login(&[
         jwt_sha2_hash_0,
         jwt_sha2_hash_1,
         masked_content_hash,

--- a/fastcrypto-zkp/src/bn254/utils.rs
+++ b/fastcrypto-zkp/src/bn254/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::bn254::poseidon::poseidon_zk_login;
+use crate::bn254::zk_login::poseidon_zk_login;
 use crate::bn254::zk_login::{OIDCProvider, ZkLoginInputsReader};
 use crate::bn254::zk_login_api::Bn254Fr;
 use crate::zk_login_utils::Bn254FrElement;

--- a/fastcrypto-zkp/src/bn254/utils.rs
+++ b/fastcrypto-zkp/src/bn254/utils.rs
@@ -43,7 +43,7 @@ pub fn gen_address_seed(
     value: &str, // i.e. the sub value
     aud: &str,   // i.e. the client ID
 ) -> Result<String, FastCryptoError> {
-    let salt_hash = poseidon_zk_login(vec![(&Bn254FrElement::from_str(salt)?).into()])?;
+    let salt_hash = poseidon_zk_login(&[(&Bn254FrElement::from_str(salt)?).into()])?;
     gen_address_seed_with_salt_hash(&salt_hash.to_string(), name, value, aud)
 }
 
@@ -54,7 +54,7 @@ pub(crate) fn gen_address_seed_with_salt_hash(
     value: &str, // i.e. the sub value
     aud: &str,   // i.e. the client ID
 ) -> Result<String, FastCryptoError> {
-    Ok(poseidon_zk_login(vec![
+    Ok(poseidon_zk_login(&[
         hash_ascii_str_to_field(name, MAX_KEY_CLAIM_NAME_LENGTH)?,
         hash_ascii_str_to_field(value, MAX_KEY_CLAIM_VALUE_LENGTH)?,
         hash_ascii_str_to_field(aud, MAX_AUD_VALUE_LENGTH)?,
@@ -117,7 +117,7 @@ pub fn get_nonce(
     let jwt_randomness =
         Bn254Fr::from_str(jwt_randomness).map_err(|_| FastCryptoError::InvalidInput)?;
 
-    let hash = poseidon_zk_login(vec![first, second, max_epoch, jwt_randomness])
+    let hash = poseidon_zk_login(&[first, second, max_epoch, jwt_randomness])
         .expect("inputs is not too long");
     let data = BigUint::from(hash).to_bytes_be();
     let truncated = &data[data.len() - 20..];

--- a/fastcrypto-zkp/src/bn254/zk_login.rs
+++ b/fastcrypto-zkp/src/bn254/zk_login.rs
@@ -6,7 +6,8 @@ use reqwest::Client;
 use serde_json::Value;
 
 use super::utils::split_to_two_frs;
-use crate::bn254::{poseidon, FieldElement};
+use crate::bn254::poseidon::poseidon_merkle_tree;
+use crate::bn254::FieldElement;
 use crate::zk_login_utils::{
     g1_affine_from_str_projective, g2_affine_from_str_projective, Bn254FrElement, CircomG1,
     CircomG2,
@@ -728,8 +729,7 @@ pub(crate) fn poseidon_zk_login(inputs: &[Bn254Fr]) -> FastCryptoResult<Bn254Fr>
     if inputs.is_empty() || inputs.len() > 32 {
         return Err(FastCryptoError::InputLengthWrong(inputs.len()));
     }
-    poseidon::poseidon_merkle_tree(&inputs.iter().map(|x| FieldElement(*x)).collect::<Vec<_>>())
-        .map(|x| x.0)
+    poseidon_merkle_tree(&inputs.iter().map(|x| FieldElement(*x)).collect_vec()).map(|x| x.0)
 }
 
 #[test]

--- a/fastcrypto-zkp/src/bn254/zk_login.rs
+++ b/fastcrypto-zkp/src/bn254/zk_login.rs
@@ -733,7 +733,9 @@ pub(crate) fn poseidon_zk_login(inputs: &[Bn254Fr]) -> FastCryptoResult<Bn254Fr>
 }
 
 #[test]
-fn test_poseidon_zk_login_invalid_input() {
+fn test_poseidon_zk_login_input_sizes() {
     assert!(poseidon_zk_login(&[]).is_err());
+    assert!(poseidon_zk_login(&[Bn254Fr::from_str("123").unwrap(); 1]).is_ok());
+    assert!(poseidon_zk_login(&[Bn254Fr::from_str("123").unwrap(); 32]).is_ok());
     assert!(poseidon_zk_login(&[Bn254Fr::from_str("123").unwrap(); 33]).is_err());
 }

--- a/fastcrypto-zkp/src/bn254/zk_login.rs
+++ b/fastcrypto-zkp/src/bn254/zk_login.rs
@@ -728,7 +728,8 @@ pub(crate) fn poseidon_zk_login(inputs: Vec<Bn254Fr>) -> FastCryptoResult<Bn254F
     if inputs.is_empty() || inputs.len() > 32 {
         return Err(FastCryptoError::InputLengthWrong(inputs.len()));
     }
-    poseidon::poseidon_merkle_tree(&inputs.into_iter().map(FieldElement).collect()).map(|x| x.0)
+    poseidon::poseidon_merkle_tree(&inputs.into_iter().map(FieldElement).collect::<Vec<_>>())
+        .map(|x| x.0)
 }
 
 #[test]


### PR DESCRIPTION
* Ensure that the public api for Poseidon uses the wrapped type for BN254 field elements.
* Take references as inputs instead of consuming a vector.
* Move the zk-login specific poseidon hash function to zk_login.rs.

Note that the function used from sui-framework, `poseidon_bytes` is not changed, and in zklogin, there are no functional changes.