### PR TITLE
Add Schnorr acc. to BIB-0340

### DIFF
--- a/fastcrypto/src/bulletproofs.rs
+++ b/fastcrypto/src/bulletproofs.rs
@@ -31,9 +31,6 @@ use crate::{
     error::FastCryptoError, serialize_deserialize_with_to_from_byte_array, traits::ToFromBytes,
 };
 
-use serde::de;
-use serde::Deserialize;
-
 //
 // Pedersen commitments
 //

--- a/fastcrypto/src/groups/bls12381.rs
+++ b/fastcrypto/src/groups/bls12381.rs
@@ -30,7 +30,6 @@ use blst::{
 use fastcrypto_derive::GroupOpsExtend;
 use hex_literal::hex;
 use once_cell::sync::OnceCell;
-use serde::{de, Deserialize};
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 use std::ptr;

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -22,7 +22,6 @@ use curve25519_dalek_ng::scalar::Scalar as ExternalRistrettoScalar;
 use curve25519_dalek_ng::traits::{Identity, VartimeMultiscalarMul};
 use derive_more::{Add, Div, From, Neg, Sub};
 use fastcrypto_derive::GroupOpsExtend;
-use serde::{de, Deserialize};
 use std::ops::{Add, Div, Mul};
 use zeroize::Zeroize;
 

--- a/fastcrypto/src/groups/secp256k1.rs
+++ b/fastcrypto/src/groups/secp256k1.rs
@@ -22,7 +22,6 @@ use k256::elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::elliptic_curve::Group as GroupTrait;
 use k256::Secp256k1;
-use num_bigint::BigUint;
 use serde::{de, Deserialize};
 use std::ops::{Div, Mul};
 
@@ -238,13 +237,9 @@ mod schnorr {
     use crate::error::{FastCryptoError, FastCryptoResult};
     use crate::groups::secp256k1::{ProjectivePoint, Scalar};
     use crate::groups::GroupElement;
-    use crate::hash::{HashFunction, Sha256};
     use ark_ec::{AffineRepr, CurveGroup};
     use ark_ff::{BigInteger, PrimeField};
     use ark_secp256k1::{Affine, Fq, Fr, Projective};
-    use digest::Mac;
-    use k256::ecdsa::signature::Signer;
-    use k256::ecdsa::signature::Verifier;
     use num_bigint::BigUint;
 
     fn hash(name: &str, data: &[u8]) -> [u8; 32] {

--- a/fastcrypto/src/groups/secp256k1.rs
+++ b/fastcrypto/src/groups/secp256k1.rs
@@ -289,9 +289,9 @@ pub mod schnorr {
     use crate::groups::secp256k1::schnorr::Tag::{Aux, Challenge, Nonce};
     use crate::groups::secp256k1::{ProjectivePoint, Scalar};
     use crate::groups::GroupElement;
-    use crate::{hash, serialize_deserialize_with_to_from_byte_array};
     use crate::hash::HashFunction;
     use crate::serde_helpers::ToFromByteArray;
+    use crate::{hash, serialize_deserialize_with_to_from_byte_array};
 
     pub const SIGNATURE_SIZE_IN_BYTES: usize = 64;
     pub const PUBLIC_KEY_SIZE_IN_BYTES: usize = 32;
@@ -354,7 +354,9 @@ pub mod schnorr {
     }
 
     impl ToFromByteArray<PUBLIC_KEY_SIZE_IN_BYTES> for SchnorrPublicKey {
-        fn from_byte_array(bytes: &[u8; PUBLIC_KEY_SIZE_IN_BYTES]) -> Result<Self, FastCryptoError> {
+        fn from_byte_array(
+            bytes: &[u8; PUBLIC_KEY_SIZE_IN_BYTES],
+        ) -> Result<Self, FastCryptoError> {
             Ok(SchnorrPublicKey(
                 ProjectivePoint::with_even_y_from_x_be_bytes(bytes)?,
             ))
@@ -382,7 +384,9 @@ pub mod schnorr {
     }
 
     impl ToFromByteArray<PRIVATE_KEY_SIZE_IN_BYTES> for SchnorrPrivateKey {
-        fn from_byte_array(bytes: &[u8; PRIVATE_KEY_SIZE_IN_BYTES]) -> Result<Self, FastCryptoError> {
+        fn from_byte_array(
+            bytes: &[u8; PRIVATE_KEY_SIZE_IN_BYTES],
+        ) -> Result<Self, FastCryptoError> {
             SchnorrPrivateKey::try_from(Scalar::from_byte_array(bytes)?)
         }
 
@@ -513,21 +517,27 @@ pub mod schnorr {
         }
 
         fn test_valid_test_vector(v: ValidTestVector) {
-            let sk = SchnorrPrivateKey::from_byte_array(
-                &hex::decode(v.sk).unwrap().try_into().unwrap(),
-            )
-                .unwrap();
-            let pk = SchnorrPublicKey::from_byte_array(
-                &hex::decode(v.pk).unwrap().try_into().unwrap(),
-            ).unwrap();
-            assert_eq!(SchnorrPublicKey::from(&sk).0, pk.0, "Public key does not match private key");
+            let sk =
+                SchnorrPrivateKey::from_byte_array(&hex::decode(v.sk).unwrap().try_into().unwrap())
+                    .unwrap();
+            let pk =
+                SchnorrPublicKey::from_byte_array(&hex::decode(v.pk).unwrap().try_into().unwrap())
+                    .unwrap();
+            assert_eq!(
+                SchnorrPublicKey::from(&sk).0,
+                pk.0,
+                "Public key does not match private key"
+            );
 
             let aux_rand = hex::decode(v.aux_rand).unwrap();
             let msg = hex::decode(v.msg).unwrap();
             let expected_signature = hex::decode(v.signature).unwrap();
             let signature = sk.sign(&msg, &aux_rand).unwrap();
             let signature_bytes = signature.to_byte_array();
-            assert_eq!(expected_signature, signature_bytes, "Signature does not match expected signature");
+            assert_eq!(
+                expected_signature, signature_bytes,
+                "Signature does not match expected signature"
+            );
         }
 
         #[test]

--- a/fastcrypto/src/groups/secp256k1.rs
+++ b/fastcrypto/src/groups/secp256k1.rs
@@ -12,7 +12,7 @@ use crate::serde_helpers::ToFromByteArray;
 use crate::serialize_deserialize_with_to_from_byte_array;
 use crate::traits::AllowedRng;
 use ark_ec::{Group, ScalarMul, VariableBaseMSM};
-use ark_ff::{Field, One, UniformRand, Zero};
+use ark_ff::{BigInt, Field, One, PrimeField, UniformRand, Zero};
 use ark_secp256k1::{Affine, Fq, Fr, Projective};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use derive_more::{Add, From, Neg, Sub};
@@ -22,6 +22,7 @@ use k256::elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::elliptic_curve::Group as GroupTrait;
 use k256::Secp256k1;
+use num_bigint::BigUint;
 use serde::{de, Deserialize};
 use std::ops::{Div, Mul};
 
@@ -150,6 +151,17 @@ impl HashToGroupElement for ProjectivePoint {
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, From, Add, Sub, Neg, GroupOpsExtend)]
 pub struct Scalar(pub(crate) Fr);
 
+impl Scalar {
+    /// Create a scalar from a big-endian byte representation, reducing it modulo the group order if necessary.
+    pub fn from_bytes_mod_order(bytes: &[u8; SCALAR_SIZE_IN_BYTES]) -> Self {
+        Scalar(Fr::from_be_bytes_mod_order(bytes.as_slice()))
+    }
+
+    pub fn as_big_uint(&self) -> BigInt<4> {
+        self.0.into_bigint()
+    }
+}
+
 impl GroupElement for Scalar {
     type ScalarType = Scalar;
 
@@ -221,3 +233,218 @@ impl ToLittleEndianBytes for Scalar {
 }
 
 serialize_deserialize_with_to_from_byte_array!(Scalar);
+
+mod schnorr {
+    use crate::groups::secp256k1::{ProjectivePoint, Scalar};
+    use crate::groups::GroupElement;
+    use crate::hash::{HashFunction, Sha256};
+    use ark_ec::{AffineRepr, CurveGroup};
+    use ark_ff::{BigInteger, PrimeField};
+    use ark_secp256k1::{Affine, Fq, Fr, Projective};
+    use digest::Mac;
+    use k256::ecdsa::signature::Signer;
+    use k256::ecdsa::signature::Verifier;
+    use num_bigint::BigUint;
+
+    fn hash(name: &str, data: &[u8]) -> [u8; 32] {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        let tag_hash = sha2::Sha256::digest(name.as_bytes());
+        hasher.update(&tag_hash);
+        hasher.update(&tag_hash);
+        hasher.update(data);
+        hasher.finalize().into()
+    }
+
+    fn hash_to_scalar(name: &str, data: &[u8]) -> Scalar {
+        Scalar::from_bytes_mod_order(&hash(name, data))
+    }
+
+    fn int(be_bytes: &[u8; 32]) -> Option<Scalar> {
+        let x = BigUint::from_bytes_be(be_bytes);
+        match Fr::try_from(x) {
+            Ok(x) => Some(Scalar(x)),
+            Err(_) => None,
+        }
+    }
+
+    fn x(point: &ProjectivePoint) -> [u8; 32] {
+        let affine = point.0.into_affine();
+        affine
+            .x()
+            .unwrap()
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap()
+    }
+
+    fn y(point: &ProjectivePoint) -> [u8; 32] {
+        let affine = point.0.into_affine();
+        affine
+            .y()
+            .unwrap()
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap()
+    }
+
+    fn bytes_point(point: &ProjectivePoint) -> [u8; 32] {
+        x(point)
+    }
+
+    fn bytes_scalar(scalar: &Scalar) -> [u8; 32] {
+        scalar.0.into_bigint().to_bytes_be().try_into().unwrap()
+    }
+
+    fn has_even_y(point: &ProjectivePoint) -> bool {
+        let affine = point.0.into_affine();
+        affine.y().unwrap().into_bigint().is_even()
+    }
+
+    fn lift_x(x: &[u8; 32]) -> Option<ProjectivePoint> {
+        let x = BigUint::from_bytes_be(x);
+        match Fq::try_from(x) {
+            Ok(x) => match Affine::get_ys_from_x_unchecked(x.clone()) {
+                Some((y1, y2)) => {
+                    // y2 = n - y1 so one of them must be even
+                    let even_y = if y1.clone().into_bigint().is_even() {
+                        y1
+                    } else {
+                        y2
+                    };
+                    Some(ProjectivePoint(Projective::from(Affine::new(x, even_y))))
+                }
+                None => None,
+            },
+            Err(_) => None,
+        }
+    }
+
+    fn xor(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
+        let mut res = [0u8; 32];
+        for i in 0..32 {
+            res[i] = a[i] ^ b[i];
+        }
+        res
+    }
+
+    fn sign(sk: &Scalar, msg: &[u8], aad: &[u8]) -> Option<(ProjectivePoint, Scalar)> {
+        println!("msg: {}", hex::encode(msg));
+        println!("aad: {}", hex::encode(aad));
+        let p = ProjectivePoint::generator() * *sk;
+        let d = if has_even_y(&p) { *sk } else { -*sk };
+
+        let aux_hash = hash("BIP0340/aux", aad);
+        println!("aux hash: {}", hex::encode(aux_hash));
+        let t = xor(&bytes_scalar(&d), &aux_hash);
+        println!("t: {}", hex::encode(t));
+
+        let k_prime = hash_to_scalar("BIP0340/nonce", &[&t, &bytes_point(&p), msg].concat());
+        println!("k': {}", hex::encode(bytes_scalar(&k_prime)));
+        if k_prime.as_big_uint().is_zero() {
+            return None;
+        }
+
+        let r = ProjectivePoint::generator() * k_prime;
+        println!("R: ({}, {})", hex::encode(x(&r)), hex::encode(y(&r)));
+        let k = if has_even_y(&r) { k_prime } else { -k_prime };
+        println!("k: {}", hex::encode(bytes_scalar(&k)));
+        let e = hash_to_scalar(
+            "BIP0340/challenge",
+            &[&bytes_point(&r), &bytes_point(&p), msg].concat(),
+        );
+        println!("e: {}", hex::encode(bytes_scalar(&e)));
+
+        let s = k + e * d;
+        println!("s: {}", hex::encode(bytes_scalar(&s)));
+
+        Some((r, s))
+    }
+
+    fn signature_bytes((r, s): &(ProjectivePoint, Scalar)) -> [u8; 64] {
+        [bytes_point(r), bytes_scalar(s)]
+            .concat()
+            .try_into()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_generator() {
+        let x_bytes: [u8; 32] =
+            hex::decode("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let y_bytes: [u8; 32] =
+            hex::decode("483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8")
+                .unwrap()
+                .try_into()
+                .unwrap();
+
+        // Test that the generator is aligned with the specs.
+        assert_eq!(x_bytes, x(&ProjectivePoint::generator()));
+        assert_eq!(y_bytes, y(&ProjectivePoint::generator()));
+        assert!(has_even_y(&ProjectivePoint::generator()));
+
+        assert_eq!(lift_x(&x_bytes), Some(ProjectivePoint::generator()));
+    }
+
+    #[test]
+    fn reference() {
+        let sk = k256::schnorr::SigningKey::from_bytes(
+            &hex::decode("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF")
+                .unwrap(),
+        )
+        .unwrap();
+        let pk = k256::schnorr::VerifyingKey::from_bytes(
+            &hex::decode("DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659")
+                .unwrap(),
+        )
+        .unwrap();
+
+        let aux_rand =
+            hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let msg = hex::decode("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let signature = sk.try_sign_prehashed(&msg, &aux_rand).unwrap();
+        assert!(pk.verify_prehashed(&msg, &signature).is_ok());
+
+        let expected_signature = hex::decode("6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A").unwrap();
+        assert_eq!(signature.as_bytes().to_vec(), expected_signature);
+    }
+
+    #[test]
+    fn test_schnorr() {
+        // Test vector 1 from https://github.com/bitcoin/bips/blob/master/bip-0340/test-vectors.csv
+        let sk = int(&hex::decode(
+            "B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF",
+        )
+        .unwrap()
+        .try_into()
+        .unwrap())
+        .unwrap();
+        let pk = lift_x(
+            &hex::decode("DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659")
+                .unwrap()
+                .try_into()
+                .unwrap(),
+        );
+        let aux_rand =
+            hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let msg = hex::decode("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
+            .unwrap();
+        let expected_signature = hex::decode("6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A").unwrap();
+
+        let signature = sign(&sk, &msg, &aux_rand).unwrap();
+        let signature_bytes = signature_bytes(&signature);
+        assert_eq!(expected_signature, signature_bytes);
+    }
+}

--- a/fastcrypto/src/groups/secp256k1.rs
+++ b/fastcrypto/src/groups/secp256k1.rs
@@ -343,7 +343,8 @@ pub mod schnorr {
 
     serialize_deserialize_with_to_from_byte_array!(SchnorrSignature);
 
-    /// A Schnorr public key as defined in BIP-340. The point cannot be the point at infinity.
+    /// A Schnorr public key as defined in BIP-340.
+    /// The point cannot be the point at infinity and the y-coordinate must be even.
     pub struct SchnorrPublicKey(ProjectivePoint);
 
     impl TryFrom<&ProjectivePoint> for SchnorrPublicKey {

--- a/fastcrypto/src/groups/secp256r1.rs
+++ b/fastcrypto/src/groups/secp256r1.rs
@@ -16,7 +16,6 @@ use ark_secp256r1::{Fr, Projective};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use derive_more::{Add, From, Neg, Sub};
 use fastcrypto_derive::GroupOpsExtend;
-use serde::{de, Deserialize};
 use std::ops::{Div, Mul};
 
 pub const SCALAR_SIZE_IN_BYTES: usize = 32;

--- a/fastcrypto/src/serde_helpers.rs
+++ b/fastcrypto/src/serde_helpers.rs
@@ -100,9 +100,9 @@ macro_rules! serialize_deserialize_with_to_from_byte_array {
                     true => {
                         let s = String::deserialize(deserializer)?;
                         let decoded = Base64::decode(&s)
-                            .map_err(|_| de::Error::custom("Base64 decoding failed"))?;
+                            .map_err(|_| ::serde::de::Error::custom("Base64 decoding failed"))?;
                         if decoded.len() != { <$type>::BYTE_LENGTH } {
-                            return Err(de::Error::custom(format!(
+                            return Err(::serde::de::Error::custom(format!(
                                 "Invalid buffer length {}, expecting {}",
                                 decoded.len(),
                                 { <$type>::BYTE_LENGTH }
@@ -112,12 +112,12 @@ macro_rules! serialize_deserialize_with_to_from_byte_array {
                     }
                     false => {
                         let helper: SerializationHelper<{ <$type>::BYTE_LENGTH }> =
-                            Deserialize::deserialize(deserializer)?;
+                            ::serde::Deserialize::deserialize(deserializer)?;
                         helper.0
                     }
                 };
                 Self::from_byte_array(&bytes)
-                    .map_err(|_| de::Error::custom("Failed in reconstructing the object"))
+                    .map_err(|_| ::serde::de::Error::custom("Failed in reconstructing the object"))
             }
         }
     };

--- a/fastcrypto/src/tests/secp256k1_group_tests.rs
+++ b/fastcrypto/src/tests/secp256k1_group_tests.rs
@@ -43,7 +43,7 @@ fn test_regression() {
     let scalar = secp256k1::Scalar::from(7);
     assert_eq!(
         scalar.to_byte_array().to_vec(),
-        hex::decode("0700000000000000000000000000000000000000000000000000000000000000").unwrap()
+        hex::decode("0000000000000000000000000000000000000000000000000000000000000007").unwrap()
     );
 
     let point = ProjectivePoint::generator() * scalar;


### PR DESCRIPTION
Implement Schnorr signatures according the the Bitcoin specs: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki

It's tested that it follows the test vectors in https://github.com/bitcoin/bips/blob/master/bip-0340/test-vectors.csv.

Note that this does _not_ implement the `Authenticator` trait like the other signature schemes in fastcrypto since I don't think we're going to use it in Sui and because the `as_ref` trait is a bit hard to work with, but it wouldn't be too much work to do that.