### PR TITLE
Only do sanity checks in tbls

### DIFF
--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -148,12 +148,17 @@ impl Dealer {
     /// * `nodes`: The set of nodes (parties) participating in the protocol, including their public keys and weights.
     /// * `t`: The threshold number of shares required to reconstruct the secret. One party can have multiple shares according to its weight.
     /// * `sid`: A session identifier that should be unique for each invocation of the protocol but the same for all parties in a single invocation.
+    ///
+    /// Returns an error if `t` is smaller than the total weight of the nodes.
     pub fn new(
         secret: Option<S>,
         nodes: Nodes<EG>,
         t: u16,
         sid: Vec<u8>,
     ) -> FastCryptoResult<Self> {
+        if t > nodes.total_weight() {
+            return Err(InvalidInput);
+        }
         Ok(Self {
             secret,
             t,

--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -149,7 +149,7 @@ impl Dealer {
     /// * `t`: The threshold number of shares required to reconstruct the secret. One party can have multiple shares according to its weight.
     /// * `sid`: A session identifier that should be unique for each invocation of the protocol but the same for all parties in a single invocation.
     ///
-    /// Returns an error if `t` is smaller than the total weight of the nodes.
+    /// Returns an error if `t` is larger than the total weight of the nodes.
     pub fn new(
         secret: Option<S>,
         nodes: Nodes<EG>,

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
@@ -212,7 +212,7 @@ impl Dealer {
     /// * `batch_size_per_weight` is the number of secrets a dealer should deal per weight it has.
     ///
     /// Returns an `InvalidInput` error if
-    /// * t <= f or if the total weight of the nodes is smaller than t + 2*f.
+    /// * t is smaller than the total weight of the nodes.
     /// * the `dealer_id` is invalid (not part of `nodes`).
     pub fn new(
         nodes: Nodes<EG>,
@@ -221,6 +221,9 @@ impl Dealer {
         sid: Vec<u8>,
         batch_size_per_weight: u16,
     ) -> FastCryptoResult<Self> {
+        if t > nodes.total_weight() {
+            return Err(InvalidInput);
+        }
         // Each dealer deals a number of nonces proportional to their weight.
         let batch_size = nodes.weight_of(dealer_id)? as usize * batch_size_per_weight as usize;
         Ok(Self {

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
@@ -212,7 +212,7 @@ impl Dealer {
     /// * `batch_size_per_weight` is the number of secrets a dealer should deal per weight it has.
     ///
     /// Returns an `InvalidInput` error if
-    /// * t is smaller than the total weight of the nodes.
+    /// * t is larger than the total weight of the nodes.
     /// * the `dealer_id` is invalid (not part of `nodes`).
     pub fn new(
         nodes: Nodes<EG>,

--- a/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
@@ -46,8 +46,10 @@ impl Presignatures {
     ///
     /// All parties must use the same outputs in the same order, and the output from a dealer with weight `w` should be equal to `batch_size_per_weight * w`.
     ///
+    /// More parties contributing outputs gives more presignatures, so include as many as possible but at least f+1.
+    ///
     /// An InvalidInput error will be returned if:
-    /// * The total weight of the dealers for the outputs is not at least 2f+1,
+    /// * The total weight of the dealers for the outputs is not at least f+1,
     /// * The batch size of one of the outputs is not divisible by `batch_size_per_weight`,
     /// * or if batch_size_per_weight is zero.
     pub fn new(
@@ -73,7 +75,7 @@ impl Presignatures {
             })
             .collect::<FastCryptoResult<Vec<_>>>()?;
         let total_weight_of_outputs: usize = weights.iter().sum();
-        if total_weight_of_outputs < 2 * f + 1 {
+        if total_weight_of_outputs < f + 1 {
             return Err(InvalidInput);
         }
 


### PR DESCRIPTION
Only include checks that would break the functionality and leave it to the caller to collect enough signatures, e.g. for presigs.