### PR TITLE
fix: eliminate unwrap() calls and improve KeyPair API consistency

### DIFF
--- a/fastcrypto/src/bls12381/mod.rs
+++ b/fastcrypto/src/bls12381/mod.rs
@@ -469,14 +469,18 @@ macro_rules! define_bls12381 {
             }
 
             fn private(self) -> Self::PrivKey {
-                BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap()
+                self.private
             }
 
             #[cfg(feature = "copy_key")]
             fn copy(&self) -> Self {
+                // Note: The copy_key feature explicitly allows copying private keys for specific use cases.
+                // This reconstructs the private key from bytes, which should never fail for a valid keypair.
+                let private_bytes = self.private.as_ref();
                 BLS12381KeyPair {
                     public: self.public.clone(),
-                    private: BLS12381PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+                    private: BLS12381PrivateKey::from_bytes(private_bytes)
+                        .expect("KeyPair should always contain valid private key bytes"),
                 }
             }
 

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -170,14 +170,18 @@ impl KeyPair for Ed25519KeyPair {
     }
 
     fn private(self) -> Self::PrivKey {
-        Ed25519PrivateKey::from_bytes(self.private.as_ref()).unwrap()
+        self.private
     }
 
     #[cfg(feature = "copy_key")]
     fn copy(&self) -> Self {
+        // Note: The copy_key feature explicitly allows copying private keys for specific use cases.
+        // This reconstructs the private key from bytes, which should never fail for a valid keypair.
+        let private_bytes = self.private.as_ref();
         Self {
-            public: Ed25519PublicKey::from_bytes(self.public.as_ref()).unwrap(),
-            private: Ed25519PrivateKey::from_bytes(self.private.as_ref()).unwrap(),
+            public: self.public.clone(),
+            private: Ed25519PrivateKey::from_bytes(private_bytes)
+                .expect("KeyPair should always contain valid private key bytes"),
         }
     }
 


### PR DESCRIPTION
   Security improvements:
   - Replace unwrap() with expect() in copy() methods to provide clear error messages
   - Remove unnecessary from_bytes() reconstruction in private() methods
   - Add safety comments explaining copy_key feature usage

   API improvements:
   - Move signing methods from KeyPair to PrivateKey in secp256k1 module
   - Standardize field naming (secret -> private) across all key pair types
   - Ensure consistent KeyPair trait implementation patterns

   Performance improvements:
   - Make private() method O(1) by returning owned field directly
   - Eliminate redundant serialization/deserialization operations

   Affects: BLS12381KeyPair, Ed25519KeyPair, Secp256k1KeyPair