### PR TITLE
Upgrade blst to v0.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",

--- a/fastcrypto/Cargo.toml
+++ b/fastcrypto/Cargo.toml
@@ -32,7 +32,7 @@ p256 = { version = "0.13.2", features = ["ecdsa"] }
 ecdsa = { version = "0.16.6", features = ["rfc6979", "verifying"] }
 rfc6979 = "0.4.0"
 blake2 = "0.10.6"
-blst = { version = "0.3.11", features = ["no-threads"] }
+blst = { version = "0.3.13", features = ["no-threads"] }
 digest.workspace = true
 once_cell = "1.17.0"
 readonly = "0.2.3"


### PR DESCRIPTION
Upgrade `blst` to fix building on MacOS 15.11 issue.

```
cargo:warning=/var/folders/_4/1ghtd3z15qjcw8yj905dcql40000gn/T/assembly-1bb0d2.s:8561:1: error: invalid CFI advance_loc expression
cargo:warning=.cfi_adjust_cfa_offset 8
cargo:warning=^
```

