### PR TITLE
Reinstate test_get_jwks as part of zk-login-e2e flow

### DIFF
--- a/fastcrypto-zkp/src/bn254/unit_tests/zk_login_e2e_tests.rs
+++ b/fastcrypto-zkp/src/bn254/unit_tests/zk_login_e2e_tests.rs
@@ -368,3 +368,37 @@ async fn test_end_to_end_test_issuer(test_input: TestInputStruct) {
     }
     .await;
 }
+
+#[tokio::test]
+async fn test_get_jwks() {
+    let client = reqwest::Client::new();
+    for p in [
+        OIDCProvider::Facebook,
+        OIDCProvider::Google,
+        OIDCProvider::Twitch,
+        OIDCProvider::Slack,
+        OIDCProvider::Kakao,
+        OIDCProvider::Apple,
+        OIDCProvider::Microsoft,
+        OIDCProvider::KarrierOne,
+        OIDCProvider::Credenza3,
+        OIDCProvider::Playtron,
+        OIDCProvider::Threedos,
+        OIDCProvider::Onefc,
+        OIDCProvider::FanTV,
+        // OIDCProvider::Arden, // TODO: disabling until the service is up again
+        OIDCProvider::EveFrontier,
+        OIDCProvider::TestEveFrontier,
+        OIDCProvider::AwsTenant(("eu-west-3".to_string(), "eu-west-3_gGVCx53Es".to_string())), //Trace
+        OIDCProvider::AwsTenant((
+            "ap-southeast-1".to_string(),
+            "ap-southeast-1_2QQPyQXDz".to_string(),
+        )), // Decot
+    ] {
+        let res = fetch_jwks(&p, &client, true).await;
+        assert!(res.is_ok());
+        res.unwrap().iter().for_each(|e| {
+            assert_eq!(e.0.iss, p.get_config().iss);
+        });
+    }
+}

--- a/fastcrypto-zkp/src/bn254/unit_tests/zk_login_e2e_tests.rs
+++ b/fastcrypto-zkp/src/bn254/unit_tests/zk_login_e2e_tests.rs
@@ -381,7 +381,7 @@ async fn test_get_jwks() {
         OIDCProvider::Apple,
         OIDCProvider::Microsoft,
         OIDCProvider::KarrierOne,
-        OIDCProvider::Credenza3,
+        // OIDCProvider::Credenza3, // TODO: disabling until Cloudflare challenge is removed from JWK endpoint
         OIDCProvider::Playtron,
         OIDCProvider::Threedos,
         OIDCProvider::Onefc,
@@ -396,7 +396,12 @@ async fn test_get_jwks() {
         )), // Decot
     ] {
         let res = fetch_jwks(&p, &client, true).await;
-        assert!(res.is_ok());
+        assert!(
+            res.is_ok(),
+            "fetch_jwks failed for {:?}: {:?}",
+            p,
+            res.err()
+        );
         res.unwrap().iter().for_each(|e| {
             assert_eq!(e.0.iss, p.get_config().iss);
         });


### PR DESCRIPTION
The test_get_jwks test was removed in https://github.com/MystenLabs/fastcrypto/commit/4d2550a9833b3e686a94b823271e38063d309243.