### PR TITLE
[bench] Add multi-pairing benchmarks

### DIFF
--- a/fastcrypto/benches/groups.rs
+++ b/fastcrypto/benches/groups.rs
@@ -233,7 +233,36 @@ mod group_benches {
 
     fn pairing(c: &mut Criterion) {
         let mut group: BenchmarkGroup<_> = c.benchmark_group("Pairing");
-        pairing_single::<G1Element, _>("BLS12381-G1", &mut group);
+        pairing_single::<G1Element, _>("BLS12381", &mut group);
+    }
+
+    fn multi_pairing_impl<G: GroupElement + Pairing, M: measurement::Measurement>(
+        name: &str,
+        len: usize,
+        c: &mut BenchmarkGroup<M>,
+    )
+    where <G as Pairing>::Output: GroupElement
+    {
+        let (ps, qs): (Vec<G>, Vec<G::Other>) =
+            (0..len)
+                .map(|_| {
+                    (
+                        G::generator() * G::ScalarType::rand(&mut thread_rng()),
+                        G::Other::generator()
+                            * <<G as Pairing>::Other as GroupElement>::ScalarType::rand(&mut thread_rng())
+                    )
+                })
+                .unzip();
+        c.bench_function(&format!("{}/{}", name.to_string(), len), move |b| b.iter(|| G::multi_pairing(&ps, &qs)));
+    }
+
+    fn multi_pairing(c: &mut Criterion) {
+        static NUMBER_OF_INPUTS: [usize; 3] = [2, 4, 8];
+        let mut group: BenchmarkGroup<_> = c.benchmark_group("Multi-Pairing");
+
+        for n in NUMBER_OF_INPUTS {
+            multi_pairing_impl::<G1Element, _>("BLS12381", n, &mut group);
+        }
     }
 
     fn sum(c: &mut Criterion) {
@@ -365,6 +394,7 @@ mod group_benches {
             scale,
             hash_to_group,
             pairing,
+            multi_pairing,
             double_scale,
             msm,
             sum,


### PR DESCRIPTION
This PR:
- adds multi-pairing benchmarks. I was initially mislead by https://github.com/MystenLabs/fastcrypto/blob/91ce23c3af86165d32af9f462d2cc18f3fae7a9f/fastcrypto/src/groups/mod.rs#L74-L98 and thought the library wasn't using BLST's multipairing facilities
- change the pairing bench description from "BLS12381 G1" to just "BLS12381" as pairings actually use all groups G1, G2, GT