### PR TITLE
[SLH-DSA] FORS + XMSS + Hypertree

### DIFF
--- a/fastcrypto/src/sphincs/README.md
+++ b/fastcrypto/src/sphincs/README.md
@@ -2,13 +2,6 @@
 
 Hand-written Rust impl, gated behind `--features experimental`.
 
-## Status
-
-WOTS+ ✅ · ADRS ✅ · SHA2 tweakable hash ✅ · FORS ⏳ · XMSS ⏳ · Hypertree ⏳ · SLH-DSA ⏳
-
-Individual components are planned to be built in a generic way:
-- WOTS+ can be instantiated with any `n, lg_w` iff `8n % lg_w = 0` and `1 <= lg_w <= 8`
-
 ## Approved parameter sets (FIPS 205)
 
 Columns: `n` (hash bytes), `h` (total tree height), `d` (hypertree layers),
@@ -24,8 +17,6 @@ bytes), security category, pk / sig bytes.
 | SLH-DSA-{SHA2,SHAKE}-256s   | 32 | 64 | 8  | 8  | 14 | 22 | 4    | 47 | 5   | 64 | 29,792 |
 | SLH-DSA-{SHA2,SHAKE}-256f   | 32 | 68 | 17 | 4  | 9  | 35 | 4    | 49 | 5   | 64 | 49,856 |
 
-All fix `lg_w = 4`. WOTS+ collapses to 3 configs by `n`: {16, 24, 32}.
-
 ## Draft parameter sets (SP 800-230 IPD, Apr 2026)
 
 `2^24`-signature-limited sets. `d = 1` (single XMSS tree); `lg_w` varies.
@@ -36,14 +27,30 @@ All fix `lg_w = 4`. WOTS+ collapses to 3 configs by `n`: {16, 24, 32}.
 | SLH-DSA-{SHA2,SHAKE}-192-24 | 24 | 21 | 1 | 21 | 25 | 9  | 3    | 32 | 3   | 48 |  7,752 |
 | SLH-DSA-{SHA2,SHAKE}-256-24 | 32 | 21 | 1 | 21 | 25 | 12 | 2    | 41 | 5   | 64 | 14,944 |
 
-Adds new WOTS+ configs: `(n=16, lg_w=2)`, `(n=24, lg_w=3)`, `(n=32, lg_w=2)`.
-
 ## Run
 
 ```bash
 cargo test  -p fastcrypto --features experimental sphincs
 cargo bench -p fastcrypto --features experimental --bench winternitz_ots
 ```
+
+## Signature sizes
+
+```
+|sig| = (1 + k·(1 + a) + h + d·len) · n
+```
+
+Built up from the components:
+
+- **WOTS+**: `len = 8n/lg_w + ⌊log_w(8n/lg_w · (w−1))⌋ + 1`, where `w = 2^lg_w`
+  - `lg_w = 4` (FIPS 205): `len = 2n + 3`
+  - `lg_w = 3, n = 24`: `len = 68`
+  - `lg_w = 2, n = 16`: `len = 68`
+  - `lg_w = 2, n = 32`: `len = 133`
+- **XMSS**: `(len + h') · n` — `len` WOTS+ chain values + `h'` auth nodes
+- **HT** (`d` stacked XMSS trees): `d · (len + h') · n = (d·len + h) · n`
+- **FORS**: `k · (1 + a) · n` — `k` trees, each with 1 sk + `a` auth nodes
+- **SLH-DSA**: `R + FORS + HT = (1 + k·(1+a) + h + d·len) · n`
 
 ## References
 

--- a/fastcrypto/src/sphincs/fors.rs
+++ b/fastcrypto/src/sphincs/fors.rs
@@ -1,0 +1,258 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! FORS implementation from FIPS-205
+//!
+//! Every WOTS+ leaf at the bottom layer of the hypertree (layer=0) has a distinct FORS forest beneath it.
+//! So callers must set:
+//! - xmss height, xmss index & keypair address to that of the WOTS+ key
+//! - type to FORS_TREE
+
+use crate::sphincs::hash::tweakable_hash;
+use crate::sphincs::merkle::{build_auth_path, compute_root_from_path, merkle_node};
+use crate::sphincs::utils::{bits_to_base, bytes_to_bits};
+use crate::sphincs::{Adrs, AdrsType};
+
+pub struct ForsParams {
+    pub k: u16, // number of trees in the FORS forest
+    pub a: u16, // height of each tree; also equivalent to #bits a single FORS tree can sign
+    pub t: u32, // t = 2^a
+    pub n: u16,
+}
+
+pub type ForsNode = Vec<u8>;
+
+pub type ForsSignature = Vec<ForsTreeSignature>; // k elements
+
+pub struct ForsTreeSignature {
+    pub sk: Vec<u8>,         // n bytes
+    pub auth: Vec<ForsNode>, // a elements
+}
+
+impl ForsTreeSignature {
+    pub fn size_in_bytes(&self) -> usize {
+        self.sk.len() + self.auth.iter().map(|n| n.len()).sum::<usize>()
+    }
+}
+
+impl ForsParams {
+    pub fn new(k: u16, a: u16, n: u16) -> Self {
+        let t = 2u32.pow(a as u32);
+        ForsParams { k, a, t, n }
+    }
+}
+
+fn fors_sk_gen(
+    params: &ForsParams,
+    sk_seed: &[u8],
+    pk_seed: &[u8],
+    adrs: Adrs,
+    idx: u32,
+) -> Vec<u8> {
+    assert!(idx < params.t * params.k as u32);
+
+    tweakable_hash(
+        pk_seed,
+        adrs.with_type(AdrsType::ForsPrf)
+            .with_key_pair_address(adrs.get_key_pair_address())
+            .with_tree_index(idx),
+        sk_seed,
+    )
+}
+
+/// Build a FORS_TREE address at a given height/index. Assumes the caller's
+/// `adrs` is already a FORS_TREE address with `kp` set — true at every entry
+/// into this module (slh_dsa's `derive_fors_context` and the fors tests).
+fn fors_tree_adrs(adrs: Adrs, height: impl Into<u32>, index: u32) -> Adrs {
+    adrs.with_tree_height(height).with_tree_index(index)
+}
+
+/// F(sk) — the FORS leaf at forest-global index `idx`. Used by both the signer
+/// (with sk derived from sk_seed) and the verifier (with sk from the signature).
+fn fors_leaf(pk_seed: &[u8], adrs: Adrs, sk: &[u8], idx: u32) -> Vec<u8> {
+    tweakable_hash(pk_seed, fors_tree_adrs(adrs, 0u32, idx), sk)
+}
+
+fn fors_node(
+    params: &ForsParams,
+    sk_seed: &[u8],
+    i: u32,
+    z: u16,
+    pk_seed: &[u8],
+    adrs: Adrs,
+) -> ForsNode {
+    assert!(z <= params.a);
+    assert!(i < (params.k as u32) * 2u32.pow(u32::from(params.a - z)));
+
+    let leaf_generator = |idx| {
+        fors_leaf(
+            pk_seed,
+            adrs,
+            &fors_sk_gen(params, sk_seed, pk_seed, adrs, idx),
+            idx,
+        )
+    };
+    let adrs_generator = |height, idx| fors_tree_adrs(adrs, height, idx);
+    merkle_node(&leaf_generator, &adrs_generator, i, z, pk_seed)
+}
+
+/// Unpack `md` into `k` base-`a` digits per FIPS 205 Alg. 7. `md` is
+/// `⌈k·a / 8⌉` bytes; any trailing padding bits are discarded.
+fn md_to_indices(params: &ForsParams, md: &[u8]) -> Vec<u32> {
+    let ka = (params.k as usize) * (params.a as usize);
+    assert_eq!(md.len(), ka.div_ceil(8), "md must be ⌈k·a/8⌉ bytes");
+    let bits = bytes_to_bits(md);
+    let indices = bits_to_base(&bits[..ka], params.a);
+    debug_assert_eq!(indices.len(), params.k as usize);
+    indices
+}
+
+pub fn fors_sign(
+    params: &ForsParams,
+    md: &[u8],
+    sk_seed: &[u8],
+    pk_seed: &[u8],
+    adrs: Adrs,
+) -> ForsSignature {
+    assert_eq!(
+        adrs.get_type(),
+        AdrsType::ForsTree,
+        "fors_sign expects a FORS_TREE ADRS"
+    );
+    let indices = md_to_indices(params, md);
+
+    let mut fors_sign = Vec::with_capacity(params.k as usize);
+    for i in 0..params.k as u32 {
+        let fors_idx = i * params.t + indices[i as usize];
+        let fors_tree_sk = fors_sk_gen(params, sk_seed, pk_seed, adrs, fors_idx);
+        // Indices are contiguous across the forest, so shift tree i's local sibling
+        // index into the global forest-wide index space at each height.
+        let node_at = |height, sib| {
+            let shift = i * 2u32.pow(u32::from(params.a - height));
+            fors_node(params, sk_seed, shift + sib, height, pk_seed, adrs)
+        };
+        let auth = build_auth_path(params.a, indices[i as usize], node_at);
+        fors_sign.push(ForsTreeSignature {
+            sk: fors_tree_sk,
+            auth,
+        });
+    }
+
+    fors_sign
+}
+
+pub fn fors_pk_from_sig(
+    params: &ForsParams,
+    sig: &ForsSignature,
+    md: &[u8],
+    pk_seed: &[u8],
+    adrs: Adrs,
+) -> Vec<u8> {
+    assert_eq!(
+        adrs.get_type(),
+        AdrsType::ForsTree,
+        "fors_pk_from_sig expects a FORS_TREE ADRS"
+    );
+    assert_eq!(sig.len(), params.k as usize);
+    let indices = md_to_indices(params, md);
+
+    let mut roots = Vec::with_capacity(params.k as usize);
+    let adrs_generator = |height, idx| fors_tree_adrs(adrs, height, idx);
+    for i in 0..params.k as u32 {
+        let tree_sig = &sig[i as usize];
+        assert_eq!(tree_sig.auth.len(), params.a as usize);
+
+        let leaf_idx = i * params.t + indices[i as usize];
+        let leaf = fors_leaf(pk_seed, adrs, &tree_sig.sk, leaf_idx);
+        let root = compute_root_from_path(leaf, leaf_idx, &tree_sig.auth, pk_seed, adrs_generator);
+        roots.push(root);
+    }
+
+    compress_roots(&roots.concat(), pk_seed, adrs)
+}
+
+fn compress_roots(all_roots: &[u8], pk_seed: &[u8], adrs: Adrs) -> Vec<u8> {
+    tweakable_hash(
+        pk_seed,
+        adrs.with_type(AdrsType::ForsRoots)
+            .with_key_pair_address(adrs.get_key_pair_address()),
+        all_roots,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compute the FORS public key from sk_seed by hashing the k tree roots — mirrors
+    /// what a signer would publish, independent of fors_sign/fors_pk_from_sig.
+    fn fors_pk_gen(params: &ForsParams, sk_seed: &[u8], pk_seed: &[u8], adrs: Adrs) -> Vec<u8> {
+        let roots: Vec<u8> = (0..params.k as u32)
+            .flat_map(|i| fors_node(params, sk_seed, i, params.a, pk_seed, adrs))
+            .collect();
+        compress_roots(&roots, pk_seed, adrs)
+    }
+
+    use crate::sphincs::params::{
+        FipsParams, FIPS_128F, FIPS_128S, FIPS_192F, FIPS_192S, FIPS_256F, FIPS_256S,
+    };
+
+    /// End-to-end roundtrip: keygen → sign → verify, plus a tampered-md negative
+    /// check and sig size formula `k · (1 + a) · n`.
+    fn run_e2e(p: &FipsParams) {
+        let params = ForsParams::new(p.k, p.a, p.n);
+        let n = p.n as usize;
+        let pk_seed: Vec<u8> = (0..n).map(|i| 0xA0u8.wrapping_add(i as u8)).collect();
+        let sk_seed: Vec<u8> = (0..n).map(|i| 0x50u8.wrapping_add(i as u8)).collect();
+        let adrs = Adrs::new()
+            .with_type(AdrsType::ForsTree)
+            .with_key_pair_address(7u32);
+
+        // md: ⌈k·a/8⌉ bytes of arbitrary content.
+        let md_len = ((p.k as usize) * (p.a as usize)).div_ceil(8);
+        let md: Vec<u8> = (0..md_len).map(|i| 0x5Au8.wrapping_add(i as u8)).collect();
+
+        let pk = fors_pk_gen(&params, &sk_seed, &pk_seed, adrs);
+        let sig = fors_sign(&params, &md, &sk_seed, &pk_seed, adrs);
+        let recovered = fors_pk_from_sig(&params, &sig, &md, &pk_seed, adrs);
+        assert_eq!(pk, recovered, "[{}] recovered pk must match", p.name);
+
+        let mut wrong = md;
+        wrong[0] ^= 1;
+        let wrong_pk = fors_pk_from_sig(&params, &sig, &wrong, &pk_seed, adrs);
+        assert_ne!(pk, wrong_pk, "[{}] wrong md must not recover pk", p.name);
+
+        let sig_size: usize = sig.iter().map(|t| t.size_in_bytes()).sum();
+        assert_eq!(
+            sig_size,
+            (p.k as usize) * (1 + p.a as usize) * n,
+            "[{}]",
+            p.name
+        );
+    }
+
+    #[test]
+    fn test_fors_128s() {
+        run_e2e(&FIPS_128S);
+    }
+    #[test]
+    fn test_fors_128f() {
+        run_e2e(&FIPS_128F);
+    }
+    #[test]
+    fn test_fors_192s() {
+        run_e2e(&FIPS_192S);
+    }
+    #[test]
+    fn test_fors_192f() {
+        run_e2e(&FIPS_192F);
+    }
+    #[test]
+    fn test_fors_256s() {
+        run_e2e(&FIPS_256S);
+    }
+    #[test]
+    fn test_fors_256f() {
+        run_e2e(&FIPS_256F);
+    }
+}

--- a/fastcrypto/src/sphincs/fors.rs
+++ b/fastcrypto/src/sphincs/fors.rs
@@ -13,11 +13,23 @@ use crate::sphincs::merkle::{build_auth_path, compute_root_from_path, merkle_nod
 use crate::sphincs::utils::{bits_to_base, bytes_to_bits};
 use crate::sphincs::{Adrs, AdrsType};
 
+// ------------------------------------------------------------------
+//                            Parameters
+// ------------------------------------------------------------------
+
 pub struct ForsParams {
     pub k: u16, // number of trees in the FORS forest
     pub a: u16, // height of each tree; also equivalent to #bits a single FORS tree can sign
     pub t: u32, // t = 2^a
     pub n: u16,
+}
+
+impl ForsParams {
+    pub fn new(k: u16, a: u16, n: u16) -> Self {
+        assert!(a < 32);
+        let t = 2u32.pow(a as u32);
+        ForsParams { k, a, t, n }
+    }
 }
 
 pub type ForsNode = Vec<u8>;
@@ -35,11 +47,15 @@ impl ForsTreeSignature {
     }
 }
 
-impl ForsParams {
-    pub fn new(k: u16, a: u16, n: u16) -> Self {
-        let t = 2u32.pow(a as u32);
-        ForsParams { k, a, t, n }
-    }
+// ------------------------------------------------------------------
+//                             Helpers
+// ------------------------------------------------------------------
+
+/// Build a FORS_TREE address at a given height/index. Assumes the caller's
+/// `adrs` is already a FORS_TREE address with `kp` set — true at every entry
+/// into this module (slh_dsa's `derive_fors_context` and the fors tests).
+fn fors_tree_adrs(adrs: Adrs, height: impl Into<u32>, index: u32) -> Adrs {
+    adrs.with_tree_height(height).with_tree_index(index)
 }
 
 fn fors_sk_gen(
@@ -58,13 +74,6 @@ fn fors_sk_gen(
             .with_tree_index(idx),
         sk_seed,
     )
-}
-
-/// Build a FORS_TREE address at a given height/index. Assumes the caller's
-/// `adrs` is already a FORS_TREE address with `kp` set — true at every entry
-/// into this module (slh_dsa's `derive_fors_context` and the fors tests).
-fn fors_tree_adrs(adrs: Adrs, height: impl Into<u32>, index: u32) -> Adrs {
-    adrs.with_tree_height(height).with_tree_index(index)
 }
 
 /// F(sk) — the FORS leaf at forest-global index `idx`. Used by both the signer
@@ -106,6 +115,20 @@ fn md_to_indices(params: &ForsParams, md: &[u8]) -> Vec<u32> {
     debug_assert_eq!(indices.len(), params.k as usize);
     indices
 }
+
+/// Compress the k FORS tree roots into the FORS public key (`T_k`).
+fn compress_roots(all_roots: &[u8], pk_seed: &[u8], adrs: Adrs) -> Vec<u8> {
+    tweakable_hash(
+        pk_seed,
+        adrs.with_type(AdrsType::ForsRoots)
+            .with_key_pair_address(adrs.get_key_pair_address()),
+        all_roots,
+    )
+}
+
+// ------------------------------------------------------------------
+//                           Public API
+// ------------------------------------------------------------------
 
 pub fn fors_sign(
     params: &ForsParams,
@@ -171,18 +194,12 @@ pub fn fors_pk_from_sig(
     compress_roots(&roots.concat(), pk_seed, adrs)
 }
 
-fn compress_roots(all_roots: &[u8], pk_seed: &[u8], adrs: Adrs) -> Vec<u8> {
-    tweakable_hash(
-        pk_seed,
-        adrs.with_type(AdrsType::ForsRoots)
-            .with_key_pair_address(adrs.get_key_pair_address()),
-        all_roots,
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sphincs::params::{
+        FipsParams, FIPS_128F, FIPS_128S, FIPS_192F, FIPS_192S, FIPS_256F, FIPS_256S,
+    };
 
     /// Compute the FORS public key from sk_seed by hashing the k tree roots — mirrors
     /// what a signer would publish, independent of fors_sign/fors_pk_from_sig.
@@ -192,10 +209,6 @@ mod tests {
             .collect();
         compress_roots(&roots, pk_seed, adrs)
     }
-
-    use crate::sphincs::params::{
-        FipsParams, FIPS_128F, FIPS_128S, FIPS_192F, FIPS_192S, FIPS_256F, FIPS_256S,
-    };
 
     /// End-to-end roundtrip: keygen → sign → verify, plus a tampered-md negative
     /// check and sig size formula `k · (1 + a) · n`.

--- a/fastcrypto/src/sphincs/hypertree.rs
+++ b/fastcrypto/src/sphincs/hypertree.rs
@@ -1,0 +1,207 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SLH-DSA Hypertree implementation from FIPS-205
+//!
+//! A hypertree is `d` stacked XMSS trees. Layer 0's WOTS+ leaves sign the
+//! message; each layer above signs the root of the layer below; the top
+//! layer's root is the SLH-DSA public key root.
+
+use crate::sphincs::xmss::{xmss_node, xmss_pk_from_sig, xmss_sign, XmssParams, XmssSignature};
+use crate::sphincs::Adrs;
+
+pub struct HypertreeParams {
+    /// Number of layers of XMSS trees.
+    pub d: u8,
+    pub xmss: XmssParams,
+    /// Total height of the hypertree (`h = d * h'`).
+    pub h: u8,
+}
+
+impl HypertreeParams {
+    pub fn new(d: u8, xmss: XmssParams) -> Self {
+        // h' < 32 so that a leaf index fits in u32 (the type of idx_leaf in
+        // the sign/verify API). FIPS 205 tops out at h' = 12 and SP 800-230
+        // draft at h' = 22, so this is purely a sanity check.
+        debug_assert!(xmss.h_prime < 32, "h_prime must be < 32");
+        // h = d * h' ≤ 68 for every FIPS 205 / SP 800-230 param set, so fits in u8.
+        let h = d
+            .checked_mul(xmss.h_prime)
+            .expect("h = d * h_prime overflowed u8");
+        HypertreeParams { d, xmss, h }
+    }
+}
+
+pub struct HypertreeSignature {
+    /// One XMSS signature per layer; `xmss[0]` is the bottom layer.
+    pub xmss: Vec<XmssSignature>,
+}
+
+impl HypertreeSignature {
+    pub fn size_in_bytes(&self) -> usize {
+        self.xmss.iter().map(|s| s.size_in_bytes()).sum()
+    }
+}
+
+/// Consume the low `h_prime` bits of `idx_tree` as the next layer's `idx_leaf`,
+/// and shift `idx_tree` down by `h_prime`.
+fn advance_indices(idx_tree: &mut u64, idx_leaf: &mut u32, h_prime: u8) {
+    *idx_leaf = (*idx_tree & ((1u64 << h_prime) - 1)) as u32;
+    *idx_tree >>= h_prime;
+}
+
+/// Top-tree root (layer d-1, tree 0). This is the SLH-DSA public key root.
+pub fn ht_pk_root(params: &HypertreeParams, sk_seed: &[u8], pk_seed: &[u8]) -> Vec<u8> {
+    let adrs = Adrs::new().with_xmss_height(params.d - 1);
+    xmss_node(&params.xmss, sk_seed, 0, params.xmss.h_prime, pk_seed, adrs)
+}
+
+/// Sign `msg` at the layer-0 leaf identified by `(idx_tree, idx_leaf)`:
+/// - `idx_tree`: which XMSS tree at the current layer (upper `h - h'` bits of the global leaf index on entry to layer 0).
+/// - `idx_leaf`: which WOTS+ leaf inside that XMSS tree (low `h'` bits).
+pub fn ht_sign(
+    params: &HypertreeParams,
+    sk_seed: &[u8],
+    pk_seed: &[u8],
+    msg: &[u8],
+    mut idx_tree: u64,
+    mut idx_leaf: u32,
+) -> HypertreeSignature {
+    let h_prime = params.xmss.h_prime;
+    let mut sigs = Vec::with_capacity(params.d as usize);
+    let mut to_sign: Vec<u8> = msg.to_vec();
+
+    for j in 0..params.d {
+        let adrs = Adrs::new().with_xmss_height(j).with_xmss_index(idx_tree);
+        let sig_j = xmss_sign(&params.xmss, sk_seed, &to_sign, idx_leaf, pk_seed, adrs);
+
+        if j < params.d - 1 {
+            // Next layer signs the root recovered from this layer's signature.
+            to_sign = xmss_pk_from_sig(&params.xmss, idx_leaf, &sig_j, &to_sign, pk_seed, adrs);
+            advance_indices(&mut idx_tree, &mut idx_leaf, h_prime);
+        }
+        sigs.push(sig_j);
+    }
+    HypertreeSignature { xmss: sigs }
+}
+
+/// Verify a hypertree signature. `(idx_tree, idx_leaf)` identifies the layer-0
+/// leaf that was signed (same split as [`ht_sign`]).
+pub fn ht_verify(
+    params: &HypertreeParams,
+    pk_seed: &[u8],
+    pk_root: &[u8],
+    msg: &[u8],
+    sig: &HypertreeSignature,
+    mut idx_tree: u64,
+    mut idx_leaf: u32,
+) -> bool {
+    if sig.xmss.len() != params.d as usize {
+        return false;
+    }
+    let h_prime = params.xmss.h_prime;
+    let mut node: Vec<u8> = msg.to_vec();
+
+    for j in 0..params.d {
+        let adrs = Adrs::new().with_xmss_height(j).with_xmss_index(idx_tree);
+        node = xmss_pk_from_sig(
+            &params.xmss,
+            idx_leaf,
+            &sig.xmss[j as usize],
+            &node,
+            pk_seed,
+            adrs,
+        );
+        if j < params.d - 1 {
+            advance_indices(&mut idx_tree, &mut idx_leaf, h_prime);
+        }
+    }
+    node == pk_root
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sphincs::params::{
+        FipsParams, FIPS_128F, FIPS_128S, FIPS_192F, FIPS_192S, FIPS_256F, FIPS_256S,
+    };
+    use crate::sphincs::winternitz_ots::WotsParams;
+
+    /// End-to-end roundtrip: keygen → sign → verify, plus negative checks and
+    /// sig size formula `d · n · (len_wots + h')`.
+    fn run_e2e(p: &FipsParams) {
+        let params = HypertreeParams::new(
+            p.d,
+            XmssParams {
+                h_prime: p.h_prime,
+                wots: WotsParams::new(p.n, p.lg_w),
+            },
+        );
+        let n = p.n as usize;
+        let pk_seed: Vec<u8> = (0..n).map(|i| 0xA0u8.wrapping_add(i as u8)).collect();
+        let sk_seed: Vec<u8> = (0..n).map(|i| 0x50u8.wrapping_add(i as u8)).collect();
+        let msg: Vec<u8> = (0..n).map(|i| 0x10u8.wrapping_add(i as u8)).collect();
+
+        let pk_root = ht_pk_root(&params, &sk_seed, &pk_seed);
+
+        // Pick an idx somewhere below 2^h; split into (idx_tree, idx_leaf).
+        let global_idx: u64 = if params.h >= 64 {
+            u64::MAX / 3
+        } else {
+            ((1u64 << params.h) - 1) / 3
+        };
+        let idx_leaf = (global_idx & ((1u64 << p.h_prime) - 1)) as u32;
+        let idx_tree = global_idx >> p.h_prime;
+
+        let sig = ht_sign(&params, &sk_seed, &pk_seed, &msg, idx_tree, idx_leaf);
+        assert!(
+            ht_verify(&params, &pk_seed, &pk_root, &msg, &sig, idx_tree, idx_leaf),
+            "[{}] verify must accept good signature",
+            p.name,
+        );
+
+        let mut bad_msg = msg.clone();
+        bad_msg[0] ^= 1;
+        assert!(
+            !ht_verify(&params, &pk_seed, &pk_root, &bad_msg, &sig, idx_tree, idx_leaf),
+            "[{}] verify must reject tampered msg",
+            p.name,
+        );
+
+        let wrong_leaf = idx_leaf ^ 1;
+        assert!(
+            !ht_verify(&params, &pk_seed, &pk_root, &msg, &sig, idx_tree, wrong_leaf),
+            "[{}] verify must reject wrong idx_leaf",
+            p.name,
+        );
+
+        let num_elems = params.xmss.wots.num_elements() as usize;
+        let per_xmss = n * (num_elems + p.h_prime as usize);
+        assert_eq!(sig.size_in_bytes(), p.d as usize * per_xmss, "[{}]", p.name);
+    }
+
+    #[test]
+    fn test_ht_128s() {
+        run_e2e(&FIPS_128S);
+    }
+    #[test]
+    fn test_ht_128f() {
+        run_e2e(&FIPS_128F);
+    }
+    #[test]
+    fn test_ht_192s() {
+        run_e2e(&FIPS_192S);
+    }
+    #[test]
+    fn test_ht_192f() {
+        run_e2e(&FIPS_192F);
+    }
+    #[test]
+    fn test_ht_256s() {
+        run_e2e(&FIPS_256S);
+    }
+    #[test]
+    fn test_ht_256f() {
+        run_e2e(&FIPS_256F);
+    }
+}

--- a/fastcrypto/src/sphincs/hypertree.rs
+++ b/fastcrypto/src/sphincs/hypertree.rs
@@ -10,6 +10,10 @@
 use crate::sphincs::xmss::{xmss_node, xmss_pk_from_sig, xmss_sign, XmssParams, XmssSignature};
 use crate::sphincs::Adrs;
 
+// ------------------------------------------------------------------
+//                            Parameters
+// ------------------------------------------------------------------
+
 pub struct HypertreeParams {
     /// Number of layers of XMSS trees.
     pub d: u8,
@@ -43,12 +47,20 @@ impl HypertreeSignature {
     }
 }
 
+// ------------------------------------------------------------------
+//                             Helpers
+// ------------------------------------------------------------------
+
 /// Consume the low `h_prime` bits of `idx_tree` as the next layer's `idx_leaf`,
 /// and shift `idx_tree` down by `h_prime`.
 fn advance_indices(idx_tree: &mut u64, idx_leaf: &mut u32, h_prime: u8) {
     *idx_leaf = (*idx_tree & ((1u64 << h_prime) - 1)) as u32;
     *idx_tree >>= h_prime;
 }
+
+// ------------------------------------------------------------------
+//                          Public API
+// ------------------------------------------------------------------
 
 /// Top-tree root (layer d-1, tree 0). This is the SLH-DSA public key root.
 pub fn ht_pk_root(params: &HypertreeParams, sk_seed: &[u8], pk_seed: &[u8]) -> Vec<u8> {

--- a/fastcrypto/src/sphincs/merkle.rs
+++ b/fastcrypto/src/sphincs/merkle.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared Merkle-tree helpers used by both XMSS (Tree ADRS) and FORS (FORS_TREE ADRS).
+//!
+//! Three operations show up identically in both constructions:
+//!   - Compute a node at `(height z, index i)` by recursing to leaves.
+//!   - Build the authentication path from a leaf up to the root.
+//!   - Fold a leaf up to a root along an authentication path.
+//!
+//! Each caller supplies the leaf producer and an ADRS builder for interior nodes;
+//! everything else — parity-based sibling order, index shifting, hashing — is shared.
+
+use crate::sphincs::hash::tweakable_hash;
+use crate::sphincs::Adrs;
+
+/// Recursively compute the node at height `z`, index `i`.
+///   - `leaf(i)` produces the leaf value at global index `i` (called only at `z == 0`).
+///   - `mk_interior_adrs(height, index)` builds the ADRS used to hash an interior
+///     node at the given (parent) height and index.
+pub fn merkle_node(
+    leaf: &impl Fn(u32) -> Vec<u8>,
+    mk_interior_adrs: &impl Fn(u16, u32) -> Adrs,
+    i: u32,
+    z: u16,
+    pk_seed: &[u8],
+) -> Vec<u8> {
+    if z == 0 {
+        leaf(i)
+    } else {
+        let lnode = merkle_node(leaf, mk_interior_adrs, 2 * i, z - 1, pk_seed);
+        let rnode = merkle_node(leaf, mk_interior_adrs, 2 * i + 1, z - 1, pk_seed);
+        tweakable_hash(pk_seed, mk_interior_adrs(z, i), &[lnode, rnode].concat())
+    }
+}
+
+/// Build a length-`h` authentication path for leaf `leaf_idx` in a Merkle tree.
+/// `node_at(height, local_sibling_idx)` supplies the sibling node at each step.
+pub fn build_auth_path<F>(h: u16, leaf_idx: u32, node_at: F) -> Vec<Vec<u8>>
+where
+    F: Fn(u16, u32) -> Vec<u8>,
+{
+    let mut auth = Vec::with_capacity(h as usize);
+    let mut idx = leaf_idx;
+    for height in 0..h {
+        let sibling = idx ^ 1;
+        auth.push(node_at(height, sibling));
+        idx /= 2;
+    }
+    auth
+}
+
+/// Fold `leaf` up to the root by consuming each sibling in `auth`. At each step,
+/// the parity of `idx` decides sibling order; `mk_interior_adrs` builds the ADRS
+/// for the parent node at the new height/index.
+pub fn compute_root_from_path(
+    leaf: Vec<u8>,
+    mut idx: u32,
+    auth: &[Vec<u8>],
+    pk_seed: &[u8],
+    mk_interior_adrs: impl Fn(u16, u32) -> Adrs,
+) -> Vec<u8> {
+    let mut cur = leaf;
+    for (h, sibling) in auth.iter().enumerate() {
+        let combined = if idx.is_multiple_of(2) {
+            [cur.as_slice(), sibling.as_slice()].concat()
+        } else {
+            [sibling.as_slice(), cur.as_slice()].concat()
+        };
+        idx /= 2;
+        cur = tweakable_hash(pk_seed, mk_interior_adrs((h + 1) as u16, idx), &combined);
+    }
+    cur
+}

--- a/fastcrypto/src/sphincs/mod.rs
+++ b/fastcrypto/src/sphincs/mod.rs
@@ -1,16 +1,30 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod fors;
 pub mod hash;
+pub mod hypertree;
+pub mod merkle;
+mod params;
+mod utils;
 pub mod winternitz_ots;
+pub mod xmss;
 
 /// FIPS 205 Section 4.2 — ADRS (Address)
 ///
 /// 32-byte structure, 8 big-endian words:
-///   Word 0      : layer address
-///   Words 1-3   : tree address  (12 bytes; upper 4 zero, lower 8 = u64)
+///   Word 0      : XMSS tree height — layer of this XMSS tree in the hypertree stack
+///   Words 1-3   : XMSS tree index  — which XMSS tree at that layer (12 bytes; upper 4 zero, lower 8 = u64)
 ///   Word 4      : type
 ///   Words 5-7   : type-dependent (zeroed whenever type is changed)
+///
+/// FIPS 205 spec-name mapping (we rename for clarity):
+///   - "layer address" (word 0)    → `xmss_height`
+///   - "tree address"  (words 1-3) → `xmss_index`
+///
+/// Together these identify *which* XMSS tree in the hypertree (a 2D coordinate:
+/// height + index). The later `tree_height` / `tree_index` (words 6/7 of `Tree`
+/// and `FORS_TREE` ADRS) identify a node *within* a Merkle tree (either XMSS or FORS).
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -44,26 +58,23 @@ impl Adrs {
         self.0[off..off + 4].copy_from_slice(&val.to_be_bytes());
     }
 
-    // --- layer (word 0) ---
-
-    pub fn with_layer_address(mut self, layer: impl Into<u32>) -> Self {
-        self.set_word(0, layer.into());
+    // --- XMSS tree height (word 0; FIPS 205: "layer address") ---
+    // Layer of this XMSS tree in the hypertree stack.
+    pub fn with_xmss_height(mut self, height: impl Into<u32>) -> Self {
+        self.set_word(0, height.into());
         self
     }
 
-    pub fn get_layer_address(&self) -> u32 {
+    pub fn get_xmss_height(&self) -> u32 {
         self.get_word(0)
     }
 
-    // --- tree address (words 1-3, 12 bytes) ---
-
-    pub fn with_tree_address(mut self, tree: [u8; 12]) -> Self {
-        self.0[4..16].copy_from_slice(&tree);
+    // --- XMSS tree index (words 1-3, 12 bytes; FIPS 205: "tree address") ---
+    // Which XMSS tree at that layer.
+    pub fn with_xmss_index(mut self, idx: u64) -> Self {
+        self.0[4..8].fill(0);
+        self.0[8..16].copy_from_slice(&idx.to_be_bytes());
         self
-    }
-
-    pub fn get_tree_address(&self) -> [u8; 12] {
-        self.0[4..16].try_into().unwrap()
     }
 
     // --- type (word 4) — zeroes words 5-7 on change ---

--- a/fastcrypto/src/sphincs/params.rs
+++ b/fastcrypto/src/sphincs/params.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SLH-DSA parameter sets (FIPS 205).
+//!
+//! One canonical table shared by production (`SlhDsaParams::sha2_*` constructors)
+//! and tests (per-module `run_e2e` helpers).
+//!
+//! The `dead_code` allow covers consts/fields that are only read from tests or
+//! from PR 2's `slh_dsa.rs` — they look unused in a non-test build of this PR.
+
+#![allow(dead_code)]
+
+/// `name`, `m`, `sig_size` are redundant with the other fields — kept as
+/// cross-checks against the spec (FIPS 205 Table 1).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct FipsParams {
+    pub name: &'static str,
+    pub n: u16,
+    pub h: u8,
+    pub d: u8,
+    pub h_prime: u8,
+    pub a: u16,
+    pub k: u16,
+    pub lg_w: u16,
+    /// Message digest length `m = ⌈k·a/8⌉ + ⌈(h−h')/8⌉ + ⌈h'/8⌉`.
+    pub m: u16,
+    /// Total signature length in bytes (per FIPS 205 Table 1).
+    pub sig_size: usize,
+}
+
+// FIPS 205 approved sets (all use lg_w = 4).
+pub(super) const FIPS_128S: FipsParams = FipsParams {
+    name: "128s",
+    n: 16,
+    h: 63,
+    d: 7,
+    h_prime: 9,
+    a: 12,
+    k: 14,
+    lg_w: 4,
+    m: 30,
+    sig_size: 7856,
+};
+pub(super) const FIPS_128F: FipsParams = FipsParams {
+    name: "128f",
+    n: 16,
+    h: 66,
+    d: 22,
+    h_prime: 3,
+    a: 6,
+    k: 33,
+    lg_w: 4,
+    m: 34,
+    sig_size: 17088,
+};
+pub(super) const FIPS_192S: FipsParams = FipsParams {
+    name: "192s",
+    n: 24,
+    h: 63,
+    d: 7,
+    h_prime: 9,
+    a: 14,
+    k: 17,
+    lg_w: 4,
+    m: 39,
+    sig_size: 16224,
+};
+pub(super) const FIPS_192F: FipsParams = FipsParams {
+    name: "192f",
+    n: 24,
+    h: 66,
+    d: 22,
+    h_prime: 3,
+    a: 8,
+    k: 33,
+    lg_w: 4,
+    m: 42,
+    sig_size: 35664,
+};
+pub(super) const FIPS_256S: FipsParams = FipsParams {
+    name: "256s",
+    n: 32,
+    h: 64,
+    d: 8,
+    h_prime: 8,
+    a: 14,
+    k: 22,
+    lg_w: 4,
+    m: 47,
+    sig_size: 29792,
+};
+pub(super) const FIPS_256F: FipsParams = FipsParams {
+    name: "256f",
+    n: 32,
+    h: 68,
+    d: 17,
+    h_prime: 4,
+    a: 9,
+    k: 35,
+    lg_w: 4,
+    m: 49,
+    sig_size: 49856,
+};

--- a/fastcrypto/src/sphincs/utils.rs
+++ b/fastcrypto/src/sphincs/utils.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Unpack each byte of `bytes` into individual bits (MSB first), each stored as 0 or 1.
+pub(super) fn bytes_to_bits(bytes: &[u8]) -> Vec<u8> {
+    let mut bits = Vec::with_capacity(bytes.len() * 8);
+    for &b in bytes {
+        for shift in (0..8).rev() {
+            bits.push((b >> shift) & 1);
+        }
+    }
+    bits
+}
+
+/// Pack `bits` into `chunk_size`-bit values (MSB first within each chunk).
+pub(super) fn bits_to_base(bits: &[u8], chunk_size: u16) -> Vec<u32> {
+    assert!(chunk_size <= 32, "chunk_size must fit in u32");
+    let n = chunk_size as usize;
+    assert_eq!(
+        bits.len() % n,
+        0,
+        "bits.len() must be a multiple of chunk_size"
+    );
+    let mut result = Vec::with_capacity(bits.len() / n);
+    for chunk in bits.chunks(n) {
+        let mut acc: u32 = 0;
+        for &b in chunk {
+            acc = (acc << 1) | u32::from(b);
+        }
+        result.push(acc);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bits_to_base_nibbles() {
+        assert_eq!(bits_to_base(&bytes_to_bits(&[0xA3]), 4), vec![0xA, 0x3]);
+        assert_eq!(
+            bits_to_base(&bytes_to_bits(&[0xA3, 0xF0]), 4),
+            vec![0xA, 0x3, 0xF, 0x0]
+        );
+    }
+
+    #[test]
+    fn test_bits_to_base_pairs() {
+        // chunk_size = 2 → 0xA3 = 10 10 00 11 → [2, 2, 0, 3]
+        assert_eq!(bits_to_base(&bytes_to_bits(&[0xA3]), 2), vec![2, 2, 0, 3]);
+    }
+
+    #[test]
+    fn test_bits_to_base_single_bits() {
+        assert_eq!(
+            bits_to_base(&bytes_to_bits(&[0xA3]), 1),
+            vec![1, 0, 1, 0, 0, 0, 1, 1]
+        );
+    }
+}

--- a/fastcrypto/src/sphincs/winternitz_ots.rs
+++ b/fastcrypto/src/sphincs/winternitz_ots.rs
@@ -8,6 +8,7 @@
 //!     (ii) the WOTS+ keypair address within the XMSS tree.
 
 use crate::sphincs::hash::tweakable_hash;
+use crate::sphincs::utils::{bits_to_base, bytes_to_bits};
 use crate::sphincs::{Adrs, AdrsType};
 
 // ------------------------------------------------------------------
@@ -19,6 +20,24 @@ pub struct WotsParams {
     pub n: u16,    // hash output length in bytes (spec: {16, 24, 32})
     pub lg_w: u16, // bits per winternitz digit (spec: 1..=8)
     w: u16,        // hash chain length = 2^lg_w
+}
+
+pub struct WotsSignature(Vec<Vec<u8>>);
+
+impl WotsSignature {
+    pub fn as_slice(&self) -> &[Vec<u8>] {
+        &self.0
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.0.iter().map(|s| s.len()).sum()
+    }
+
+    /// Construct from a pre-parsed list of per-chain values. Used by higher-level
+    /// signature deserialization.
+    pub fn from_chains(chains: Vec<Vec<u8>>) -> Self {
+        Self(chains)
+    }
 }
 
 impl WotsParams {
@@ -60,38 +79,17 @@ impl WotsParams {
 //            Message encoding (base-w digits + checksum)
 // ------------------------------------------------------------------
 
-fn to_bits(msg: &[u8]) -> Vec<u8> {
-    let mut msg_bits = Vec::with_capacity(msg.len() * 8);
-    for &x in msg {
-        for j in 0..8 {
-            msg_bits.push((x >> (7 - j)) & 1);
-        }
-    }
-    msg_bits
-}
-
-fn convert_base(msg: &[u8], lg_b: u16) -> Vec<u8> {
-    let msg_bits = to_bits(msg);
-    // chunking is guaranteed to be exact because WotsParams::new() enforces (8 * n) % lg_w = 0
-    let mut result = Vec::with_capacity(msg_bits.len() / lg_b as usize);
-    for chunk in msg_bits.chunks(lg_b as usize) {
-        // acc < 2^lg_b by construction; WotsParams::new() enforces lg_b ≤ 8, so acc fits in u8.
-        let mut acc: u8 = 0;
-        for &bit in chunk {
-            acc = (acc << 1) | bit;
-        }
-        result.push(acc);
-    }
-    result
-}
-
 fn encode_message(params: &WotsParams, msg: &[u8]) -> Vec<u8> {
     assert_eq!(
         msg.len(),
         params.n as usize,
         "msg length doesn't match params"
     );
-    let mut msg_digits = convert_base(msg, params.lg_w);
+    // lg_w ≤ 8 is enforced by WotsParams::new(), so each digit fits in u8.
+    let mut msg_digits: Vec<u8> = bits_to_base(&bytes_to_bits(msg), params.lg_w)
+        .into_iter()
+        .map(|d| d as u8)
+        .collect();
     let sum: u16 = msg_digits.iter().map(|&d| d as u16).sum();
     let checksum = params.max_checksum() - sum;
     let mask = params.w - 1;
@@ -189,26 +187,28 @@ pub fn wots_sign(
     pk_seed: &[u8],
     adrs: Adrs,
     msg: &[u8],
-) -> Vec<Vec<u8>> {
+) -> WotsSignature {
     let msg_digits = encode_message(params, msg);
     let sks = gen_sks(params, sk_seed, pk_seed, adrs);
-    chain_all(params, pk_seed, adrs, &sks, |i| (0, msg_digits[i] as u16))
+    WotsSignature(chain_all(params, pk_seed, adrs, &sks, |i| {
+        (0, msg_digits[i] as u16)
+    }))
 }
 
 pub fn wots_pk_from_sig(
     params: &WotsParams,
-    sig: &[Vec<u8>],
+    sig: &WotsSignature,
     msg: &[u8],
     pk_seed: &[u8],
     adrs: Adrs,
 ) -> Vec<u8> {
     assert_eq!(
-        sig.len(),
+        sig.0.len(),
         params.num_elements() as usize,
         "sig length doesn't match params"
     );
     let msg_digits = encode_message(params, msg);
-    let pks = chain_all(params, pk_seed, adrs, sig, |i| {
+    let pks = chain_all(params, pk_seed, adrs, &sig.0, |i| {
         (msg_digits[i] as u16, params.w - 1)
     });
     compress_chain_pks(pks, pk_seed, adrs)
@@ -226,23 +226,6 @@ mod tests {
             assert_eq!(sphincs_params.num_checksum_digits(), 3);
             assert_eq!(sphincs_params.num_elements(), 2 * n + 3);
         }
-    }
-
-    #[test]
-    fn test_convert_base_nibbles() {
-        assert_eq!(convert_base(&[0xA3], 4), vec![0xA, 0x3]);
-        assert_eq!(convert_base(&[0xA3, 0xF0], 4), vec![0xA, 0x3, 0xF, 0x0]);
-    }
-
-    #[test]
-    fn test_convert_base_pairs() {
-        // lg_b = 2 → 0xA3 = 10 10 00 11 → [2, 2, 0, 3]
-        assert_eq!(convert_base(&[0xA3], 2), vec![2, 2, 0, 3]);
-    }
-
-    #[test]
-    fn test_convert_base_single_bits() {
-        assert_eq!(convert_base(&[0xA3], 1), vec![1, 0, 1, 0, 0, 0, 1, 1]);
     }
 
     /// Runs keygen → sign → verify and a wrong-message negative check for the given WOTS+ config.

--- a/fastcrypto/src/sphincs/xmss.rs
+++ b/fastcrypto/src/sphincs/xmss.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! XMSS implementation from FIPS-205
+//!
+//! Callers must ensure that the address input encodes XMSS tree address (layer & tree).
+
+use crate::sphincs::merkle::{build_auth_path, compute_root_from_path, merkle_node};
+use crate::sphincs::winternitz_ots::{
+    wots_pk_from_sig, wots_pk_gen, wots_sign, WotsParams, WotsSignature,
+};
+use crate::sphincs::{Adrs, AdrsType};
+
+/// Build a Tree ADRS for a node at `height` and `index` inside an XMSS tree.
+/// Sets `type = Tree` (which zeros kp, as Tree ADRS has no kp).
+fn xmss_tree_adrs(adrs: Adrs, height: impl Into<u32>, index: u32) -> Adrs {
+    adrs.with_type(AdrsType::Tree)
+        .with_tree_height(height)
+        .with_tree_index(index)
+}
+
+pub struct XmssParams {
+    /// Height of the XMSS tree (`h'`). An XMSS tree contains `2^h'` WOTS+
+    /// instances and can therefore sign `2^h'` messages.
+    pub h_prime: u8,
+    pub wots: WotsParams,
+}
+
+pub type XmssNode = Vec<u8>;
+
+pub struct XmssSignature {
+    pub wots: WotsSignature,
+    pub auth: Vec<XmssNode>,
+}
+
+impl XmssSignature {
+    pub fn size_in_bytes(&self) -> usize {
+        self.wots.size_in_bytes() + self.auth.iter().map(|n| n.len()).sum::<usize>()
+    }
+}
+
+/// Compute the XMSS subtree node at height `z` and index `i` (within that height).
+pub fn xmss_node(
+    params: &XmssParams,
+    sk_seed: &[u8],
+    i: u32,
+    z: u8,
+    pk_seed: &[u8],
+    adrs: Adrs,
+) -> XmssNode {
+    assert!(z <= params.h_prime);
+    assert!(i < 2u32.pow(u32::from(params.h_prime - z)));
+
+    let leaf_generator = |idx| {
+        wots_pk_gen(
+            &params.wots,
+            sk_seed,
+            pk_seed,
+            adrs.with_key_pair_address(idx),
+        )
+    };
+    let adrs_generator = |height, idx| xmss_tree_adrs(adrs, height, idx);
+    merkle_node(&leaf_generator, &adrs_generator, i, u16::from(z), pk_seed)
+}
+
+pub fn xmss_sign(
+    params: &XmssParams,
+    sk_seed: &[u8],
+    msg: &[u8],
+    wots_idx: u32,
+    pk_seed: &[u8],
+    adrs: Adrs,
+) -> XmssSignature {
+    let node_at = |height, sib| xmss_node(params, sk_seed, sib, height as u8, pk_seed, adrs);
+    let auth = build_auth_path(u16::from(params.h_prime), wots_idx, node_at);
+
+    XmssSignature {
+        wots: wots_sign(
+            &params.wots,
+            sk_seed,
+            pk_seed,
+            adrs.with_key_pair_address(wots_idx),
+            msg,
+        ),
+        auth,
+    }
+}
+
+pub fn xmss_pk_from_sig(
+    params: &XmssParams,
+    idx: u32,
+    sig: &XmssSignature,
+    msg: &[u8],
+    pk_seed: &[u8],
+    adrs: Adrs,
+) -> Vec<u8> {
+    let leaf = wots_pk_from_sig(
+        &params.wots,
+        &sig.wots,
+        msg,
+        pk_seed,
+        adrs.with_key_pair_address(idx),
+    );
+    let adrs_generator = |height, parent_idx| xmss_tree_adrs(adrs, height, parent_idx);
+    compute_root_from_path(leaf, idx, &sig.auth, pk_seed, adrs_generator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sphincs::params::{
+        FipsParams, FIPS_128F, FIPS_128S, FIPS_192F, FIPS_192S, FIPS_256F, FIPS_256S,
+    };
+
+    /// Sign → verify → tampered-msg rejection; assert sig size formula `n · (len_wots + h')`.
+    fn run_e2e(p: &FipsParams) {
+        let params = XmssParams {
+            h_prime: p.h_prime,
+            wots: WotsParams::new(p.n, p.lg_w),
+        };
+        let n = p.n as usize;
+        let pk_seed: Vec<u8> = (0..n).map(|i| 0xA0u8.wrapping_add(i as u8)).collect();
+        let sk_seed: Vec<u8> = (0..n).map(|i| 0x50u8.wrapping_add(i as u8)).collect();
+        let msg: Vec<u8> = (0..n).map(|i| 0x10u8.wrapping_add(i as u8)).collect();
+        let leaf: u32 = 5 % (1u32 << p.h_prime);
+        let adrs = Adrs::new();
+
+        let root = xmss_node(&params, &sk_seed, 0, p.h_prime, &pk_seed, adrs);
+        let sig = xmss_sign(&params, &sk_seed, &msg, leaf, &pk_seed, adrs);
+
+        let recovered = xmss_pk_from_sig(&params, leaf, &sig, &msg, &pk_seed, adrs);
+        assert_eq!(
+            recovered, root,
+            "[{}] recovered root must equal computed root",
+            p.name
+        );
+
+        let mut bad_msg = msg.clone();
+        bad_msg[0] ^= 1;
+        let bad_root = xmss_pk_from_sig(&params, leaf, &sig, &bad_msg, &pk_seed, adrs);
+        assert_ne!(
+            bad_root, root,
+            "[{}] tampered msg must not recover root",
+            p.name
+        );
+
+        let num_elems = params.wots.num_elements() as usize;
+        assert_eq!(
+            sig.size_in_bytes(),
+            n * (num_elems + p.h_prime as usize),
+            "[{}]",
+            p.name
+        );
+    }
+
+    #[test]
+    fn test_xmss_128s() {
+        run_e2e(&FIPS_128S);
+    }
+    #[test]
+    fn test_xmss_128f() {
+        run_e2e(&FIPS_128F);
+    }
+    #[test]
+    fn test_xmss_192s() {
+        run_e2e(&FIPS_192S);
+    }
+    #[test]
+    fn test_xmss_192f() {
+        run_e2e(&FIPS_192F);
+    }
+    #[test]
+    fn test_xmss_256s() {
+        run_e2e(&FIPS_256S);
+    }
+    #[test]
+    fn test_xmss_256f() {
+        run_e2e(&FIPS_256F);
+    }
+}

--- a/fastcrypto/src/sphincs/xmss.rs
+++ b/fastcrypto/src/sphincs/xmss.rs
@@ -11,13 +11,9 @@ use crate::sphincs::winternitz_ots::{
 };
 use crate::sphincs::{Adrs, AdrsType};
 
-/// Build a Tree ADRS for a node at `height` and `index` inside an XMSS tree.
-/// Sets `type = Tree` (which zeros kp, as Tree ADRS has no kp).
-fn xmss_tree_adrs(adrs: Adrs, height: impl Into<u32>, index: u32) -> Adrs {
-    adrs.with_type(AdrsType::Tree)
-        .with_tree_height(height)
-        .with_tree_index(index)
-}
+// ------------------------------------------------------------------
+//                            Parameters
+// ------------------------------------------------------------------
 
 pub struct XmssParams {
     /// Height of the XMSS tree (`h'`). An XMSS tree contains `2^h'` WOTS+
@@ -37,6 +33,18 @@ impl XmssSignature {
     pub fn size_in_bytes(&self) -> usize {
         self.wots.size_in_bytes() + self.auth.iter().map(|n| n.len()).sum::<usize>()
     }
+}
+
+// ------------------------------------------------------------------
+//                             Helpers
+// ------------------------------------------------------------------
+
+/// Build a Tree ADRS for a node at `height` and `index` inside an XMSS tree.
+/// Sets `type = Tree` (which zeros kp, as Tree ADRS has no kp).
+fn xmss_tree_adrs(adrs: Adrs, height: impl Into<u32>, index: u32) -> Adrs {
+    adrs.with_type(AdrsType::Tree)
+        .with_tree_height(height)
+        .with_tree_index(index)
 }
 
 /// Compute the XMSS subtree node at height `z` and index `i` (within that height).
@@ -62,6 +70,10 @@ pub fn xmss_node(
     let adrs_generator = |height, idx| xmss_tree_adrs(adrs, height, idx);
     merkle_node(&leaf_generator, &adrs_generator, i, u16::from(z), pk_seed)
 }
+
+// ------------------------------------------------------------------
+//                          Public API
+// ------------------------------------------------------------------
 
 pub fn xmss_sign(
     params: &XmssParams,


### PR DESCRIPTION
## Summary

Adds the three SLH-DSA building blocks between WOTS+ (already on main, #947) and the eventual top-level `slh_sign` / `slh_verify` (follow-up PR):

- **FORS** — per-leaf Forest of Random Subsets (FIPS 205 §8)
- **XMSS** — single-tree Merkle signature (FIPS 205 §6)
- **Hypertree** — `d`-layer stack of XMSS trees (FIPS 205 §7)

Plus shared machinery used by the above:

- `merkle` — recursive subtree computation, auth-path build / verify
- `utils` — byte↔bit + base-`2^b` conversions (used by FORS and WOTS+)
- `params` — canonical `FipsParams` table for FIPS 205 approved sets

The follow-up PR will add `slh_dsa.rs` (top-level Alg. 18/19/20), NIST ACVP KATs, a bench, and the `prf_msg` / `h_msg` helpers in `hash.rs`.

## Test plan

Each of `fors`, `xmss`, `hypertree` has a `run_e2e` helper + six FIPS 205 parameter-set test wrappers (`128s/f, 192s/f, 256s/f`). Each e2e test does sign → verify → tampered-msg rejection and asserts the spec sig-size formula against the sig it produced. `params.rs` anchors `m` and `sig_size` to FIPS 205 Table 1 for the cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)