### PR TITLE
BLS fast sums

### DIFF
--- a/fastcrypto/benches/groups.rs
+++ b/fastcrypto/benches/groups.rs
@@ -7,8 +7,8 @@ mod group_benches {
     use criterion::measurement::Measurement;
     use criterion::{measurement, BenchmarkGroup, BenchmarkId, Criterion};
     use fastcrypto::groups::bls12381::{
-        sum_affine, G1Element, G2Element, GTElement, Scalar as BlsScalar, G1_ELEMENT_BYTE_LENGTH,
-        G2_ELEMENT_BYTE_LENGTH, GT_ELEMENT_BYTE_LENGTH, SCALAR_LENGTH,
+        affine_to_raw, sum_raw_affine, G1Element, G2Element, GTElement, Scalar as BlsScalar,
+        G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH, GT_ELEMENT_BYTE_LENGTH, SCALAR_LENGTH,
     };
     use fastcrypto::groups::multiplier::windowed::WindowedScalarMultiplier;
     use fastcrypto::groups::multiplier::ScalarMultiplier;
@@ -218,9 +218,10 @@ mod group_benches {
             let terms = (0..n)
                 .map(|_| G1Element::generator() * bls12381::Scalar::rand(&mut thread_rng()))
                 .map(|x: G1Element| x.to_uncompressed_bytes())
+                .map(|b| affine_to_raw(&b))
                 .collect::<Vec<_>>();
             c.bench_function(format!("{}/{}", name.to_string(), n), move |b| {
-                b.iter(|| sum_affine(terms.as_slice()))
+                b.iter(|| sum_raw_affine(terms.as_slice()))
             });
         }
     }

--- a/fastcrypto/benches/groups.rs
+++ b/fastcrypto/benches/groups.rs
@@ -7,9 +7,8 @@ mod group_benches {
     use criterion::measurement::Measurement;
     use criterion::{measurement, BenchmarkGroup, BenchmarkId, Criterion};
     use fastcrypto::groups::bls12381::{
-        sum_g1_uncompressed, G1Element, G1ElementUncompressed, G2Element, GTElement,
-        Scalar as BlsScalar, G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH,
-        GT_ELEMENT_BYTE_LENGTH, SCALAR_LENGTH,
+        G1Element, G1ElementUncompressed, G2Element, GTElement, Scalar as BlsScalar,
+        G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH, GT_ELEMENT_BYTE_LENGTH, SCALAR_LENGTH,
     };
     use fastcrypto::groups::multiplier::windowed::WindowedScalarMultiplier;
     use fastcrypto::groups::multiplier::ScalarMultiplier;
@@ -221,7 +220,7 @@ mod group_benches {
                 .map(|x| G1ElementUncompressed::from(&x))
                 .collect::<Vec<_>>();
             c.bench_function(&format!("Sum/BLS12381-G1/{}", n), move |b| {
-                b.iter(|| sum_g1_uncompressed(terms.as_slice()))
+                b.iter(|| G1ElementUncompressed::sum(terms.as_slice()))
             });
         }
     }

--- a/fastcrypto/benches/groups.rs
+++ b/fastcrypto/benches/groups.rs
@@ -7,7 +7,7 @@ mod group_benches {
     use criterion::measurement::Measurement;
     use criterion::{measurement, BenchmarkGroup, BenchmarkId, Criterion};
     use fastcrypto::groups::bls12381::{
-        sum_uncompressed, G1Element, G1ElementUncompressed, G2Element, GTElement,
+        sum_g1_uncompressed, G1Element, G1ElementUncompressed, G2Element, GTElement,
         Scalar as BlsScalar, G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH,
         GT_ELEMENT_BYTE_LENGTH, SCALAR_LENGTH,
     };
@@ -221,7 +221,7 @@ mod group_benches {
                 .map(|x| G1ElementUncompressed::from(&x))
                 .collect::<Vec<_>>();
             c.bench_function(&format!("Sum/BLS12381-G1/{}", n), move |b| {
-                b.iter(|| sum_uncompressed(terms.as_slice()))
+                b.iter(|| sum_g1_uncompressed(terms.as_slice()))
             });
         }
     }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -349,8 +349,9 @@ impl ToFromUncompressedBytes<{ 2 * G1_ELEMENT_BYTE_LENGTH }> for G1Element {
     ) -> FastCryptoResult<G1Element> {
         // See https://github.com/supranational/blst for details on the serialization format.
 
-        // The compressed bit flag and the third bit flag (used to indicate sign of the y-coordinate
-        // for compressed representations) should not be set.
+        // Note that `blst_p1_deserialize` accepts both compressed and uncompressed serializations,
+        // so we check for the compressed bit flag which are the first and third bit flags (used to
+        // indicate sign of the y-coordinate for compressed representations) should not be set.
         if bytes[0] & 0xA0 != 0 {
             return Err(InvalidInput);
         }
@@ -359,8 +360,7 @@ impl ToFromUncompressedBytes<{ 2 * G1_ELEMENT_BYTE_LENGTH }> for G1Element {
         unsafe {
             let mut affine = blst_p1_affine::default();
 
-            // Note that `blst_p1_deserialize` accepts both compressed and uncompressed serializations
-            // which is why we checked for the compressed bit flag above.
+            // blst_p1_deserialize checks that the point is on the curve but NOT that it is in the G1 subgroup.
             if blst_p1_deserialize(&mut affine, bytes.as_ptr()) != BLST_ERROR::BLST_SUCCESS {
                 return Err(InvalidInput);
             }
@@ -576,8 +576,9 @@ impl ToFromUncompressedBytes<{ 2 * G2_ELEMENT_BYTE_LENGTH }> for G2Element {
     ) -> FastCryptoResult<G2Element> {
         // See https://github.com/supranational/blst for details on the serialization format.
 
-        // The compressed bit flag and the third bit flag (used to indicate sign of the y-coordinate
-        // for compressed representations) should not be set.
+        // Note that `blst_p2_deserialize` accepts both compressed and uncompressed serializations,
+        // so we check for the compressed bit flag which are the first and third bit flags (used to
+        // indicate sign of the y-coordinate for compressed representations) should not be set.
         if bytes[0] & 0xA0 != 0 {
             return Err(InvalidInput);
         }
@@ -586,8 +587,7 @@ impl ToFromUncompressedBytes<{ 2 * G2_ELEMENT_BYTE_LENGTH }> for G2Element {
         unsafe {
             let mut affine = blst_p2_affine::default();
 
-            // Note that `blst_p1_deserialize` accepts both compressed and uncompressed serializations
-            // which is why we checked for the compressed bit flag above.
+            // blst_p2_deserialize checks that the point is on the curve but NOT that it is in the G2 subgroup.
             if blst_p2_deserialize(&mut affine, bytes.as_ptr()) != BLST_ERROR::BLST_SUCCESS {
                 return Err(InvalidInput);
             }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -359,6 +359,11 @@ impl G1ElementUncompressed {
         Self(bytes)
     }
 
+    /// Return the binary representation of this element.
+    pub fn to_bytes(&self) -> [u8; 2 * G1_ELEMENT_BYTE_LENGTH] {
+        self.0
+    }
+
     fn to_blst_p1_affine(&self) -> FastCryptoResult<blst_p1_affine> {
         let mut affine = blst_p1_affine::default();
         unsafe {

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -34,6 +34,7 @@ use serde::{de, Deserialize};
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 use std::ptr;
+use std::ptr::null;
 use zeroize::Zeroize;
 
 /// Elements of the group G_1 in BLS 12-381.
@@ -425,7 +426,7 @@ impl G1ElementUncompressed {
 
         // Inspired by https://github.com/supranational/blst/blob/6f3136ffb636974166a93f2f25436854fe8d10ff/bindings/rust/src/pippenger.rs#L334-L337
         let mut ret = blst_p1::default();
-        let p: [*const _; 2] = [&affine_points[0], ptr::null()];
+        let p: [*const _; 2] = [&affine_points[0], null()];
         unsafe { blst_p1s_add(&mut ret, &p[0], terms.len()) };
         Ok(G1Element(ret))
     }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -339,7 +339,7 @@ generate_bytes_representation!(G1Element, G1_ELEMENT_BYTE_LENGTH, G1ElementAsByt
 /// format used by `G1Element::serialize`, but is much faster to deserialize.
 ///
 /// The intended use of this struct is to deserialize and sum a large number of G1 elements without
-/// having to decompress each of them first.
+/// having to decompress them first.
 #[derive(Clone, Debug)]
 #[repr(transparent)]
 pub struct G1ElementUncompressed(pub(crate) [u8; 2 * G1_ELEMENT_BYTE_LENGTH]);

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -20,13 +20,14 @@ use blst::{
     blst_fp12_one, blst_fp12_sqr, blst_fp_from_bendian, blst_fr, blst_fr_add, blst_fr_cneg,
     blst_fr_from_scalar, blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_rshift,
     blst_fr_sub, blst_hash_to_g1, blst_hash_to_g2, blst_lendian_from_scalar, blst_miller_loop,
-    blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg, blst_p1_compress,
-    blst_p1_deserialize, blst_p1_from_affine, blst_p1_in_g1, blst_p1_mult, blst_p1_serialize,
-    blst_p1_to_affine, blst_p1_uncompress, blst_p1s_add, blst_p2, blst_p2_add_or_double,
-    blst_p2_affine, blst_p2_cneg, blst_p2_compress, blst_p2_deserialize, blst_p2_from_affine,
-    blst_p2_in_g2, blst_p2_mult, blst_p2_serialize, blst_p2_to_affine, blst_p2_uncompress,
-    blst_scalar, blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian,
-    blst_scalar_from_fr, p1_affines, p2_affines, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_affine_serialize, blst_p1_cneg,
+    blst_p1_compress, blst_p1_deserialize, blst_p1_from_affine, blst_p1_in_g1, blst_p1_mult,
+    blst_p1_serialize, blst_p1_to_affine, blst_p1_uncompress, blst_p1s_add, blst_p2,
+    blst_p2_add_or_double, blst_p2_affine, blst_p2_cneg, blst_p2_compress, blst_p2_deserialize,
+    blst_p2_from_affine, blst_p2_in_g2, blst_p2_mult, blst_p2_serialize, blst_p2_to_affine,
+    blst_p2_uncompress, blst_scalar, blst_scalar_fr_check, blst_scalar_from_be_bytes,
+    blst_scalar_from_bendian, blst_scalar_from_fr, p1_affines, p2_affines, BLS12_381_G1,
+    BLS12_381_G2, BLST_ERROR,
 };
 use fastcrypto_derive::GroupOpsExtend;
 use hex_literal::hex;
@@ -34,7 +35,7 @@ use once_cell::sync::OnceCell;
 use serde::{de, Deserialize};
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};
-use std::ptr;
+use std::{mem, ptr};
 use zeroize::Zeroize;
 
 /// Elements of the group G_1 in BLS 12-381.
@@ -245,6 +246,36 @@ pub fn sum_affine(terms: &[[u8; 2 * G1_ELEMENT_BYTE_LENGTH]]) -> G1Element {
     let mut ret = <blst_p1>::default();
     let p: [*const _; 2] = [&affine_points[0], ptr::null()];
     unsafe { blst_p1s_add(&mut ret, &p[0], terms.len()) };
+    G1Element(ret)
+}
+
+pub fn affine_to_raw(
+    affine: &[u8; 2 * G1_ELEMENT_BYTE_LENGTH],
+) -> [u8; 2 * G1_ELEMENT_BYTE_LENGTH] {
+    let mut affine_pt = blst_p1_affine::default();
+    unsafe {
+        blst_p1_deserialize(&mut affine_pt, affine.as_ptr());
+    }
+    let affine_ptr = &affine_pt as *const _ as *const u8;
+    (0..2 * G1_ELEMENT_BYTE_LENGTH)
+        .map(|i| unsafe { *affine_ptr.offset(i as isize) })
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap()
+}
+
+pub fn sum_raw_affine(terms: &[[u8; 2 * G1_ELEMENT_BYTE_LENGTH]]) -> G1Element {
+    if terms.is_empty() {
+        return G1Element::zero();
+    }
+
+    let mut ret = <blst_p1>::default();
+    unsafe {
+        let transmuted =
+            mem::transmute::<&[[u8; 2 * G1_ELEMENT_BYTE_LENGTH]], &[blst_p1_affine]>(terms);
+        let p: [*const _; 2] = [&transmuted[0], ptr::null()];
+        blst_p1s_add(&mut ret, &p[0], terms.len());
+    }
     G1Element(ret)
 }
 

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -34,7 +34,6 @@ use serde::{de, Deserialize};
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 use std::ptr;
-use std::ptr::null;
 use zeroize::Zeroize;
 
 /// Elements of the group G_1 in BLS 12-381.
@@ -426,8 +425,11 @@ impl G1ElementUncompressed {
 
         // Inspired by https://github.com/supranational/blst/blob/6f3136ffb636974166a93f2f25436854fe8d10ff/bindings/rust/src/pippenger.rs#L334-L337
         let mut ret = blst_p1::default();
-        let p: [*const _; 2] = [&affine_points[0], null()];
-        unsafe { blst_p1s_add(&mut ret, &p[0], terms.len()) };
+        let p = affine_points
+            .iter()
+            .map(|p| p as *const _)
+            .collect::<Vec<_>>();
+        unsafe { blst_p1s_add(&mut ret, p.as_ptr(), p.len()) };
         Ok(G1Element(ret))
     }
 }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -22,11 +22,11 @@ use blst::{
     blst_fr_sub, blst_hash_to_g1, blst_hash_to_g2, blst_lendian_from_scalar, blst_miller_loop,
     blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg, blst_p1_compress,
     blst_p1_deserialize, blst_p1_from_affine, blst_p1_in_g1, blst_p1_mult, blst_p1_serialize,
-    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double, blst_p2_affine,
-    blst_p2_cneg, blst_p2_compress, blst_p2_deserialize, blst_p2_from_affine, blst_p2_in_g2,
-    blst_p2_mult, blst_p2_serialize, blst_p2_to_affine, blst_p2_uncompress, blst_scalar,
-    blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian, blst_scalar_from_fr,
-    p1_affines, p2_affines, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
+    blst_p2_affine, blst_p2_cneg, blst_p2_compress, blst_p2_deserialize, blst_p2_from_affine,
+    blst_p2_in_g2, blst_p2_mult, blst_p2_serialize, blst_p2_to_affine, blst_p2_uncompress,
+    blst_scalar, blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian,
+    blst_scalar_from_fr, p1_affines, p2_affines, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use fastcrypto_derive::GroupOpsExtend;
 use hex_literal::hex;
@@ -215,6 +215,14 @@ impl GroupElement for G1Element {
             blst_p1_from_affine(&mut ret, &BLS12_381_G1);
         }
         Self(ret)
+    }
+
+    fn sum(terms: &[Self]) -> Self {
+        if terms.is_empty() {
+            return Self::zero();
+        }
+        let terms = p1_affines::from(to_blst_type_slice(&terms));
+        Self(terms.add())
     }
 }
 
@@ -496,6 +504,14 @@ impl GroupElement for G2Element {
             blst_p2_from_affine(&mut ret, &BLS12_381_G2);
         }
         Self(ret)
+    }
+
+    fn sum(terms: &[Self]) -> Self {
+        if terms.is_empty() {
+            return Self::zero();
+        }
+        let terms = p2_affines::from(to_blst_type_slice(&terms));
+        Self(terms.add())
     }
 }
 

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -423,7 +423,6 @@ impl G1ElementUncompressed {
             .map(G1ElementUncompressed::to_blst_p1_affine)
             .collect::<FastCryptoResult<Vec<_>>>()?;
 
-        // Inspired by https://github.com/supranational/blst/blob/6f3136ffb636974166a93f2f25436854fe8d10ff/bindings/rust/src/pippenger.rs#L334-L337
         let mut ret = blst_p1::default();
         let p = affine_points
             .iter()

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -400,7 +400,7 @@ impl TryFrom<&G1ElementUncompressed> for G1Element {
     }
 }
 
-pub fn sum_uncompressed(terms: &[G1ElementUncompressed]) -> FastCryptoResult<G1Element> {
+pub fn sum_g1_uncompressed(terms: &[G1ElementUncompressed]) -> FastCryptoResult<G1Element> {
     if terms.is_empty() {
         return Ok(G1Element::zero());
     }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -22,11 +22,11 @@ use blst::{
     blst_fr_sub, blst_hash_to_g1, blst_hash_to_g2, blst_lendian_from_scalar, blst_miller_loop,
     blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg, blst_p1_compress,
     blst_p1_deserialize, blst_p1_from_affine, blst_p1_in_g1, blst_p1_mult, blst_p1_serialize,
-    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
-    blst_p2_affine, blst_p2_cneg, blst_p2_compress, blst_p2_deserialize, blst_p2_from_affine,
-    blst_p2_in_g2, blst_p2_mult, blst_p2_serialize, blst_p2_to_affine, blst_p2_uncompress,
-    blst_scalar, blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian,
-    blst_scalar_from_fr, p1_affines, p2_affines, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double, blst_p2_affine,
+    blst_p2_cneg, blst_p2_compress, blst_p2_deserialize, blst_p2_from_affine, blst_p2_in_g2,
+    blst_p2_mult, blst_p2_serialize, blst_p2_to_affine, blst_p2_uncompress, blst_scalar,
+    blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian, blst_scalar_from_fr,
+    p1_affines, p2_affines, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use fastcrypto_derive::GroupOpsExtend;
 use hex_literal::hex;
@@ -221,7 +221,7 @@ impl GroupElement for G1Element {
         if terms.is_empty() {
             return Self::zero();
         }
-        let terms = p1_affines::from(to_blst_type_slice(&terms));
+        let terms = p1_affines::from(to_blst_type_slice(terms));
         Self(terms.add())
     }
 }
@@ -510,7 +510,7 @@ impl GroupElement for G2Element {
         if terms.is_empty() {
             return Self::zero();
         }
-        let terms = p2_affines::from(to_blst_type_slice(&terms));
+        let terms = p2_affines::from(to_blst_type_slice(terms));
         Self(terms.add())
     }
 }

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -357,6 +357,15 @@ impl TryFrom<&G1ElementUncompressed> for G1Element {
     type Error = FastCryptoError;
 
     fn try_from(value: &G1ElementUncompressed) -> Result<Self, Self::Error> {
+        // See https://github.com/supranational/blst for details on the serialization format.
+
+        // Note that `blst_p1_deserialize` accepts both compressed and uncompressed serializations,
+        // so we check that the compressed bit flag (the 1st) is not set. The third is used for
+        // compressed points to indicate sign of the y-coordinate and should also not be set.
+        if value.0[0] & 0x20 != 0 || value.0[0] & 0x80 != 0 {
+            return Err(InvalidInput);
+        }
+
         let mut ret = blst_p1::default();
         unsafe {
             let mut affine = blst_p1_affine::default();

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -124,16 +124,3 @@ pub trait MultiScalarMul: GroupElement {
 pub trait FromTrustedByteArray<const LENGTH: usize>: Sized {
     fn from_trusted_byte_array(bytes: &[u8; LENGTH]) -> FastCryptoResult<Self>;
 }
-
-/// Trait for types that has an uncompressed representation. The [ToFromByteArray] implementations
-/// uses compressed representations of the data, which are smaller (half the size) but slower to
-/// deserialize.
-pub trait ToFromUncompressedBytes<const UNCOMPRESSED_LENGTH: usize>: Sized {
-    /// Serialize an element to an uncompressed byte array.
-    fn to_uncompressed_bytes(&self) -> [u8; UNCOMPRESSED_LENGTH];
-
-    /// Convert an uncompressed byte array to the element. It is not verified whether the deserialized
-    /// element is valid (e.g., in the group) or not.
-    fn from_trusted_uncompressed_bytes(bytes: &[u8; UNCOMPRESSED_LENGTH])
-        -> FastCryptoResult<Self>;
-}

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -41,6 +41,11 @@ pub trait GroupElement:
 
     /// Return an instance of the generator for this group.
     fn generator() -> Self;
+
+    /// Compute the sum of a list of group elements.
+    fn sum(terms: &[Self]) -> Self {
+        terms.iter().fold(Self::zero(), |acc, x| acc + x)
+    }
 }
 
 // TODO: Move Serialize + DeserializeOwned to GroupElement.

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -41,11 +41,6 @@ pub trait GroupElement:
 
     /// Return an instance of the generator for this group.
     fn generator() -> Self;
-
-    /// Compute the sum of a list of group elements.
-    fn sum(terms: &[Self]) -> Self {
-        terms.iter().fold(Self::zero(), |acc, x| acc + x)
-    }
 }
 
 // TODO: Move Serialize + DeserializeOwned to GroupElement.

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -124,7 +124,7 @@ pub trait FromTrustedByteArray<const LENGTH: usize>: Sized {
 /// uses compressed representations of the data, which are smaller (half the size) but slower to
 /// deserialize.
 pub trait ToFromUncompressedBytes<const UNCOMPRESSED_LENGTH: usize>: Sized {
-    /// Convert the element to an uncompressed byte array.
+    /// Serialize an element to an uncompressed byte array.
     fn to_uncompressed_bytes(&self) -> [u8; UNCOMPRESSED_LENGTH];
 
     /// Convert an uncompressed byte array to the element. It is not verified whether the deserialized

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -119,3 +119,16 @@ pub trait MultiScalarMul: GroupElement {
 pub trait FromTrustedByteArray<const LENGTH: usize>: Sized {
     fn from_trusted_byte_array(bytes: &[u8; LENGTH]) -> FastCryptoResult<Self>;
 }
+
+/// Trait for types that has an uncompressed representation. The [ToFromByteArray] implementations
+/// uses compressed representations of the data, which are smaller (half the size) but slower to
+/// deserialize.
+pub trait ToFromUncompressedBytes<const UNCOMPRESSED_LENGTH: usize>: Sized {
+    /// Convert the element to an uncompressed byte array.
+    fn to_uncompressed_bytes(&self) -> [u8; UNCOMPRESSED_LENGTH];
+
+    /// Convert an uncompressed byte array to the element. It is not verified whether the deserialized
+    /// element is valid (e.g., in the group) or not.
+    fn from_trusted_uncompressed_bytes(bytes: &[u8; UNCOMPRESSED_LENGTH])
+        -> FastCryptoResult<Self>;
+}

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -717,21 +717,32 @@ fn test_g1_to_from_uncompressed() {
 
 #[test]
 fn test_g1_sum() {
+    // Empty sum
+    assert_eq!(sum_uncompressed(&[]).unwrap(), G1Element::zero());
+
+    // Non-trivial sum
     let a = G1Element::generator();
     let b = G1Element::generator() * Scalar::from(2u128);
     let c = G1Element::generator() * Scalar::from(3u128);
-
     let mut bytes: Vec<G1ElementUncompressed> = vec![(&a).into(), (&b).into(), (&c).into()];
-
     let sum = sum_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::generator() * Scalar::from(6u128));
 
-    // Adding a zero doesn't change anything
+    // Adding zeros doesn't change anything
     bytes.push(G1ElementUncompressed::from(&G1Element::zero()));
     let sum = sum_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::generator() * Scalar::from(6u128));
 
-    let bytes = [G1ElementUncompressed::from(&G1Element::zero())];
+    // Singleton sum
+    let bytes = [(&b).into()];
+    let sum = sum_uncompressed(&bytes).unwrap();
+    assert_eq!(sum, b);
+
+    // Adding zero's
+    let mut bytes = vec![G1ElementUncompressed::from(&G1Element::zero())];
+    let sum = sum_uncompressed(&bytes).unwrap();
+    assert_eq!(sum, G1Element::zero());
+    bytes.push(G1ElementUncompressed::from(&G1Element::zero()));
     let sum = sum_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::zero());
 }

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -15,7 +15,11 @@ use crate::test_helpers::verify_serialization;
 use crate::traits::Signer;
 use crate::traits::VerifyingKey;
 use crate::traits::{KeyPair, ToFromBytes};
-use blst::{blst_p1_affine, blst_p1_affine_generator, blst_p1_affine_on_curve, blst_p1_affine_serialize, blst_p1_deserialize, blst_p2_affine, blst_p2_affine_generator, blst_p2_affine_on_curve, blst_p2_affine_serialize, blst_p2_deserialize, BLST_ERROR};
+use blst::{
+    blst_p1_affine, blst_p1_affine_generator, blst_p1_affine_on_curve, blst_p1_affine_serialize,
+    blst_p1_deserialize, blst_p2_affine, blst_p2_affine_generator, blst_p2_affine_on_curve,
+    blst_p2_affine_serialize, blst_p2_deserialize, BLST_ERROR,
+};
 use rand::{rngs::StdRng, thread_rng, RngCore, SeedableRng as _};
 
 const MSG: &[u8] = b"test message";
@@ -766,4 +770,26 @@ fn test_g2_to_from_uncompressed() {
 
     let b = G2Element::from_trusted_uncompressed_bytes(&uncompressed_bytes).unwrap();
     assert_eq!(a, b);
+}
+
+#[test]
+fn test_g1_sum() {
+    let a = G1Element::generator();
+    let b = G1Element::generator() * Scalar::from(2u128);
+    let c = G1Element::generator() * Scalar::from(3u128);
+    let d = G1Element::sum(&[a, b, c]);
+    assert_eq!(d, G1Element::generator() * Scalar::from(6u128));
+    assert_eq!(a, G1Element::sum(&[a]));
+    assert_eq!(G1Element::zero(), G1Element::sum(&[]));
+}
+
+#[test]
+fn test_g2_sum() {
+    let a = G2Element::generator();
+    let b = G2Element::generator() * Scalar::from(2u128);
+    let c = G2Element::generator() * Scalar::from(3u128);
+    let d = G2Element::sum(&[a, b, c]);
+    assert_eq!(d, G2Element::generator() * Scalar::from(6u128));
+    assert_eq!(a, G2Element::sum(&[a]));
+    assert_eq!(G2Element::zero(), G2Element::sum(&[]));
 }

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -744,3 +744,18 @@ fn test_g1_sum() {
     let sum = G1ElementUncompressed::sum(&bytes).unwrap();
     assert_eq!(sum, G1Element::zero());
 }
+
+#[test]
+fn test_g1_large_sum() {
+    let mut rng = thread_rng();
+    let n: usize = 1000;
+    let points: Vec<G1Element> = (0..n)
+        .map(|_| G1Element::generator() * Scalar::rand(&mut rng))
+        .collect();
+    let expected = points.iter().fold(G1Element::zero(), |acc, p| acc + p);
+
+    let as_uncompressed: Vec<G1ElementUncompressed> =
+        points.iter().map(G1ElementUncompressed::from).collect();
+    let sum = G1ElementUncompressed::sum(as_uncompressed.as_slice()).unwrap();
+    assert_eq!(expected, sum);
+}

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -3,8 +3,8 @@
 
 use crate::bls12381::min_pk::{BLS12381KeyPair, BLS12381Signature};
 use crate::groups::bls12381::{
-    reduce_mod_uniform_buffer, sum_affine, G1Element, G2Element, GTElement, Scalar,
-    G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH,
+    affine_to_raw, reduce_mod_uniform_buffer, sum_raw_affine, G1Element, G2Element, GTElement,
+    Scalar, G1_ELEMENT_BYTE_LENGTH, G2_ELEMENT_BYTE_LENGTH,
 };
 use crate::groups::{
     FromTrustedByteArray, GroupElement, HashToGroupElement, MultiScalarMul, Pairing,
@@ -808,7 +808,12 @@ fn test_g1_sum_fast() {
         b.to_uncompressed_bytes(),
         c.to_uncompressed_bytes(),
     ];
-    let sum = sum_affine(&bytes);
+    let raw_bytes = bytes
+        .iter()
+        .map(|b| affine_to_raw(b))
+        .collect::<Vec<[u8; 96]>>();
+
+    let sum = sum_raw_affine(&raw_bytes);
 
     assert_eq!(sum, G1Element::generator() * Scalar::from(6u128));
 }

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -4,6 +4,7 @@
 use crate::bls12381::min_pk::{BLS12381KeyPair, BLS12381Signature};
 use crate::groups::bls12381::{
     reduce_mod_uniform_buffer, G1Element, G2Element, GTElement, Scalar, G1_ELEMENT_BYTE_LENGTH,
+    G2_ELEMENT_BYTE_LENGTH,
 };
 use crate::groups::{
     FromTrustedByteArray, GroupElement, HashToGroupElement, MultiScalarMul, Pairing,
@@ -659,26 +660,29 @@ fn test_serialization_gt() {
 #[test]
 fn test_g1_to_from_uncompressed() {
     let a = G1Element::generator();
+
     let uncompressed_bytes = a.to_uncompressed_bytes();
+    assert_eq!(uncompressed_bytes.len(), G1_ELEMENT_BYTE_LENGTH * 2);
+
     let b = G1Element::from_trusted_uncompressed_bytes(&uncompressed_bytes).unwrap();
     assert_eq!(a, b);
 
-    // Uncompressed bit flags is not set.
-    assert_eq!(uncompressed_bytes[0] & 0x80, 0);
+    // Compressed bit flags (1 and 3) should not be set.
+    assert_eq!(uncompressed_bytes[0] & 0xA0, 0);
 
-    // Infinity bit flag is not set.
+    // Infinity bit flag (2) should not be set.
     assert_eq!(uncompressed_bytes[0] & 0x40, 0);
 
-    let mut compressed_bytes = a.to_byte_array();
-
     // A vector with the first half being the compressed bytes and the second half being zeros should fail
+    let mut compressed_bytes = a.to_byte_array();
     let mut extended_compressed_bytes = compressed_bytes.to_vec();
     extended_compressed_bytes.extend_from_slice(&[0; G1_ELEMENT_BYTE_LENGTH]);
     let extended_compressed_bytes: [u8; 2 * G1_ELEMENT_BYTE_LENGTH] =
         extended_compressed_bytes.try_into().unwrap();
     assert!(G1Element::from_trusted_uncompressed_bytes(&extended_compressed_bytes).is_err());
 
-    // If we clear the compressed bit flags, we should get the same bytes as the first half of the uncompressed bytes
+    // If we clear the compressed bit flags (the first three), we should get the same bytes as the
+    // first half of the uncompressed bytes
     compressed_bytes[0] &= 0x1f;
     assert_eq!(
         uncompressed_bytes[..G1_ELEMENT_BYTE_LENGTH],
@@ -688,9 +692,67 @@ fn test_g1_to_from_uncompressed() {
     // Test with point at infinity
     let a = G1Element::zero();
     let uncompressed_bytes = a.to_uncompressed_bytes();
+    assert_eq!(uncompressed_bytes.len(), G1_ELEMENT_BYTE_LENGTH * 2);
+
+    // Only the point at infinity flag should be set.
+    assert_eq!(uncompressed_bytes[0], 0x40);
+
+    // The remaining bytes should all be zero
+    assert_eq!(
+        uncompressed_bytes[1..],
+        [0u8; G1_ELEMENT_BYTE_LENGTH * 2 - 1]
+    );
+
     let b = G1Element::from_trusted_uncompressed_bytes(&uncompressed_bytes).unwrap();
     assert_eq!(a, b);
+}
 
-    // Point at infinity has the second bit flag set
-    assert_ne!(uncompressed_bytes[0] & 0x40, 0);
+#[test]
+fn test_g2_to_from_uncompressed() {
+    let a = G2Element::generator();
+
+    let uncompressed_bytes = a.to_uncompressed_bytes();
+    assert_eq!(uncompressed_bytes.len(), G2_ELEMENT_BYTE_LENGTH * 2);
+
+    let b = G2Element::from_trusted_uncompressed_bytes(&uncompressed_bytes).unwrap();
+    assert_eq!(a, b);
+
+    // Compressed bit flags (1 and 3) should not be set.
+    assert_eq!(uncompressed_bytes[0] & 0xA0, 0);
+
+    // Infinity bit flag (2) should not be set.
+    assert_eq!(uncompressed_bytes[0] & 0x40, 0);
+
+    // A vector with the first half being the compressed bytes and the second half being zeros should fail
+    let mut compressed_bytes = a.to_byte_array();
+    let mut extended_compressed_bytes = compressed_bytes.to_vec();
+    extended_compressed_bytes.extend_from_slice(&[0; G2_ELEMENT_BYTE_LENGTH]);
+    let extended_compressed_bytes: [u8; 2 * G2_ELEMENT_BYTE_LENGTH] =
+        extended_compressed_bytes.try_into().unwrap();
+    assert!(G2Element::from_trusted_uncompressed_bytes(&extended_compressed_bytes).is_err());
+
+    // If we clear the compressed bit flags (the first three), we should get the same bytes as the
+    // first half of the uncompressed bytes
+    compressed_bytes[0] &= 0x1f;
+    assert_eq!(
+        uncompressed_bytes[..G2_ELEMENT_BYTE_LENGTH],
+        compressed_bytes
+    );
+
+    // Test with point at infinity
+    let a = G2Element::zero();
+    let uncompressed_bytes = a.to_uncompressed_bytes();
+    assert_eq!(uncompressed_bytes.len(), G2_ELEMENT_BYTE_LENGTH * 2);
+
+    // Only the point at infinity flag should be set.
+    assert_eq!(uncompressed_bytes[0], 0x40);
+
+    // The remaining bytes should all be zero
+    assert_eq!(
+        uncompressed_bytes[1..],
+        [0u8; G2_ELEMENT_BYTE_LENGTH * 2 - 1]
+    );
+
+    let b = G2Element::from_trusted_uncompressed_bytes(&uncompressed_bytes).unwrap();
+    assert_eq!(a, b);
 }

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -748,7 +748,7 @@ fn test_g1_sum() {
 #[test]
 fn test_g1_large_sum() {
     let mut rng = thread_rng();
-    let n: usize = 1000;
+    let n: usize = 100;
     let points: Vec<G1Element> = (0..n)
         .map(|_| G1Element::generator() * Scalar::rand(&mut rng))
         .collect();

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::bls12381::min_pk::{BLS12381KeyPair, BLS12381Signature};
 use crate::groups::bls12381::{
-    reduce_mod_uniform_buffer, sum_uncompressed, G1Element, G1ElementUncompressed, G2Element,
+    reduce_mod_uniform_buffer, sum_g1_uncompressed, G1Element, G1ElementUncompressed, G2Element,
     GTElement, Scalar, G1_ELEMENT_BYTE_LENGTH,
 };
 use crate::groups::{
@@ -718,31 +718,31 @@ fn test_g1_to_from_uncompressed() {
 #[test]
 fn test_g1_sum() {
     // Empty sum
-    assert_eq!(sum_uncompressed(&[]).unwrap(), G1Element::zero());
+    assert_eq!(sum_g1_uncompressed(&[]).unwrap(), G1Element::zero());
 
     // Non-trivial sum
     let a = G1Element::generator();
     let b = G1Element::generator() * Scalar::from(2u128);
     let c = G1Element::generator() * Scalar::from(3u128);
     let mut bytes: Vec<G1ElementUncompressed> = vec![(&a).into(), (&b).into(), (&c).into()];
-    let sum = sum_uncompressed(&bytes).unwrap();
+    let sum = sum_g1_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::generator() * Scalar::from(6u128));
 
     // Adding zeros doesn't change anything
     bytes.push(G1ElementUncompressed::from(&G1Element::zero()));
-    let sum = sum_uncompressed(&bytes).unwrap();
+    let sum = sum_g1_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::generator() * Scalar::from(6u128));
 
     // Singleton sum
     let bytes = [(&b).into()];
-    let sum = sum_uncompressed(&bytes).unwrap();
+    let sum = sum_g1_uncompressed(&bytes).unwrap();
     assert_eq!(sum, b);
 
     // Adding zero's
     let mut bytes = vec![G1ElementUncompressed::from(&G1Element::zero())];
-    let sum = sum_uncompressed(&bytes).unwrap();
+    let sum = sum_g1_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::zero());
     bytes.push(G1ElementUncompressed::from(&G1Element::zero()));
-    let sum = sum_uncompressed(&bytes).unwrap();
+    let sum = sum_g1_uncompressed(&bytes).unwrap();
     assert_eq!(sum, G1Element::zero());
 }

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -704,6 +704,11 @@ fn test_g1_sum() {
     let sum = G1ElementUncompressed::sum(&bytes).unwrap();
     assert_eq!(sum, G1Element::generator() * Scalar::from(6u128));
 
+    // Equal elements in sum
+    let bytes = vec![(&b).into(), (&b).into()];
+    let sum = G1ElementUncompressed::sum(&bytes).unwrap();
+    assert_eq!(sum, G1Element::generator() * Scalar::from(4u128));
+
     // Singleton sum
     let bytes = [(&b).into()];
     let sum = G1ElementUncompressed::sum(&bytes).unwrap();

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -15,11 +15,7 @@ use crate::test_helpers::verify_serialization;
 use crate::traits::Signer;
 use crate::traits::VerifyingKey;
 use crate::traits::{KeyPair, ToFromBytes};
-use blst::{
-    blst_p1_affine, blst_p1_affine_generator, blst_p1_affine_on_curve, blst_p1_affine_serialize,
-    blst_p1_deserialize, blst_p2_affine, blst_p2_affine_generator, blst_p2_affine_on_curve,
-    blst_p2_affine_serialize, blst_p2_deserialize, BLST_ERROR,
-};
+use blst::{blst_p1_affine, blst_p1_affine_generator, blst_p1_affine_on_curve, blst_p1_affine_serialize, blst_p1_deserialize, blst_p2_affine, blst_p2_affine_generator, blst_p2_affine_on_curve, blst_p2_affine_serialize, blst_p2_deserialize, BLST_ERROR};
 use rand::{rngs::StdRng, thread_rng, RngCore, SeedableRng as _};
 
 const MSG: &[u8] = b"test message";
@@ -673,6 +669,16 @@ fn test_g1_to_from_uncompressed() {
     // Infinity bit flag (2) should not be set.
     assert_eq!(uncompressed_bytes[0] & 0x40, 0);
 
+    // All zeros should fail
+    assert!(
+        G1Element::from_trusted_uncompressed_bytes(&[0u8; G1_ELEMENT_BYTE_LENGTH * 2]).is_err()
+    );
+
+    // A point not on the curve fails
+    let mut invalid_uncompressed = uncompressed_bytes;
+    invalid_uncompressed[1] += 1;
+    assert!(G1Element::from_trusted_uncompressed_bytes(&invalid_uncompressed).is_err());
+
     // A vector with the first half being the compressed bytes and the second half being zeros should fail
     let mut compressed_bytes = a.to_byte_array();
     let mut extended_compressed_bytes = compressed_bytes.to_vec();
@@ -722,6 +728,11 @@ fn test_g2_to_from_uncompressed() {
 
     // Infinity bit flag (2) should not be set.
     assert_eq!(uncompressed_bytes[0] & 0x40, 0);
+
+    // A point not on the curve fails
+    let mut invalid_uncompressed = uncompressed_bytes;
+    invalid_uncompressed[1] += 1;
+    assert!(G2Element::from_trusted_uncompressed_bytes(&invalid_uncompressed).is_err());
 
     // A vector with the first half being the compressed bytes and the second half being zeros should fail
     let mut compressed_bytes = a.to_byte_array();

--- a/fastcrypto/src/tests/bls12381_group_tests.rs
+++ b/fastcrypto/src/tests/bls12381_group_tests.rs
@@ -659,7 +659,7 @@ fn test_serialization_gt() {
 
 #[test]
 fn test_g1_to_uncompressed() {
-    let a = G1Element::generator();
+    let a = G1Element::generator() * Scalar::from(7u128);
 
     let uncompressed_bytes = G1ElementUncompressed::from(&a);
 
@@ -669,6 +669,10 @@ fn test_g1_to_uncompressed() {
     // Infinity bit flag (2) should not be set.
     assert_eq!(uncompressed_bytes.0[0] & 0x40, 0);
 
+    // Regression test
+    assert_eq!(&uncompressed_bytes.0, hex::decode("1928f3beb93519eecf0145da903b40a4c97dca00b21f12ac0df3be9116ef2ef27b2ae6bcd4c5bc2d54ef5a70627efcb7108dadbaa4b636445639d5ae3089b3c43a8a1d47818edd1839d7383959a41c10fdc66849cfa1b08c5a11ec7e28981a1c").unwrap().as_slice());
+
+    // Serialize the point-at-infinity
     let a = G1Element::zero();
     let uncompressed_bytes = G1ElementUncompressed::from(&a);
 


### PR DESCRIPTION
Adds a method to deserialize from uncompressed serialization format for G1 elements in the BLS12381 construction and add them together. This is much faster than if we first have to decompress each term:
```
Sum/BLS12381-G1/500 uncompressed
                        time:   [233.90 µs 234.58 µs 235.34 µs]

Sum/BLS12381-G1/500 compressed
                        time:   [6.2162 ms 6.2344 ms 6.2557 ms]
```
  