### PR TITLE
Add hash_to_ristretto255 following RFC 9380

### DIFF
--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -120,7 +120,7 @@ pub trait FiatShamirChallenge {
 }
 
 /// Trait for groups that have a standardized "hash_to_point"/"hash_to_curve" function (see
-/// [https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve#section-3].
+/// [RFC 9380, section 3](https://www.rfc-editor.org/rfc/rfc9380.html#section-3)).
 pub trait HashToGroupElement {
     /// Hashes the given message and maps the result to a group element.
     fn hash_to_group_element(msg: &[u8]) -> Self;

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -23,10 +23,10 @@ use curve25519_dalek::scalar::Scalar as ExternalScalar;
 use curve25519_dalek::traits::{Identity, VartimeMultiscalarMul};
 use derive_more::{Add, Div, Neg, Sub};
 use elliptic_curve::group::GroupEncoding;
+use elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, Expander};
 use elliptic_curve::Field;
 use fastcrypto_derive::GroupOpsExtend;
 use std::ops::{Add, Div, Mul};
-use elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, Expander};
 use zeroize::Zeroize;
 
 pub const RISTRETTO_POINT_BYTE_LENGTH: usize = 32;
@@ -51,13 +51,9 @@ impl RistrettoPoint {
     /// following the specifications in [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B).
     pub fn hash_to_ristretto255(msg: &[u8]) -> Self {
         let mut bytes = [0u8; 64];
-        let mut expanded_message = ExpandMsgXmd::<
-            <Sha512 as ReverseWrapper>::Variant,
-        >::expand_message(
-            &[msg],
-            &[DST],
-            64,
-        ).unwrap();
+        let mut expanded_message =
+            ExpandMsgXmd::<<Sha512 as ReverseWrapper>::Variant>::expand_message(&[msg], &[DST], 64)
+                .unwrap();
         expanded_message.fill_bytes(&mut bytes);
         Self::from_uniform_bytes(&bytes)
     }

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -10,7 +10,7 @@ use crate::groups::{
     Doubling, FiatShamirChallenge, FromTrustedByteArray, GroupElement, HashToGroupElement,
     MultiScalarMul, Scalar,
 };
-use crate::hash::Sha512;
+use crate::hash::{ReverseWrapper, Sha512};
 use crate::serde_helpers::ToFromByteArray;
 use crate::traits::AllowedRng;
 use crate::{
@@ -26,10 +26,12 @@ use elliptic_curve::group::GroupEncoding;
 use elliptic_curve::Field;
 use fastcrypto_derive::GroupOpsExtend;
 use std::ops::{Add, Div, Mul};
+use elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, Expander};
 use zeroize::Zeroize;
 
 pub const RISTRETTO_POINT_BYTE_LENGTH: usize = 32;
 pub const RISTRETTO_SCALAR_BYTE_LENGTH: usize = 32;
+pub const DST: &[u8] = b"ristretto255_XMD:SHA-512_R255MAP_RO_";
 
 /// Represents a point in the Ristretto group for Curve25519.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Add, Sub, Neg, GroupOpsExtend)]
@@ -39,8 +41,25 @@ impl RistrettoPoint {
     /// Construct a RistrettoPoint from the given data using a Ristretto-flavoured Elligator 2 map.
     /// If the input bytes are uniformly distributed, the resulting point will be uniformly
     /// distributed over the Ristretto group.
+    ///
+    /// This is called `ristretto255_map` in RFC9380 and is defined in the [RFC9496 draft](https://www.rfc-editor.org/rfc/rfc9496.html#name-element-derivation).
     pub fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
         RistrettoPoint(ExternalPoint::from_uniform_bytes(bytes))
+    }
+
+    /// Implementation of `hash_to_ristretto255` using the `ristretto255_XMD:SHA-512_R255MAP_RO_` suite,
+    /// following the specifications in [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B).
+    pub fn hash_to_ristretto255(msg: &[u8]) -> Self {
+        let mut bytes = [0u8; 64];
+        let mut expanded_message = ExpandMsgXmd::<
+            <Sha512 as ReverseWrapper>::Variant,
+        >::expand_message(
+            &[msg],
+            &[DST],
+            64,
+        ).unwrap();
+        expanded_message.fill_bytes(&mut bytes);
+        Self::from_uniform_bytes(&bytes)
     }
 }
 
@@ -94,6 +113,7 @@ impl GroupElement for RistrettoPoint {
 }
 
 impl HashToGroupElement for RistrettoPoint {
+    /// Hash the message using SHA-512 without any DST and derive a point as defined in [Self::from_uniform_bytes].
     fn hash_to_group_element(msg: &[u8]) -> Self {
         Self::from_uniform_bytes(&Sha512::digest(msg).digest)
     }

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -50,11 +50,18 @@ impl RistrettoPoint {
     /// Implementation of `hash_to_ristretto255` using the `ristretto255_XMD:SHA-512_R255MAP_RO_` suite,
     /// following the specifications in [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B).
     pub fn hash_to_ristretto255(msg: &[u8]) -> Self {
+        Self::hash_to_ristretto255_with_dst(&[msg], DST)
+    }
+
+    /// Map a message to a [RistrettoPoint] following [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B)
+    /// using `expand_message_xmd` with SHA-512 and the given domain separation tag.
+    pub fn hash_to_ristretto255_with_dst(msgs: &[&[u8]], dst: &[u8]) -> Self {
         let mut bytes = [0u8; 64];
-        let mut expanded_message =
-            ExpandMsgXmd::<<Sha512 as ReverseWrapper>::Variant>::expand_message(&[msg], &[DST], 64)
-                .unwrap();
-        expanded_message.fill_bytes(&mut bytes);
+        // expand_message only errors if the output length is out of bounds, which it is not here
+        // since it is a constant, so we can safely unwrap.
+        ExpandMsgXmd::<<Sha512 as ReverseWrapper>::Variant>::expand_message(msgs, &[dst], 64)
+            .unwrap()
+            .fill_bytes(&mut bytes);
         Self::from_uniform_bytes(&bytes)
     }
 }

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementations of the [ristretto255 group](https://www.ietf.org/archive/id/draft-irtf-cfrg-ristretto255-decaf448-03.html) which is a group of
+//! Implementations of the [ristretto255 group](https://www.rfc-editor.org/rfc/rfc9496.html) which is a group of
 //! prime order 2^{252} + 27742317777372353535851937790883648493 built over Curve25519.
 
 use crate::error::FastCryptoError::InvalidInput;
@@ -42,18 +42,18 @@ impl RistrettoPoint {
     /// If the input bytes are uniformly distributed, the resulting point will be uniformly
     /// distributed over the Ristretto group.
     ///
-    /// This is called `ristretto255_map` in RFC9380 and is defined in the [RFC9496 draft](https://www.rfc-editor.org/rfc/rfc9496.html#name-element-derivation).
+    /// This is called `ristretto255_map` in RFC 9380 and is defined in [RFC 9496, Section 4.3.4](https://www.rfc-editor.org/rfc/rfc9496.html#section-4.3.4).
     pub fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
         RistrettoPoint(ExternalPoint::from_uniform_bytes(bytes))
     }
 
     /// Implementation of `hash_to_ristretto255` using the `ristretto255_XMD:SHA-512_R255MAP_RO_` suite,
-    /// following the specifications in [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B).
+    /// following the specifications in [RFC 9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B).
     pub fn hash_to_ristretto255(msg: &[u8]) -> Self {
         Self::hash_to_ristretto255_with_dst(&[msg], DST)
     }
 
-    /// Map a message to a [RistrettoPoint] following [RFC9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B)
+    /// Map a message to a [RistrettoPoint] following [RFC 9380](https://www.rfc-editor.org/rfc/rfc9380.html#appendix-B)
     /// using `expand_message_xmd` with SHA-512 and the given domain separation tag.
     pub fn hash_to_ristretto255_with_dst(msgs: &[&[u8]], dst: &[u8]) -> Self {
         let mut bytes = [0u8; 64];

--- a/fastcrypto/src/tests/ristretto255_tests.rs
+++ b/fastcrypto/src/tests/ristretto255_tests.rs
@@ -6,6 +6,7 @@ use crate::groups::ristretto255::RistrettoScalar;
 use crate::groups::{GroupElement, HashToGroupElement, MultiScalarMul};
 use crate::serde_helpers::ToFromByteArray;
 use hex_literal::hex;
+use crate::encoding::{Encoding, Hex};
 
 pub(crate) const GROUP_ORDER: [u8; 32] = [
     237, 211, 245, 92, 26, 99, 18, 88, 214, 156, 247, 162, 222, 249, 222, 20, 0, 0, 0, 0, 0, 0, 0,
@@ -231,4 +232,22 @@ fn test_multiscalar_mul() {
         &[g, g, g]
     )
     .is_err());
+}
+
+#[test]
+fn test_hash_to_point() {
+    // Test vectors from @noble/curves using the ristretto255_XMD:SHA-512_R255MAP_RO_ suite
+    let test_vectors: &[(&[u8], &str)] = &[
+        (b"", "d2ef0e42a21c1b4221350ac82ad8669a18a0994df551ac07597a704a23d36436"),
+        (b"abc", "76a44d9dbe1079e8ca0637f69161de4b76e66d9604fc759c48e13bc5b30adc44"),
+        (b"abcdef0123456789", "086575a167ff6b9c0bbb90ef9a6c7498838188051f7f1f44db0d492b25b9db02"),
+        (b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq", "446e5de27a26ea681258dfb38af2ca7ce64aa832768375386372da7a1f92cd24"),
+        (b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bae7b0ae7e4e19d166ba57965ae3968d09a92c029befe7f96626dbdcdbadce18"),
+    ];
+
+    for (msg, expected_hex) in test_vectors {
+        let expected = Hex::decode(expected_hex).unwrap();
+        let actual = RistrettoPoint::hash_to_ristretto255(msg);
+        assert_eq!(expected, actual.to_byte_array(), "Failed for msg: {:?}", std::str::from_utf8(msg).unwrap_or("<invalid utf8>"));
+    }
 }

--- a/fastcrypto/src/tests/ristretto255_tests.rs
+++ b/fastcrypto/src/tests/ristretto255_tests.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::encoding::{Encoding, Hex};
 use crate::groups::ristretto255::RistrettoPoint;
 use crate::groups::ristretto255::RistrettoScalar;
 use crate::groups::{GroupElement, HashToGroupElement, MultiScalarMul};
 use crate::serde_helpers::ToFromByteArray;
 use hex_literal::hex;
-use crate::encoding::{Encoding, Hex};
 
 pub(crate) const GROUP_ORDER: [u8; 32] = [
     237, 211, 245, 92, 26, 99, 18, 88, 214, 156, 247, 162, 222, 249, 222, 20, 0, 0, 0, 0, 0, 0, 0,
@@ -248,6 +248,11 @@ fn test_hash_to_point() {
     for (msg, expected_hex) in test_vectors {
         let expected = Hex::decode(expected_hex).unwrap();
         let actual = RistrettoPoint::hash_to_ristretto255(msg);
-        assert_eq!(expected, actual.to_byte_array(), "Failed for msg: {:?}", std::str::from_utf8(msg).unwrap_or("<invalid utf8>"));
+        assert_eq!(
+            expected,
+            actual.to_byte_array(),
+            "Failed for msg: {:?}",
+            std::str::from_utf8(msg).unwrap_or("<invalid utf8>")
+        );
     }
 }

--- a/fastcrypto/src/tests/ristretto255_tests.rs
+++ b/fastcrypto/src/tests/ristretto255_tests.rs
@@ -107,7 +107,11 @@ fn test_serialize_deserialize_element() {
 
 #[test]
 fn test_vectors() {
-    // Test vectors from draft-irtf-cfrg-ristretto255-decaf448-03
+    // Test vectors for ristretto255 from RFC 9496 (https://www.rfc-editor.org/rfc/rfc9496.html),
+    // which supersedes draft-irtf-cfrg-ristretto255-decaf448-03:
+    // - VEC_MULGEN:  Appendix A.1 (multiples of the generator)
+    // - VEC_INVALID: Appendix A.2 (invalid encodings)
+    // - VEC_MAP:     Appendix A.3 (group elements from uniform byte strings, i.e. from_uniform_bytes)
     const VEC_MULGEN: [&str; 16] = [
         "0000000000000000000000000000000000000000000000000000000000000000",
         "e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76",

--- a/fastcrypto/src/tests/vrf_tests.rs
+++ b/fastcrypto/src/tests/vrf_tests.rs
@@ -5,7 +5,7 @@ use crate::encoding::{Encoding, Hex};
 use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::serde_helpers::ToFromByteArray;
 use crate::test_helpers::verify_serialization;
-use crate::vrf::ecvrf::{ECVRFKeyPair, ECVRFProof, ECVRFPublicKey};
+use crate::vrf::ecvrf::{ECVRFKeyPair, ECVRFPrivateKey, ECVRFProof, ECVRFPublicKey};
 use crate::vrf::{VRFKeyPair, VRFProof};
 use rand::thread_rng;
 
@@ -25,6 +25,28 @@ fn test_proof() {
     assert!(proof2.verify_output(input2, &kp.pk, &output2).is_ok());
 
     assert_ne!(output1, output2);
+}
+
+#[test]
+fn test_ecvrf_prove() {
+    let secret_key_bytes =
+        Hex::decode("b057530c45b7b0f4b96f9b21b011072b2a513f45dd9537ad796acf571055550f").unwrap();
+    let sk = bcs::from_bytes::<ECVRFPrivateKey>(&secret_key_bytes).unwrap();
+    let kp = ECVRFKeyPair::from(sk);
+
+    let input = Hex::decode("01020304").unwrap();
+    let (output, proof) = kp.output(&input);
+
+    assert_eq!(
+        "2640d12c11a372c726348d60ec74ac80320960ba541fb3e66af0a21590c0a75bf5ccf408d5070c5de77f87c733512f575b4a03511d0031dc2e78ab1582fbbef919b52732c8cb1f44b27ad1d1293dec0f",
+        Hex::encode(bcs::to_bytes(&proof).unwrap())
+    );
+    assert_eq!(
+        "84588b918a6c9f5b8b74e56a305bb1c2d44e73f68457e991a1dc8defd51672c36b07a2fa95b9f1e701d0152b35d373ab8c48468f0de4bb5abfe84504319fd00c",
+        Hex::encode(output)
+    );
+
+    assert!(proof.verify_output(&input, &kp.pk, &output).is_ok());
 }
 
 #[test]

--- a/fastcrypto/src/vrf.rs
+++ b/fastcrypto/src/vrf.rs
@@ -66,11 +66,10 @@ pub mod ecvrf {
     use crate::error::FastCryptoError;
     use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
     use crate::groups::{GroupElement, MultiScalarMul, Scalar};
-    use crate::hash::{HashFunction, ReverseWrapper, Sha512};
+    use crate::hash::{HashFunction, Sha512};
     use crate::serde_helpers::ToFromByteArray;
     use crate::traits::AllowedRng;
     use crate::vrf::{VRFKeyPair, VRFPrivateKey, VRFProof, VRFPublicKey};
-    use elliptic_curve::hash2curve::{ExpandMsg, Expander};
     use serde::{Deserialize, Serialize};
     use zeroize::ZeroizeOnDrop;
 
@@ -99,24 +98,13 @@ pub mod ecvrf {
         /// Encode the given binary string as curve point. See section 5.4.1.2 of draft-irtf-cfrg-vrf-15.
         fn ecvrf_encode_to_curve(&self, alpha_string: &[u8]) -> RistrettoPoint {
             // This follows section 5.4.1.2 of draft-irtf-cfrg-vrf-15 for the ristretto255 group using
-            // SHA-512. The hash-to-curve for ristretto255 follows appendix B of draft-irtf-cfrg-hash-to-curve-16.
-
-            // Compute expand_message_xmd for the given message. Note that expand_message only returns
-            // and error if the len_in_bytes and output size of the hash function is out of bounds
-            // (https://github.com/mikelodder7/hash2field/blob/cdf56a2b722aeae25b8019945afe4cccec132f25/src/expand_msg_xmd.rs#L21),
-            // so we can safely unwrap since they are constants here.
-            let mut expanded_message = elliptic_curve::hash2curve::ExpandMsgXmd::<
-                <H as ReverseWrapper>::Variant,
-            >::expand_message(
+            // SHA-512. The hash-to-curve for ristretto255 follows appendix B of draft-irtf-cfrg-hash-to-curve-16,
+            // using the ECVRF-specific [DST]. The message is the concatenation of the public key encoding
+            // and the input string as specified in section 5.4.1.2.
+            RistrettoPoint::hash_to_ristretto255_with_dst(
                 &[&self.0.to_byte_array(), alpha_string],
-                &[DST],
-                H::OUTPUT_SIZE,
+                DST,
             )
-            .unwrap();
-
-            let mut bytes = [0u8; H::OUTPUT_SIZE];
-            expanded_message.fill_bytes(&mut bytes);
-            RistrettoPoint::from_uniform_bytes(&bytes)
         }
 
         /// Implements ECVRF_validate_key which checks the validity of a public key. See section 5.4.5

--- a/fastcrypto/src/vrf.rs
+++ b/fastcrypto/src/vrf.rs
@@ -84,7 +84,7 @@ pub mod ecvrf {
     /// Default hash function
     type H = Sha512;
 
-    /// Domain separation tag used in ecvrf_encode_to_curve (see also draft-irtf-cfrg-hash-to-curve-16)
+    /// Domain separation tag used in ecvrf_encode_to_curve (see also RFC 9380)
     const DST: &[u8; 49] = b"ECVRF_ristretto255_XMD:SHA-512_R255MAP_RO_sui_vrf";
 
     #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -98,7 +98,7 @@ pub mod ecvrf {
         /// Encode the given binary string as curve point. See section 5.4.1.2 of draft-irtf-cfrg-vrf-15.
         fn ecvrf_encode_to_curve(&self, alpha_string: &[u8]) -> RistrettoPoint {
             // This follows section 5.4.1.2 of draft-irtf-cfrg-vrf-15 for the ristretto255 group using
-            // SHA-512. The hash-to-curve for ristretto255 follows appendix B of draft-irtf-cfrg-hash-to-curve-16,
+            // SHA-512. The hash-to-curve for ristretto255 follows appendix B of RFC 9380,
             // using the ECVRF-specific [DST]. The message is the concatenation of the public key encoding
             // and the input string as specified in section 5.4.1.2.
             RistrettoPoint::hash_to_ristretto255_with_dst(


### PR DESCRIPTION
## Summary
- Add `hash_to_ristretto255` method to `RistrettoPoint` implementing the `ristretto255_XMD:SHA-512_R255MAP_RO_` suite from RFC 9380 Appendix B
- Uses `expand_message_xmd` with SHA-512 to produce 64 uniform bytes, then maps to a point via the Ristretto Elligator 2 map
- Add test vectors verified against `@noble/curves` for cross-library compatibility
- Refactor to let the VRF implementation use this new function. This is a refactor and doesn't change the behaviour of the implementation.