### PR TITLE
Add prop_reduce weight reduction

### DIFF
--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -292,9 +292,243 @@ impl<G: GroupElement + Serialize> Nodes<G> {
             new_f,
         ))
     }
+
+    /// Same API shape as [`Nodes::new_reduced`]: takes `nodes_vec`, signing threshold
+    /// `t`, precision budget `allowed_delta`, and `total_weight_lower_bound`, and
+    /// returns the reduced [`Nodes`] together with `t' = ceil(t * W' / W)` for the
+    /// effective divisor implied by the reduced profile (`W` / `W'`).
+    ///
+    /// Internally this runs [`Nodes::prop_reduce`] (fractional divisor search with
+    /// exact per-profile `delta` and the `delta + 2*d <= allowed_delta` criterion)
+    /// and then applies the same ceiling scaling as Stage 2 for the `t` parameter only.
+    pub fn prop_reduced(
+        nodes_vec: Vec<Node<G>>,
+        t: u16,
+        allowed_delta: u16,
+        total_weight_lower_bound: u16,
+    ) -> FastCryptoResult<(Self, u16)> {
+        let w_orig = Self::new(nodes_vec.clone())?.total_weight();
+        let reduced = Self::prop_reduce(nodes_vec, allowed_delta, total_weight_lower_bound)?;
+        let w_prime = reduced.total_weight();
+        let (new_t, _) = derive_reduced_params(t, 0, w_orig, w_prime);
+        Ok((reduced, new_t))
+    }
+
+    /// Same API shape as [`Nodes::new_reduced_with_f`]: takes `nodes_vec`, `t`, `f`,
+    /// `allowed_delta`, and `total_weight_lower_bound`, and returns the reduced
+    /// [`Nodes`] together with `t' = ceil(t * W' / W)` and `f' = ceil(f * W' / W)`.
+    ///
+    /// Internally this runs [`Nodes::prop_reduce`] and then applies the same
+    /// ceiling scaling as Stage 2 for both parameters.
+    pub fn prop_reduced_with_f(
+        nodes_vec: Vec<Node<G>>,
+        t: u16,
+        f: u16,
+        allowed_delta: u16,
+        total_weight_lower_bound: u16,
+    ) -> FastCryptoResult<(Self, u16, u16)> {
+        let w_orig = Self::new(nodes_vec.clone())?.total_weight();
+        let reduced = Self::prop_reduce(nodes_vec, allowed_delta, total_weight_lower_bound)?;
+        let w_prime = reduced.total_weight();
+        let (new_t, new_f) = derive_reduced_params(t, f, w_orig, w_prime);
+        Ok((reduced, new_t, new_f))
+    }
+
+    /// Stage 1 of the `prop` two-stage weight-reduction API. The reduction depends *only* on the original weights and the
+    /// precision budget `allowed_delta`; the threshold parameters `(t, f)` are not
+    /// inputs here. Stage 2 (see [`derive_reduced_params`]) turns any subsequent
+    /// `(t, f)` into reduced-space `(t', f')` in closed form.
+    ///
+    /// Behaves as a unilateral reduction: each reduced weight is `w'_i = floor(w_i / D)`
+    /// for a trial divisor `D`, and the routine searches for the largest feasible `D`
+    /// in `[2, 100]` at granularity `1/100`. At each candidate it evaluates the *exact*
+    /// precision loss `delta = sum_i max(w_i - w'_i * d, 0)` against the effective
+    /// divisor `d = W / W'` (rather than the conservative `sum_i (w_i mod D)` surrogate
+    /// used by `new_reduced` / `new_reduced_with_f`).
+    ///
+    /// The Stage-1 search criterion is the conservative bound
+    ///
+    ///   `delta + 2 * d <= allowed_delta`.
+    ///
+    /// The constant `2` is the worst-case sum of the two ceiling overheads
+    /// `delta_t = ceil(t/d) * d - t` and `delta_f = ceil(f/d) * d - f` that any
+    /// later Stage-2 instantiation can introduce; reserving `2 * d` of the budget
+    /// up front pre-pays the worst case for *every* `(t, f)` a caller might pass
+    /// to [`derive_reduced_params`]. As a result, the resulting reduction admits
+    /// the clean liveness statement
+    ///
+    ///   `w(S) >= t + f + allowed_delta  =>  w'(S) >= t' + f'`,
+    ///
+    /// uniformly across all valid `(t, f)`.
+    ///
+    /// The sweep follows the structure of the spec: each integer step `D = 2..=100`
+    /// is followed, when it overshoots the budget, by a fine sweep of the preceding
+    /// unit interval `(D - 1, D)` in `0.01` increments; the search then stops at the
+    /// first integer overshoot.
+    ///
+    /// `total_weight_lower_bound` allows limiting the level of reduction (e.g., in
+    /// benchmarks). Set to `1` to get the smallest committee the budget admits.
+    pub fn prop_reduce(
+        nodes_vec: Vec<Node<G>>,
+        allowed_delta: u16,
+        total_weight_lower_bound: u16,
+    ) -> FastCryptoResult<Self> {
+        let n = Self::new(nodes_vec)?; // checks the input, etc
+        assert!(total_weight_lower_bound <= n.total_weight && total_weight_lower_bound > 0);
+
+        let total_weight = n.total_weight as u32;
+        let allowed_delta_u64 = allowed_delta as u64;
+        let lower_bound = total_weight_lower_bound as u32;
+
+        // The trial divisor `D` is represented as `D * 100` in u32 so that the sweep
+        // step `0.01` corresponds to a single integer unit.
+        let mut best_d_x100: u32 = 100; // D = 1, i.e., no reduction.
+
+        'sweep: for d_int in 2u32..=100 {
+            let d_x100 = d_int * 100;
+            let (w_total, delta_scaled) = check_outcome(&n.nodes, d_x100, total_weight);
+            if w_total < lower_bound {
+                // Further increases of D can only shrink W'; nothing more to find.
+                break 'sweep;
+            }
+            if is_feasible(delta_scaled, w_total, total_weight, allowed_delta_u64) {
+                best_d_x100 = d_x100;
+                continue;
+            }
+            // Integer step overshoots: fine-sweep the preceding unit interval
+            // (d_int - 1, d_int) at 0.01 granularity, scanning largest-first so the
+            // first feasible candidate is the largest feasible D in that interval.
+            for k in (1..100).rev() {
+                let d_frac_x100 = (d_int - 1) * 100 + k;
+                let (w_total_frac, delta_frac_scaled) =
+                    check_outcome(&n.nodes, d_frac_x100, total_weight);
+                if w_total_frac < lower_bound {
+                    continue;
+                }
+                if is_feasible(
+                    delta_frac_scaled,
+                    w_total_frac,
+                    total_weight,
+                    allowed_delta_u64,
+                ) {
+                    if d_frac_x100 > best_d_x100 {
+                        best_d_x100 = d_frac_x100;
+                    }
+                    break;
+                }
+            }
+            break 'sweep;
+        }
+
+        let nodes: Vec<Node<G>> = n
+            .nodes
+            .iter()
+            .map(|node| Node {
+                id: node.id,
+                pk: node.pk.clone(),
+                weight: ((node.weight as u32 * 100) / best_d_x100) as u16,
+            })
+            .collect();
+
+        let total_weight_reduced = nodes.iter().map(|n| n.weight as u32).sum::<u32>();
+        debug!(
+            "Nodes::prop_reduce reducing from {} to {} with D*100 = {}, allowed_delta {}, total_weight_lower_bound {}",
+            n.total_weight, total_weight_reduced, best_d_x100, allowed_delta, total_weight_lower_bound
+        );
+
+        let total_weight_reduced_u16 = total_weight_reduced as u16;
+        let accumulated_weights = Self::get_accumulated_weights(&nodes);
+        let nodes_with_nonzero_weight = Self::filter_nonzero_weights(&nodes);
+        Ok(Self {
+            nodes,
+            total_weight: total_weight_reduced_u16,
+            accumulated_weights,
+            nodes_with_nonzero_weight,
+        })
+    }
+}
+
+/// Stage 2 of the `prop` two-stage weight-reduction API. Given the original-space
+/// flexible-threshold parameters `(t, f)` and the totals implied by Stage 1
+/// (`total_weight_orig` = `W`, `total_weight_reduced` = `W'`), returns
+///
+///   `t' = ceil(t * W' / W)`,
+///   `f' = ceil(f * W' / W)`.
+///
+/// This is the same ceiling scaling used by [`Nodes::prop_reduced`] /
+/// [`Nodes::prop_reduced_with_f`] after [`Nodes::prop_reduce`]. It is purely
+/// arithmetic --- no search over the weight profile --- so the same Stage-1
+/// output can be reused across many `(t, f)` choices without re-running
+/// [`Nodes::prop_reduce`].
+///
+/// The flexible-threshold protocol assumes `t > f` in original space; this
+/// function does not assert that. The two ceilings can collapse to `t' = f'`
+/// when `t - f` is small relative to the effective divisor `d = W / W'`; this
+/// is operationally harmless because `f'` only feeds reduced-space certification
+/// thresholds, not the AVSS `t > f` check.
+pub fn derive_reduced_params(
+    t: u16,
+    f: u16,
+    total_weight_orig: u16,
+    total_weight_reduced: u16,
+) -> (u16, u16) {
+    assert!(total_weight_orig > 0);
+    let w_o = total_weight_orig as u64;
+    let w_p = total_weight_reduced as u64;
+    let t_prime = (t as u64 * w_p).div_ceil(w_o) as u16;
+    let f_prime = (f as u64 * w_p).div_ceil(w_o) as u16;
+    (t_prime, f_prime)
 }
 
 /// Compute (-x) mod d = d * ceil(x/d) - x
 fn neg_mod(x: u16, d: u16) -> u16 {
     (-(x as i32)).rem_euclid(d as i32) as u16
+}
+
+/// Helper for [`Nodes::prop_reduce`]. Tests the Stage-1 search criterion
+/// `δ + 2d ≤ δ_allowed`, multiplied through by `W'` to keep everything in integers:
+///
+/// ```text
+///   (δ + 2d) * W'  ≤  δ_allowed * W'
+///   ⟺  δ_scaled + 2 * W  ≤  δ_allowed * W'.
+/// ```
+///
+/// `delta_scaled = δ * W' = Σ max(w_i * W' - w'_i * W, 0)` is computed by
+/// [`check_outcome`].
+fn is_feasible(delta_scaled: u64, w_total: u32, total_weight: u32, allowed_delta: u64) -> bool {
+    let lhs = delta_scaled + 2 * (total_weight as u64);
+    let rhs = allowed_delta * (w_total as u64);
+    lhs <= rhs
+}
+
+/// Helper for [`Nodes::prop_reduce`]. Returns `(W', delta * W')` for the reduced
+/// profile `w'_i = floor(w_i * 100 / d_x100)`. The product `delta * W'` is returned
+/// in place of `delta` so that feasibility can be tested in fully-integer arithmetic
+/// (see [`is_feasible`]). When `W' = 0` we return `u64::MAX` for the scaled delta
+/// to flag the candidate as infeasible.
+fn check_outcome<G: GroupElement>(nodes: &[Node<G>], d_x100: u32, total_weight: u32) -> (u32, u64) {
+    let mut w_total: u32 = 0;
+    let mut w_prime: Vec<u16> = Vec::with_capacity(nodes.len());
+    for node in nodes {
+        let w_p = ((node.weight as u32 * 100) / d_x100) as u16;
+        w_total += w_p as u32;
+        w_prime.push(w_p);
+    }
+    if w_total == 0 {
+        return (0, u64::MAX);
+    }
+    // delta = sum_i max(w_i - w'_i * d, 0) with d = W / W'.
+    // Multiplying through by W' gives delta * W' = sum_i max(w_i * W' - w'_i * W, 0),
+    // which is the integer quantity we accumulate below.
+    let total_weight_u64 = total_weight as u64;
+    let w_total_u64 = w_total as u64;
+    let mut delta_scaled: u64 = 0;
+    for (node, &w_p) in nodes.iter().zip(w_prime.iter()) {
+        let lhs = (node.weight as u64) * w_total_u64;
+        let rhs = (w_p as u64) * total_weight_u64;
+        if lhs > rhs {
+            delta_scaled += lhs - rhs;
+        }
+    }
+    (w_total, delta_scaled)
 }

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -293,94 +293,79 @@ impl<G: GroupElement + Serialize> Nodes<G> {
         ))
     }
 
-    /// Same API as [`Nodes::new_reduced_with_f`], with two changes relative to
-    /// the integer-only routine:
+    /// Create a new set of nodes. Nodes must have consecutive ids starting from 0.
+    /// Like [`Nodes::new_reduced_with_f`], but in addition to the integer divisor
+    /// sweep, fine-sweeps the unit interval above the first feasible integer at
+    /// granularity 0.01 to find a (possibly strictly larger) fractional divisor d.
+    /// Finds the largest d such that:
+    /// - The new threshold is ceil(t / d)
+    /// - The new threshold for Byzantine parties is ceil(f / d)
+    /// - The new weights are all divided by d (floor division)
+    /// - The precision loss, counted as the sum of remainders Σ_i (w_i mod d) plus the
+    ///   ceiling overheads (-t) mod d and (-f) mod d, is at most the allowed delta
     ///
-    ///   1. The integer divisor sweep goes *downward* from `40` to `2`, breaking
-    ///      on the first feasible integer `d_int`. Going down, the first feasible
-    ///      candidate is by definition the largest feasible *integer* `d`, so
-    ///      no further integer steps need to be evaluated. (The criterion is not
-    ///      monotone in `d`, so an upward sweep cannot use this early-termination
-    ///      shortcut: e.g.\ for `t = 100`, `neg_mod(t, 10) = 0` but
-    ///      `neg_mod(t, 11) = 10`, then `neg_mod(t, 100) = 0` again.)
+    /// Operates on a 0.01-multiple grid for d (represented internally in u64
+    /// arithmetic via d_x100 = 100*d). The Stage-1 criterion is the natural
+    /// fractional-d extension of the one in `new_reduced_with_f`, with
+    /// (w mod d) := w - floor(w/d) * d ∈ [0, d) for any real d > 0; the
+    /// Safety, Liveness, and Byzantine-removal proofs go through verbatim.
+    /// Since prop_reduce considers a strict superset of `new_reduced_with_f`'s
+    /// candidates, its reduced total weight (and ceilings t', f') are always
+    /// ≤ those of `new_reduced_with_f`.
     ///
-    ///   2. After locking onto the first feasible integer `d_int`, the routine
-    ///      fine-sweeps the unit interval `(d_int, d_int + 1)` at granularity
-    ///      `0.01`, decreasing-first, and takes the first hit. Since `d_int`
-    ///      is feasible and `d_int + 1` is infeasible (or out of range), the
-    ///      criterion's feasibility boundary lives somewhere in `(d_int, d_int+1)`,
-    ///      and the largest fractional candidate at `0.01` granularity in that
-    ///      interval is returned (or `d_int` itself if no fractional candidate
-    ///      satisfies the criterion).
+    /// In practice, allowed delta will be the extra liveness we would assume above 2f+1.
     ///
-    /// The criterion is the natural fractional-`d` extension of the one used
-    /// by [`Nodes::new_reduced_with_f`]:
-    ///
-    ///   `Σ_i (w_i mod d) + neg_mod(t, d) + neg_mod(f, d) ≤ allowed_delta`,
-    ///
-    /// with `(w mod d) = w - floor(w/d) * d ∈ [0, d)` and
-    /// `neg_mod(w, d) = ceil(w/d) * d - w ∈ [0, d)` for any real `d > 0`.
-    /// Stage-2 outputs `w'_i = floor(w_i / d)`, `t' = ceil(t / d)`,
-    /// `f' = ceil(f / d)` use only floor/ceiling identities and integer
-    /// arithmetic on the reduced weights, so the safety, liveness, and
-    /// Byzantine-removal proofs go through verbatim for fractional `d`.
-    ///
-    /// All fractional arithmetic is carried out in u64 against the integer
-    /// representation `d_x100 = 100 * d` (so `d_x100 ∈ {200, ..., 4099}` covers
-    /// the integer sweep `[2, 40]` and the fractional sweep `(d_int, d_int+1)`
-    /// at `0.01` granularity); no floating-point is involved.
-    ///
-    /// Because every candidate considered by [`Nodes::new_reduced_with_f`] is
-    /// also considered here, `W'_prop ≤ W'_new` on every input. When the chosen
-    /// `d` is integer (i.e., `d_x100` is a multiple of 100), the two routines
-    /// return identical reduced weights and `(t', f')`.
-    ///
-    /// Returns `(reduced_nodes, t', f', d_x100)` where `d_x100 = 100 * d` is
-    /// the chosen divisor in integer form; the divisor itself is `d_x100 / 100`.
+    /// total_weight_lower_bound allows limiting the level of reduction (e.g., in benchmarks). To
+    /// get the best results, set it to 1.
     pub fn prop_reduce(
         nodes_vec: Vec<Node<G>>,
         t: u16,
         f: u16,
         allowed_delta: u16,
         total_weight_lower_bound: u16,
-    ) -> FastCryptoResult<(Self, u16, u16, u32)> {
+    ) -> FastCryptoResult<(Self, u16, u16)> {
         let n = Self::new(nodes_vec)?; // checks the input, etc
         assert!(total_weight_lower_bound <= n.total_weight && total_weight_lower_bound > 0);
-
-        let allowed_delta_x100: u64 = (allowed_delta as u64) * 100;
-        let mut max_d_x100: u32 = 100; // d = 1, no reduction (fallback if no d in [2, 40] works)
-
-        'outer: for d_int in (2u16..=40).rev() {
-            // Integer-d feasibility check (identical to new_reduced_with_f).
-            let new_total_int = n.nodes.iter().map(|n| n.weight / d_int).sum::<u16>();
-            if new_total_int < total_weight_lower_bound {
+        let allowed_delta_x100 = (allowed_delta as u64) * 100;
+        let mut max_d_x100: u32 = 100; // d = 1, no reduction
+                                       // Sweep d downward from 40 to 2. Going down, the first feasible integer
+                                       // is the largest feasible integer divisor (the criterion is non-monotone
+                                       // in d, so an upward sweep cannot break early). After locking onto the
+                                       // first feasible integer d, fine-sweep (d, d+1) at 0.01 in decreasing
+                                       // order to find the largest feasible fractional divisor in that interval.
+        'outer: for d in (2u16..=40).rev() {
+            // Continue if we are below the lower bound. (Going down, W' grows as
+            // d shrinks, so once W' clears the lower bound it stays cleared.)
+            // U16 is safe here since total_weight is u16.
+            let new_total_weight = n.nodes.iter().map(|n| n.weight / d).sum::<u16>();
+            if new_total_weight < total_weight_lower_bound {
                 continue;
             }
-            let delta_int = n.nodes.iter().map(|n| n.weight % d_int).sum::<u16>()
-                + neg_mod(t, d_int)
-                + neg_mod(f, d_int);
-            if delta_int > allowed_delta {
+            // Compute the precision loss at integer d.
+            // U16 is safe here since total_weight is u16.
+            let delta =
+                n.nodes.iter().map(|n| n.weight % d).sum::<u16>() + neg_mod(t, d) + neg_mod(f, d);
+            if delta > allowed_delta {
                 continue;
             }
-            // First feasible integer d_int going down: lock it as the fallback,
-            // then fine-sweep (d_int, d_int + 1) at 0.01 in decreasing order to
-            // see whether a strictly larger fractional d is also feasible.
-            max_d_x100 = (d_int as u32) * 100;
+            // Integer d is feasible; lock it as the fallback.
+            max_d_x100 = (d as u32) * 100;
+            // Fine-sweep (d, d+1) at 0.01, largest-first. The first hit is the
+            // largest feasible 0.01-multiple in that interval.
             for k in (1..100u32).rev() {
-                let d_x100 = (d_int as u32) * 100 + k;
-                let new_w_total: u32 = n
+                let d_x100 = (d as u32) * 100 + k;
+                let new_w_total = n
                     .nodes
                     .iter()
-                    .map(|node| ((node.weight as u32) * 100) / d_x100)
-                    .sum();
+                    .map(|n| ((n.weight as u32) * 100) / d_x100)
+                    .sum::<u32>();
                 if (new_w_total as u16) < total_weight_lower_bound {
                     continue;
                 }
-                // Σ_i (w_i mod d) * 100 = W * 100 - W' * d_x100 (telescopes by floor).
-                let sum_mod_x100: u64 =
+                // Σ_i (w_i mod d) * 100 = W*100 − W' * d_x100 (telescopes by floor).
+                let sum_mod_x100 =
                     (n.total_weight as u64) * 100 - (new_w_total as u64) * (d_x100 as u64);
-                let delta_x100: u64 =
-                    sum_mod_x100 + neg_mod_x100(t, d_x100) + neg_mod_x100(f, d_x100);
+                let delta_x100 = sum_mod_x100 + neg_mod_x100(t, d_x100) + neg_mod_x100(f, d_x100);
                 if delta_x100 <= allowed_delta_x100 {
                     max_d_x100 = d_x100;
                     break;
@@ -388,26 +373,26 @@ impl<G: GroupElement + Serialize> Nodes<G> {
             }
             break 'outer;
         }
-
         debug!(
-            "Nodes::prop_reduce reducing from {} with d_x100 {}, allowed_delta {}, total_weight_lower_bound {}",
+            "Nodes::prop_reduce reducing from {} with max_d_x100 {}, allowed_delta {}, total_weight_lower_bound {}",
             n.total_weight, max_d_x100, allowed_delta, total_weight_lower_bound
         );
 
         let nodes = n
             .nodes
             .iter()
-            .map(|node| Node {
-                id: node.id,
-                pk: node.pk.clone(),
-                weight: (((node.weight as u32) * 100) / max_d_x100) as u16,
+            .map(|n| Node {
+                id: n.id,
+                pk: n.pk.clone(),
+                weight: (((n.weight as u32) * 100) / max_d_x100) as u16,
             })
             .collect::<Vec<_>>();
         let accumulated_weights = Self::get_accumulated_weights(&nodes);
         let nodes_with_nonzero_weight = Self::filter_nonzero_weights(&nodes);
+        // U16 is safe here since the original total_weight is u16.
         let total_weight = nodes.iter().map(|n| n.weight).sum::<u16>();
-        let new_t = (((t as u64) * 100).div_ceil(max_d_x100 as u64)) as u16;
-        let new_f = (((f as u64) * 100).div_ceil(max_d_x100 as u64)) as u16;
+        let new_t = ((t as u64) * 100).div_ceil(max_d_x100 as u64) as u16;
+        let new_f = ((f as u64) * 100).div_ceil(max_d_x100 as u64) as u16;
         Ok((
             Self {
                 nodes,
@@ -417,19 +402,17 @@ impl<G: GroupElement + Serialize> Nodes<G> {
             },
             new_t,
             new_f,
-            max_d_x100,
         ))
     }
 }
 
-/// Compute `(-x) mod d = d * ceil(x/d) - x` for an integer divisor `d > 0`.
+/// Compute (-x) mod d = d * ceil(x/d) - x
 fn neg_mod(x: u16, d: u16) -> u16 {
     (-(x as i32)).rem_euclid(d as i32) as u16
 }
 
-/// Compute `((-w) mod d) * 100`, the ceiling overhead of `w` against the
-/// possibly-fractional divisor `d = d_x100 / 100`, scaled by 100. The result
-/// equals `(ceil(w/d) * d - w) * 100` and is a non-negative integer in `[0, d_x100)`.
+/// Compute ((-w) mod d) * 100 for the possibly-fractional divisor d = d_x100 / 100.
+/// Equals (ceil(w/d) * d - w) * 100, a non-negative integer in [0, d_x100).
 fn neg_mod_x100(w: u16, d_x100: u32) -> u64 {
     let r = ((w as u64) * 100) % (d_x100 as u64);
     if r == 0 {

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -293,242 +293,148 @@ impl<G: GroupElement + Serialize> Nodes<G> {
         ))
     }
 
-    /// Same API shape as [`Nodes::new_reduced`]: takes `nodes_vec`, signing threshold
-    /// `t`, precision budget `allowed_delta`, and `total_weight_lower_bound`, and
-    /// returns the reduced [`Nodes`] together with `t' = ceil(t * W' / W)` for the
-    /// effective divisor implied by the reduced profile (`W` / `W'`).
+    /// Same API as [`Nodes::new_reduced_with_f`], with two changes relative to
+    /// the integer-only routine:
     ///
-    /// Internally this runs [`Nodes::prop_reduce`] (fractional divisor search with
-    /// exact per-profile `delta` and the `delta + 2*d <= allowed_delta` criterion)
-    /// and then applies the same ceiling scaling as Stage 2 for the `t` parameter only.
-    pub fn prop_reduced(
-        nodes_vec: Vec<Node<G>>,
-        t: u16,
-        allowed_delta: u16,
-        total_weight_lower_bound: u16,
-    ) -> FastCryptoResult<(Self, u16)> {
-        let w_orig = Self::new(nodes_vec.clone())?.total_weight();
-        let reduced = Self::prop_reduce(nodes_vec, allowed_delta, total_weight_lower_bound)?;
-        let w_prime = reduced.total_weight();
-        let (new_t, _) = derive_reduced_params(t, 0, w_orig, w_prime);
-        Ok((reduced, new_t))
-    }
-
-    /// Same API shape as [`Nodes::new_reduced_with_f`]: takes `nodes_vec`, `t`, `f`,
-    /// `allowed_delta`, and `total_weight_lower_bound`, and returns the reduced
-    /// [`Nodes`] together with `t' = ceil(t * W' / W)` and `f' = ceil(f * W' / W)`.
+    ///   1. The integer divisor sweep goes *downward* from `40` to `2`, breaking
+    ///      on the first feasible integer `d_int`. Going down, the first feasible
+    ///      candidate is by definition the largest feasible *integer* `d`, so
+    ///      no further integer steps need to be evaluated. (The criterion is not
+    ///      monotone in `d`, so an upward sweep cannot use this early-termination
+    ///      shortcut: e.g.\ for `t = 100`, `neg_mod(t, 10) = 0` but
+    ///      `neg_mod(t, 11) = 10`, then `neg_mod(t, 100) = 0` again.)
     ///
-    /// Internally this runs [`Nodes::prop_reduce`] and then applies the same
-    /// ceiling scaling as Stage 2 for both parameters.
-    pub fn prop_reduced_with_f(
+    ///   2. After locking onto the first feasible integer `d_int`, the routine
+    ///      fine-sweeps the unit interval `(d_int, d_int + 1)` at granularity
+    ///      `0.01`, decreasing-first, and takes the first hit. Since `d_int`
+    ///      is feasible and `d_int + 1` is infeasible (or out of range), the
+    ///      criterion's feasibility boundary lives somewhere in `(d_int, d_int+1)`,
+    ///      and the largest fractional candidate at `0.01` granularity in that
+    ///      interval is returned (or `d_int` itself if no fractional candidate
+    ///      satisfies the criterion).
+    ///
+    /// The criterion is the natural fractional-`d` extension of the one used
+    /// by [`Nodes::new_reduced_with_f`]:
+    ///
+    ///   `Σ_i (w_i mod d) + neg_mod(t, d) + neg_mod(f, d) ≤ allowed_delta`,
+    ///
+    /// with `(w mod d) = w - floor(w/d) * d ∈ [0, d)` and
+    /// `neg_mod(w, d) = ceil(w/d) * d - w ∈ [0, d)` for any real `d > 0`.
+    /// Stage-2 outputs `w'_i = floor(w_i / d)`, `t' = ceil(t / d)`,
+    /// `f' = ceil(f / d)` use only floor/ceiling identities and integer
+    /// arithmetic on the reduced weights, so the safety, liveness, and
+    /// Byzantine-removal proofs go through verbatim for fractional `d`.
+    ///
+    /// All fractional arithmetic is carried out in u64 against the integer
+    /// representation `d_x100 = 100 * d` (so `d_x100 ∈ {200, ..., 4099}` covers
+    /// the integer sweep `[2, 40]` and the fractional sweep `(d_int, d_int+1)`
+    /// at `0.01` granularity); no floating-point is involved.
+    ///
+    /// Because every candidate considered by [`Nodes::new_reduced_with_f`] is
+    /// also considered here, `W'_prop ≤ W'_new` on every input. When the chosen
+    /// `d` is integer (i.e., `d_x100` is a multiple of 100), the two routines
+    /// return identical reduced weights and `(t', f')`.
+    ///
+    /// Returns `(reduced_nodes, t', f', d_x100)` where `d_x100 = 100 * d` is
+    /// the chosen divisor in integer form; the divisor itself is `d_x100 / 100`.
+    pub fn prop_reduce(
         nodes_vec: Vec<Node<G>>,
         t: u16,
         f: u16,
         allowed_delta: u16,
         total_weight_lower_bound: u16,
-    ) -> FastCryptoResult<(Self, u16, u16)> {
-        let w_orig = Self::new(nodes_vec.clone())?.total_weight();
-        let reduced = Self::prop_reduce(nodes_vec, allowed_delta, total_weight_lower_bound)?;
-        let w_prime = reduced.total_weight();
-        let (new_t, new_f) = derive_reduced_params(t, f, w_orig, w_prime);
-        Ok((reduced, new_t, new_f))
-    }
-
-    /// Stage 1 of the `prop` two-stage weight-reduction API. The reduction depends *only* on the original weights and the
-    /// precision budget `allowed_delta`; the threshold parameters `(t, f)` are not
-    /// inputs here. Stage 2 (see [`derive_reduced_params`]) turns any subsequent
-    /// `(t, f)` into reduced-space `(t', f')` in closed form.
-    ///
-    /// Behaves as a unilateral reduction: each reduced weight is `w'_i = floor(w_i / D)`
-    /// for a trial divisor `D`, and the routine searches for the largest feasible `D`
-    /// in `[2, 100]` at granularity `1/100`. At each candidate it evaluates the *exact*
-    /// precision loss `delta = sum_i max(w_i - w'_i * d, 0)` against the effective
-    /// divisor `d = W / W'` (rather than the conservative `sum_i (w_i mod D)` surrogate
-    /// used by `new_reduced` / `new_reduced_with_f`).
-    ///
-    /// The Stage-1 search criterion is the conservative bound
-    ///
-    ///   `delta + 2 * d <= allowed_delta`.
-    ///
-    /// The constant `2` is the worst-case sum of the two ceiling overheads
-    /// `delta_t = ceil(t/d) * d - t` and `delta_f = ceil(f/d) * d - f` that any
-    /// later Stage-2 instantiation can introduce; reserving `2 * d` of the budget
-    /// up front pre-pays the worst case for *every* `(t, f)` a caller might pass
-    /// to [`derive_reduced_params`]. As a result, the resulting reduction admits
-    /// the clean liveness statement
-    ///
-    ///   `w(S) >= t + f + allowed_delta  =>  w'(S) >= t' + f'`,
-    ///
-    /// uniformly across all valid `(t, f)`.
-    ///
-    /// The sweep follows the structure of the spec: each integer step `D = 2..=100`
-    /// is followed, when it overshoots the budget, by a fine sweep of the preceding
-    /// unit interval `(D - 1, D)` in `0.01` increments; the search then stops at the
-    /// first integer overshoot.
-    ///
-    /// `total_weight_lower_bound` allows limiting the level of reduction (e.g., in
-    /// benchmarks). Set to `1` to get the smallest committee the budget admits.
-    pub fn prop_reduce(
-        nodes_vec: Vec<Node<G>>,
-        allowed_delta: u16,
-        total_weight_lower_bound: u16,
-    ) -> FastCryptoResult<Self> {
+    ) -> FastCryptoResult<(Self, u16, u16, u32)> {
         let n = Self::new(nodes_vec)?; // checks the input, etc
         assert!(total_weight_lower_bound <= n.total_weight && total_weight_lower_bound > 0);
 
-        let total_weight = n.total_weight as u32;
-        let allowed_delta_u64 = allowed_delta as u64;
-        let lower_bound = total_weight_lower_bound as u32;
+        let allowed_delta_x100: u64 = (allowed_delta as u64) * 100;
+        let mut max_d_x100: u32 = 100; // d = 1, no reduction (fallback if no d in [2, 40] works)
 
-        // The trial divisor `D` is represented as `D * 100` in u32 so that the sweep
-        // step `0.01` corresponds to a single integer unit.
-        let mut best_d_x100: u32 = 100; // D = 1, i.e., no reduction.
-
-        'sweep: for d_int in 2u32..=100 {
-            let d_x100 = d_int * 100;
-            let (w_total, delta_scaled) = check_outcome(&n.nodes, d_x100, total_weight);
-            if w_total < lower_bound {
-                // Further increases of D can only shrink W'; nothing more to find.
-                break 'sweep;
-            }
-            if is_feasible(delta_scaled, w_total, total_weight, allowed_delta_u64) {
-                best_d_x100 = d_x100;
+        'outer: for d_int in (2u16..=40).rev() {
+            // Integer-d feasibility check (identical to new_reduced_with_f).
+            let new_total_int = n.nodes.iter().map(|n| n.weight / d_int).sum::<u16>();
+            if new_total_int < total_weight_lower_bound {
                 continue;
             }
-            // Integer step overshoots: fine-sweep the preceding unit interval
-            // (d_int - 1, d_int) at 0.01 granularity, scanning largest-first so the
-            // first feasible candidate is the largest feasible D in that interval.
-            for k in (1..100).rev() {
-                let d_frac_x100 = (d_int - 1) * 100 + k;
-                let (w_total_frac, delta_frac_scaled) =
-                    check_outcome(&n.nodes, d_frac_x100, total_weight);
-                if w_total_frac < lower_bound {
+            let delta_int = n.nodes.iter().map(|n| n.weight % d_int).sum::<u16>()
+                + neg_mod(t, d_int)
+                + neg_mod(f, d_int);
+            if delta_int > allowed_delta {
+                continue;
+            }
+            // First feasible integer d_int going down: lock it as the fallback,
+            // then fine-sweep (d_int, d_int + 1) at 0.01 in decreasing order to
+            // see whether a strictly larger fractional d is also feasible.
+            max_d_x100 = (d_int as u32) * 100;
+            for k in (1..100u32).rev() {
+                let d_x100 = (d_int as u32) * 100 + k;
+                let new_w_total: u32 = n
+                    .nodes
+                    .iter()
+                    .map(|node| ((node.weight as u32) * 100) / d_x100)
+                    .sum();
+                if (new_w_total as u16) < total_weight_lower_bound {
                     continue;
                 }
-                if is_feasible(
-                    delta_frac_scaled,
-                    w_total_frac,
-                    total_weight,
-                    allowed_delta_u64,
-                ) {
-                    if d_frac_x100 > best_d_x100 {
-                        best_d_x100 = d_frac_x100;
-                    }
+                // Σ_i (w_i mod d) * 100 = W * 100 - W' * d_x100 (telescopes by floor).
+                let sum_mod_x100: u64 =
+                    (n.total_weight as u64) * 100 - (new_w_total as u64) * (d_x100 as u64);
+                let delta_x100: u64 =
+                    sum_mod_x100 + neg_mod_x100(t, d_x100) + neg_mod_x100(f, d_x100);
+                if delta_x100 <= allowed_delta_x100 {
+                    max_d_x100 = d_x100;
                     break;
                 }
             }
-            break 'sweep;
+            break 'outer;
         }
 
-        let nodes: Vec<Node<G>> = n
+        debug!(
+            "Nodes::prop_reduce reducing from {} with d_x100 {}, allowed_delta {}, total_weight_lower_bound {}",
+            n.total_weight, max_d_x100, allowed_delta, total_weight_lower_bound
+        );
+
+        let nodes = n
             .nodes
             .iter()
             .map(|node| Node {
                 id: node.id,
                 pk: node.pk.clone(),
-                weight: ((node.weight as u32 * 100) / best_d_x100) as u16,
+                weight: (((node.weight as u32) * 100) / max_d_x100) as u16,
             })
-            .collect();
-
-        let total_weight_reduced = nodes.iter().map(|n| n.weight as u32).sum::<u32>();
-        debug!(
-            "Nodes::prop_reduce reducing from {} to {} with D*100 = {}, allowed_delta {}, total_weight_lower_bound {}",
-            n.total_weight, total_weight_reduced, best_d_x100, allowed_delta, total_weight_lower_bound
-        );
-
-        let total_weight_reduced_u16 = total_weight_reduced as u16;
+            .collect::<Vec<_>>();
         let accumulated_weights = Self::get_accumulated_weights(&nodes);
         let nodes_with_nonzero_weight = Self::filter_nonzero_weights(&nodes);
-        Ok(Self {
-            nodes,
-            total_weight: total_weight_reduced_u16,
-            accumulated_weights,
-            nodes_with_nonzero_weight,
-        })
+        let total_weight = nodes.iter().map(|n| n.weight).sum::<u16>();
+        let new_t = (((t as u64) * 100).div_ceil(max_d_x100 as u64)) as u16;
+        let new_f = (((f as u64) * 100).div_ceil(max_d_x100 as u64)) as u16;
+        Ok((
+            Self {
+                nodes,
+                total_weight,
+                accumulated_weights,
+                nodes_with_nonzero_weight,
+            },
+            new_t,
+            new_f,
+            max_d_x100,
+        ))
     }
 }
 
-/// Stage 2 of the `prop` two-stage weight-reduction API. Given the original-space
-/// flexible-threshold parameters `(t, f)` and the totals implied by Stage 1
-/// (`total_weight_orig` = `W`, `total_weight_reduced` = `W'`), returns
-///
-///   `t' = ceil(t * W' / W)`,
-///   `f' = ceil(f * W' / W)`.
-///
-/// This is the same ceiling scaling used by [`Nodes::prop_reduced`] /
-/// [`Nodes::prop_reduced_with_f`] after [`Nodes::prop_reduce`]. It is purely
-/// arithmetic --- no search over the weight profile --- so the same Stage-1
-/// output can be reused across many `(t, f)` choices without re-running
-/// [`Nodes::prop_reduce`].
-///
-/// The flexible-threshold protocol assumes `t > f` in original space; this
-/// function does not assert that. The two ceilings can collapse to `t' = f'`
-/// when `t - f` is small relative to the effective divisor `d = W / W'`; this
-/// is operationally harmless because `f'` only feeds reduced-space certification
-/// thresholds, not the AVSS `t > f` check.
-pub fn derive_reduced_params(
-    t: u16,
-    f: u16,
-    total_weight_orig: u16,
-    total_weight_reduced: u16,
-) -> (u16, u16) {
-    assert!(total_weight_orig > 0);
-    let w_o = total_weight_orig as u64;
-    let w_p = total_weight_reduced as u64;
-    let t_prime = (t as u64 * w_p).div_ceil(w_o) as u16;
-    let f_prime = (f as u64 * w_p).div_ceil(w_o) as u16;
-    (t_prime, f_prime)
-}
-
-/// Compute (-x) mod d = d * ceil(x/d) - x
+/// Compute `(-x) mod d = d * ceil(x/d) - x` for an integer divisor `d > 0`.
 fn neg_mod(x: u16, d: u16) -> u16 {
     (-(x as i32)).rem_euclid(d as i32) as u16
 }
 
-/// Helper for [`Nodes::prop_reduce`]. Tests the Stage-1 search criterion
-/// `δ + 2d ≤ δ_allowed`, multiplied through by `W'` to keep everything in integers:
-///
-/// ```text
-///   (δ + 2d) * W'  ≤  δ_allowed * W'
-///   ⟺  δ_scaled + 2 * W  ≤  δ_allowed * W'.
-/// ```
-///
-/// `delta_scaled = δ * W' = Σ max(w_i * W' - w'_i * W, 0)` is computed by
-/// [`check_outcome`].
-fn is_feasible(delta_scaled: u64, w_total: u32, total_weight: u32, allowed_delta: u64) -> bool {
-    let lhs = delta_scaled + 2 * (total_weight as u64);
-    let rhs = allowed_delta * (w_total as u64);
-    lhs <= rhs
-}
-
-/// Helper for [`Nodes::prop_reduce`]. Returns `(W', delta * W')` for the reduced
-/// profile `w'_i = floor(w_i * 100 / d_x100)`. The product `delta * W'` is returned
-/// in place of `delta` so that feasibility can be tested in fully-integer arithmetic
-/// (see [`is_feasible`]). When `W' = 0` we return `u64::MAX` for the scaled delta
-/// to flag the candidate as infeasible.
-fn check_outcome<G: GroupElement>(nodes: &[Node<G>], d_x100: u32, total_weight: u32) -> (u32, u64) {
-    let mut w_total: u32 = 0;
-    let mut w_prime: Vec<u16> = Vec::with_capacity(nodes.len());
-    for node in nodes {
-        let w_p = ((node.weight as u32 * 100) / d_x100) as u16;
-        w_total += w_p as u32;
-        w_prime.push(w_p);
+/// Compute `((-w) mod d) * 100`, the ceiling overhead of `w` against the
+/// possibly-fractional divisor `d = d_x100 / 100`, scaled by 100. The result
+/// equals `(ceil(w/d) * d - w) * 100` and is a non-negative integer in `[0, d_x100)`.
+fn neg_mod_x100(w: u16, d_x100: u32) -> u64 {
+    let r = ((w as u64) * 100) % (d_x100 as u64);
+    if r == 0 {
+        0
+    } else {
+        (d_x100 as u64) - r
     }
-    if w_total == 0 {
-        return (0, u64::MAX);
-    }
-    // delta = sum_i max(w_i - w'_i * d, 0) with d = W / W'.
-    // Multiplying through by W' gives delta * W' = sum_i max(w_i * W' - w'_i * W, 0),
-    // which is the integer quantity we accumulate below.
-    let total_weight_u64 = total_weight as u64;
-    let w_total_u64 = w_total as u64;
-    let mut delta_scaled: u64 = 0;
-    for (node, &w_p) in nodes.iter().zip(w_prime.iter()) {
-        let lhs = (node.weight as u64) * w_total_u64;
-        let rhs = (w_p as u64) * total_weight_u64;
-        if lhs > rhs {
-            delta_scaled += lhs - rhs;
-        }
-    }
-    (w_total, delta_scaled)
 }

--- a/fastcrypto-tbls/src/tests/nodes_tests.rs
+++ b/fastcrypto-tbls/src/tests/nodes_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ecies_v1;
-use crate::nodes::{Node, Nodes};
+use crate::nodes::{derive_reduced_params, Node, Nodes};
 use fastcrypto::groups::bls12381::G2Element;
 use fastcrypto::groups::ristretto255::RistrettoPoint;
 use fastcrypto::groups::{FiatShamirChallenge, GroupElement};
@@ -218,6 +218,287 @@ fn test_reduce() {
         // The loss per node is on average (d - 1) / 2
         // We use 9 instead of 10 to compensate wrong value of d
         assert!((d - 1) / 2 * number_of_nodes < (nodes.total_weight() / 9));
+    }
+}
+
+/// Sui mainnet voting-power snapshots embedded at compile time. Each file is a CSV
+/// `Validator Name,Voting Power` with a single header line and basis-point weights
+/// summing to 10000.
+const SUI_EPOCH_DATA: &[(&str, &str)] = &[
+    (
+        "100",
+        include_str!("../weight_reduction/data/sui_real_all_voting_power_epoch_100_details.txt"),
+    ),
+    (
+        "200",
+        include_str!("../weight_reduction/data/sui_real_all_voting_power_epoch_200_details.txt"),
+    ),
+    (
+        "400",
+        include_str!("../weight_reduction/data/sui_real_all_voting_power_epoch_400_details.txt"),
+    ),
+    (
+        "800",
+        include_str!("../weight_reduction/data/sui_real_all_voting_power_epoch_800_details.txt"),
+    ),
+    (
+        "974",
+        include_str!("../weight_reduction/data/sui_real_all_voting_power_epoch_974_details.txt"),
+    ),
+];
+
+fn parse_sui_epoch(contents: &str) -> Vec<u16> {
+    contents
+        .lines()
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let weight = line.rsplit(',').next().expect("non-empty CSV line").trim();
+            weight.parse::<u16>().expect("u16 voting power")
+        })
+        .collect()
+}
+
+fn build_sui_nodes(weights: &[u16]) -> Vec<Node<RistrettoPoint>> {
+    let sk = ecies_v1::PrivateKey::<RistrettoPoint>::new(&mut thread_rng());
+    let pk = ecies_v1::PublicKey::<RistrettoPoint>::from_private_key(&sk);
+    weights
+        .iter()
+        .enumerate()
+        .map(|(i, &w)| Node {
+            id: i as u16,
+            pk: pk.clone(),
+            weight: w,
+        })
+        .collect()
+}
+
+/// Single shared scenario for the Sui-epoch tests below.
+const SUI_T: u16 = 4000;
+const SUI_F: u16 = 3400;
+const SUI_ALLOWED_DELTA: u16 = 800;
+
+#[test]
+fn test_prop_reduce_sui_epochs() {
+    println!(
+        "\nprop_reduce + derive_reduced_params on Sui epochs — t = {}, f = {}, δ_allowed = {}\n",
+        SUI_T, SUI_F, SUI_ALLOWED_DELTA
+    );
+    println!("| epoch |   n |     W |    W' |  W/W' |  t' |  f' |     δ | δ + 2d |");
+    println!("|------:|----:|------:|------:|------:|----:|----:|------:|-------:|");
+
+    for (epoch_name, contents) in SUI_EPOCH_DATA {
+        let weights = parse_sui_epoch(contents);
+        let n_parties = weights.len();
+        let nodes_vec = build_sui_nodes(&weights);
+        let original_nodes = Nodes::<RistrettoPoint>::new(nodes_vec.clone()).unwrap();
+        let total_weight = original_nodes.total_weight() as u32;
+        // Sanity: Sui basis-point convention.
+        assert_eq!(
+            total_weight, 10000,
+            "epoch {} should sum to 10000",
+            epoch_name
+        );
+
+        // Stage 1: search the divisor — depends only on the weights and δ_allowed.
+        let reduced = Nodes::<RistrettoPoint>::prop_reduce(nodes_vec.clone(), SUI_ALLOWED_DELTA, 1)
+            .expect("prop_reduce should succeed on Sui epoch data");
+
+        let new_total = reduced.total_weight() as u32;
+        let total_weight_u16 = original_nodes.total_weight();
+        let new_total_u16 = reduced.total_weight();
+
+        // Stage 2: derive (t', f') in closed form from the Stage-1 output.
+        let (new_t, new_f) = derive_reduced_params(SUI_T, SUI_F, total_weight_u16, new_total_u16);
+
+        // Reduction actually shrinks the committee size at this budget.
+        assert!(
+            new_total < total_weight,
+            "epoch {}: expected reduction (W = {}, W' = {})",
+            epoch_name,
+            total_weight,
+            new_total
+        );
+        assert!(new_total >= 1);
+        assert!(new_t >= 1);
+        // t > f in original space => t' >= f' after both ceilings, but the strict
+        // inequality t' > f' is *not* guaranteed (the two ceilings can collapse).
+        assert!(
+            new_t >= new_f,
+            "epoch {}: t > f should give t' >= f' (got t' = {}, f' = {})",
+            epoch_name,
+            new_t,
+            new_f
+        );
+
+        // Each reduced weight is `floor(w_i / D)` for some D, hence at most w_i.
+        for (orig, red) in nodes_vec.iter().zip(reduced.iter()) {
+            assert!(red.weight <= orig.weight);
+            assert_eq!(orig.id, red.id);
+        }
+
+        // Verify the Stage-1 search criterion δ + 2d ≤ δ_allowed (scaled by W'):
+        //   Σ max(w_i * W' - w'_i * W, 0) + 2 * W ≤ δ_allowed * W'.
+        let delta_scaled: i128 = nodes_vec
+            .iter()
+            .zip(reduced.iter())
+            .map(|(orig, red)| {
+                let lhs = (orig.weight as i128) * (new_total as i128);
+                let rhs = (red.weight as i128) * (total_weight as i128);
+                (lhs - rhs).max(0)
+            })
+            .sum();
+        let lhs_scaled = delta_scaled + 2 * (total_weight as i128);
+        let rhs_scaled = (SUI_ALLOWED_DELTA as i128) * (new_total as i128);
+        assert!(
+            lhs_scaled <= rhs_scaled,
+            "epoch {}: (δ + 2d) * W' = {} > δ_allowed * W' = {}",
+            epoch_name,
+            lhs_scaled,
+            rhs_scaled
+        );
+
+        // t' must equal the closed-form formula: t' = ceil(t * W' / W).
+        let expected_t = ((SUI_T as u64) * (new_total as u64)).div_ceil(total_weight as u64) as u16;
+        assert_eq!(
+            new_t, expected_t,
+            "epoch {}: t' mismatch (expected ceil(t*W'/W) = {}, got {})",
+            epoch_name, expected_t, new_t
+        );
+
+        // f' must equal ceil(f * W' / W).
+        let expected_f = ((SUI_F as u64) * (new_total as u64)).div_ceil(total_weight as u64) as u16;
+        assert_eq!(
+            new_f, expected_f,
+            "epoch {}: f' mismatch (expected {}, got {})",
+            epoch_name, expected_f, new_f
+        );
+
+        // Liveness sanity check: a coalition with original weight ≥ t + f + δ_allowed
+        // must reach reduced weight ≥ t' + f' under any unilateral reduction. We
+        // verify this against the actual reduction by computing the smallest reduced
+        // weight a coalition of total original weight ≥ t + f + δ_allowed could carry.
+        // (Worst case under the unilateral inequality is w'(S) = (w(S) - δ) / d.)
+        let live_threshold = (SUI_T as i128) + (SUI_F as i128) + (SUI_ALLOWED_DELTA as i128);
+        let lower_bound_w_prime_scaled =
+            (live_threshold * (new_total as i128) - delta_scaled) / (total_weight as i128);
+        let target = (new_t as i128) + (new_f as i128);
+        assert!(
+            lower_bound_w_prime_scaled >= target,
+            "epoch {}: live coalition w(S) ≥ t+f+δ_allowed should give w'(S) ≥ t'+f' \
+             (got lower bound on w'(S) = {}, target = {})",
+            epoch_name,
+            lower_bound_w_prime_scaled,
+            target
+        );
+
+        let delta = (delta_scaled as f64) / (new_total as f64);
+        let combined = delta + 2.0 * (total_weight as f64 / new_total as f64);
+        println!(
+            "|  {:>3} | {:>3} | {:>5} | {:>5} | {:>4.1}× | {:>3} | {:>3} | {:>5.2} | {:>6.2} |",
+            epoch_name,
+            n_parties,
+            total_weight,
+            new_total,
+            total_weight as f64 / new_total as f64,
+            new_t,
+            new_f,
+            delta,
+            combined,
+        );
+    }
+}
+
+#[test]
+fn test_prop_reduce_modular_reuse() {
+    // Stage 1 is independent of (t, f), so a single Stage-1 reduction can be reused
+    // across multiple Stage-2 calls. We exercise this on every Sui epoch with a
+    // family of (t, f) pairs satisfying t > f at W = 10000.
+    let tf_pairs: &[(u16, u16)] = &[
+        (4000, 3400),
+        (5000, 3300),
+        (6000, 3000),
+        (6700, 3300),
+        (7000, 2000),
+    ];
+
+    for (epoch_name, contents) in SUI_EPOCH_DATA {
+        let weights = parse_sui_epoch(contents);
+        let nodes_vec = build_sui_nodes(&weights);
+        let original = Nodes::<RistrettoPoint>::new(nodes_vec.clone()).unwrap();
+        let w = original.total_weight();
+
+        // One Stage-1 call.
+        let reduced =
+            Nodes::<RistrettoPoint>::prop_reduce(nodes_vec.clone(), SUI_ALLOWED_DELTA, 1).unwrap();
+        let w_prime = reduced.total_weight();
+
+        // Many Stage-2 calls reusing the same `reduced`.
+        for (t, f) in tf_pairs {
+            let (t_prime, f_prime) = derive_reduced_params(*t, *f, w, w_prime);
+            // t > f in original space => t' >= f' after ceilings.
+            assert!(
+                t_prime >= f_prime,
+                "epoch {} (t={}, f={}): t > f should give t' >= f' (got t'={}, f'={})",
+                epoch_name,
+                t,
+                f,
+                t_prime,
+                f_prime
+            );
+            // Stage-2 formulas (closed form, no cap).
+            let expected_t = ((*t as u64) * (w_prime as u64)).div_ceil(w as u64) as u16;
+            let expected_f = ((*f as u64) * (w_prime as u64)).div_ceil(w as u64) as u16;
+            assert_eq!(t_prime, expected_t);
+            assert_eq!(f_prime, expected_f);
+        }
+    }
+}
+
+#[test]
+fn test_prop_reduce_vs_new_reduced_on_sui_epochs() {
+    // prop_reduce uses fractional divisors and the exact δ accounting, so its W'
+    // should not exceed new_reduced_with_f's W' at the same budget - even
+    // though prop_reduce reserves an extra 2d for ceiling overheads in the
+    // search criterion.
+    println!(
+        "\nprop_reduce vs new_reduced_with_f on Sui epochs — t = {}, f = {}, δ_allowed = {}\n",
+        SUI_T, SUI_F, SUI_ALLOWED_DELTA
+    );
+    println!("| epoch | prop_reduce W' | new_reduced_with_f W' | smaller by |");
+    println!("|------:|---------------:|----------------------:|-----------:|");
+
+    for (epoch_name, contents) in SUI_EPOCH_DATA {
+        let weights = parse_sui_epoch(contents);
+        let nodes_vec = build_sui_nodes(&weights);
+
+        let prop_nodes =
+            Nodes::<RistrettoPoint>::prop_reduce(nodes_vec.clone(), SUI_ALLOWED_DELTA, 1).unwrap();
+        let (legacy_nodes, _, _) = Nodes::<RistrettoPoint>::new_reduced_with_f(
+            nodes_vec.clone(),
+            SUI_T,
+            SUI_F,
+            SUI_ALLOWED_DELTA,
+            1,
+        )
+        .unwrap();
+
+        let prop_w = prop_nodes.total_weight();
+        let legacy_w = legacy_nodes.total_weight();
+
+        assert!(
+            prop_w <= legacy_w,
+            "epoch {}: prop_reduce W' = {} should be ≤ new_reduced_with_f W' = {}",
+            epoch_name,
+            prop_w,
+            legacy_w
+        );
+
+        let ratio = (legacy_w as f64) / (prop_w as f64);
+        println!(
+            "|  {:>3} | {:>14} | {:>21} | {:>9.2}× |",
+            epoch_name, prop_w, legacy_w, ratio,
+        );
     }
 }
 

--- a/fastcrypto-tbls/src/tests/nodes_tests.rs
+++ b/fastcrypto-tbls/src/tests/nodes_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ecies_v1;
-use crate::nodes::{derive_reduced_params, Node, Nodes};
+use crate::nodes::{Node, Nodes};
 use fastcrypto::groups::bls12381::G2Element;
 use fastcrypto::groups::ristretto255::RistrettoPoint;
 use fastcrypto::groups::{FiatShamirChallenge, GroupElement};
@@ -273,26 +273,39 @@ fn build_sui_nodes(weights: &[u16]) -> Vec<Node<RistrettoPoint>> {
         .collect()
 }
 
-/// Single shared scenario for the Sui-epoch tests below.
-const SUI_T: u16 = 4000;
-const SUI_F: u16 = 3400;
 const SUI_ALLOWED_DELTA: u16 = 800;
 
 #[test]
-fn test_prop_reduce_sui_epochs() {
+fn test_prop_reduce_vs_new_reduced_with_f() {
+    // Compare the integer-only `new_reduced_with_f` (upward sweep) against
+    // `prop_reduce` (downward integer sweep + 0.01-granularity fractional
+    // sweep above the first feasible integer). Both apply the same
+    // criterion
+    //
+    //   Σ_i (w_i mod d) + neg_mod(t, d) + neg_mod(f, d) ≤ δ_allowed,
+    //
+    // extended naturally to fractional d in prop_reduce. Since prop_reduce
+    // evaluates a strict superset of new_reduced_with_f's candidates, we
+    // must always have W'_prop ≤ W'_new (and t'_prop ≤ t'_new, f'_prop ≤ f'_new).
+    let tf_pairs: &[(u16, u16)] = &[(3400, 3300), (5200, 2000)];
+
     println!(
-        "\nprop_reduce + derive_reduced_params on Sui epochs — t = {}, f = {}, δ_allowed = {}\n",
-        SUI_T, SUI_F, SUI_ALLOWED_DELTA
+        "\nnew_reduced_with_f (integer, upward) vs prop_reduce (downward + 0.01 fractional), δ_allowed = {}\n",
+        SUI_ALLOWED_DELTA
     );
-    println!("| epoch |   n |     W |    W' |  W/W' |  t' |  f' |     δ | δ + 2d |");
-    println!("|------:|----:|------:|------:|------:|----:|----:|------:|-------:|");
+    println!(
+        "| epoch |    t |    f | W'(new) | t'(new) | f'(new) | d(new) | W'(prop) | t'(prop) | f'(prop) | d(prop) |"
+    );
+    println!(
+        "|------:|-----:|-----:|--------:|--------:|--------:|-------:|---------:|---------:|---------:|--------:|"
+    );
 
     for (epoch_name, contents) in SUI_EPOCH_DATA {
         let weights = parse_sui_epoch(contents);
-        let n_parties = weights.len();
         let nodes_vec = build_sui_nodes(&weights);
-        let original_nodes = Nodes::<RistrettoPoint>::new(nodes_vec.clone()).unwrap();
-        let total_weight = original_nodes.total_weight() as u32;
+        let total_weight = Nodes::<RistrettoPoint>::new(nodes_vec.clone())
+            .unwrap()
+            .total_weight();
         // Sanity: Sui basis-point convention.
         assert_eq!(
             total_weight, 10000,
@@ -300,205 +313,140 @@ fn test_prop_reduce_sui_epochs() {
             epoch_name
         );
 
-        // Stage 1: search the divisor — depends only on the weights and δ_allowed.
-        let reduced = Nodes::<RistrettoPoint>::prop_reduce(nodes_vec.clone(), SUI_ALLOWED_DELTA, 1)
-            .expect("prop_reduce should succeed on Sui epoch data");
-
-        let new_total = reduced.total_weight() as u32;
-        let total_weight_u16 = original_nodes.total_weight();
-        let new_total_u16 = reduced.total_weight();
-
-        // Stage 2: derive (t', f') in closed form from the Stage-1 output.
-        let (new_t, new_f) = derive_reduced_params(SUI_T, SUI_F, total_weight_u16, new_total_u16);
-
-        // Reduction actually shrinks the committee size at this budget.
-        assert!(
-            new_total < total_weight,
-            "epoch {}: expected reduction (W = {}, W' = {})",
-            epoch_name,
-            total_weight,
-            new_total
-        );
-        assert!(new_total >= 1);
-        assert!(new_t >= 1);
-        // t > f in original space => t' >= f' after both ceilings, but the strict
-        // inequality t' > f' is *not* guaranteed (the two ceilings can collapse).
-        assert!(
-            new_t >= new_f,
-            "epoch {}: t > f should give t' >= f' (got t' = {}, f' = {})",
-            epoch_name,
-            new_t,
-            new_f
-        );
-
-        // Each reduced weight is `floor(w_i / D)` for some D, hence at most w_i.
-        for (orig, red) in nodes_vec.iter().zip(reduced.iter()) {
-            assert!(red.weight <= orig.weight);
-            assert_eq!(orig.id, red.id);
-        }
-
-        // Verify the Stage-1 search criterion δ + 2d ≤ δ_allowed (scaled by W'):
-        //   Σ max(w_i * W' - w'_i * W, 0) + 2 * W ≤ δ_allowed * W'.
-        let delta_scaled: i128 = nodes_vec
-            .iter()
-            .zip(reduced.iter())
-            .map(|(orig, red)| {
-                let lhs = (orig.weight as i128) * (new_total as i128);
-                let rhs = (red.weight as i128) * (total_weight as i128);
-                (lhs - rhs).max(0)
-            })
-            .sum();
-        let lhs_scaled = delta_scaled + 2 * (total_weight as i128);
-        let rhs_scaled = (SUI_ALLOWED_DELTA as i128) * (new_total as i128);
-        assert!(
-            lhs_scaled <= rhs_scaled,
-            "epoch {}: (δ + 2d) * W' = {} > δ_allowed * W' = {}",
-            epoch_name,
-            lhs_scaled,
-            rhs_scaled
-        );
-
-        // t' must equal the closed-form formula: t' = ceil(t * W' / W).
-        let expected_t = ((SUI_T as u64) * (new_total as u64)).div_ceil(total_weight as u64) as u16;
-        assert_eq!(
-            new_t, expected_t,
-            "epoch {}: t' mismatch (expected ceil(t*W'/W) = {}, got {})",
-            epoch_name, expected_t, new_t
-        );
-
-        // f' must equal ceil(f * W' / W).
-        let expected_f = ((SUI_F as u64) * (new_total as u64)).div_ceil(total_weight as u64) as u16;
-        assert_eq!(
-            new_f, expected_f,
-            "epoch {}: f' mismatch (expected {}, got {})",
-            epoch_name, expected_f, new_f
-        );
-
-        // Liveness sanity check: a coalition with original weight ≥ t + f + δ_allowed
-        // must reach reduced weight ≥ t' + f' under any unilateral reduction. We
-        // verify this against the actual reduction by computing the smallest reduced
-        // weight a coalition of total original weight ≥ t + f + δ_allowed could carry.
-        // (Worst case under the unilateral inequality is w'(S) = (w(S) - δ) / d.)
-        let live_threshold = (SUI_T as i128) + (SUI_F as i128) + (SUI_ALLOWED_DELTA as i128);
-        let lower_bound_w_prime_scaled =
-            (live_threshold * (new_total as i128) - delta_scaled) / (total_weight as i128);
-        let target = (new_t as i128) + (new_f as i128);
-        assert!(
-            lower_bound_w_prime_scaled >= target,
-            "epoch {}: live coalition w(S) ≥ t+f+δ_allowed should give w'(S) ≥ t'+f' \
-             (got lower bound on w'(S) = {}, target = {})",
-            epoch_name,
-            lower_bound_w_prime_scaled,
-            target
-        );
-
-        let delta = (delta_scaled as f64) / (new_total as f64);
-        let combined = delta + 2.0 * (total_weight as f64 / new_total as f64);
-        println!(
-            "|  {:>3} | {:>3} | {:>5} | {:>5} | {:>4.1}× | {:>3} | {:>3} | {:>5.2} | {:>6.2} |",
-            epoch_name,
-            n_parties,
-            total_weight,
-            new_total,
-            total_weight as f64 / new_total as f64,
-            new_t,
-            new_f,
-            delta,
-            combined,
-        );
-    }
-}
-
-#[test]
-fn test_prop_reduce_modular_reuse() {
-    // Stage 1 is independent of (t, f), so a single Stage-1 reduction can be reused
-    // across multiple Stage-2 calls. We exercise this on every Sui epoch with a
-    // family of (t, f) pairs satisfying t > f at W = 10000.
-    let tf_pairs: &[(u16, u16)] = &[
-        (4000, 3400),
-        (5000, 3300),
-        (6000, 3000),
-        (6700, 3300),
-        (7000, 2000),
-    ];
-
-    for (epoch_name, contents) in SUI_EPOCH_DATA {
-        let weights = parse_sui_epoch(contents);
-        let nodes_vec = build_sui_nodes(&weights);
-        let original = Nodes::<RistrettoPoint>::new(nodes_vec.clone()).unwrap();
-        let w = original.total_weight();
-
-        // One Stage-1 call.
-        let reduced =
-            Nodes::<RistrettoPoint>::prop_reduce(nodes_vec.clone(), SUI_ALLOWED_DELTA, 1).unwrap();
-        let w_prime = reduced.total_weight();
-
-        // Many Stage-2 calls reusing the same `reduced`.
         for (t, f) in tf_pairs {
-            let (t_prime, f_prime) = derive_reduced_params(*t, *f, w, w_prime);
-            // t > f in original space => t' >= f' after ceilings.
+            let (new_nodes, new_t, new_f) = Nodes::<RistrettoPoint>::new_reduced_with_f(
+                nodes_vec.clone(),
+                *t,
+                *f,
+                SUI_ALLOWED_DELTA,
+                1,
+            )
+            .unwrap();
+            let (prop_nodes, prop_t, prop_f, prop_d_x100) =
+                Nodes::<RistrettoPoint>::prop_reduce(
+                    nodes_vec.clone(),
+                    *t,
+                    *f,
+                    SUI_ALLOWED_DELTA,
+                    1,
+                )
+                .unwrap();
+
+            let new_w = new_nodes.total_weight();
+            let prop_w = prop_nodes.total_weight();
+
+            // Recover the integer divisor `new_reduced_with_f` actually used:
+            // w'_i = w_i / d for the same d ∈ [1, 40] across all parties.
+            let new_d: u16 = (1u16..=40)
+                .find(|&d| {
+                    nodes_vec
+                        .iter()
+                        .zip(new_nodes.iter())
+                        .all(|(o, r)| o.weight / d == r.weight)
+                })
+                .expect("new_reduced_with_f divisor must lie in [1, 40]");
+
+            // 1. prop is at least as good (smaller-or-equal W', t', f').
             assert!(
-                t_prime >= f_prime,
-                "epoch {} (t={}, f={}): t > f should give t' >= f' (got t'={}, f'={})",
+                prop_w <= new_w,
+                "epoch {} (t={}, f={}): prop should give W' ≤ new W' (prop={}, new={})",
                 epoch_name,
                 t,
                 f,
-                t_prime,
-                f_prime
+                prop_w,
+                new_w
             );
-            // Stage-2 formulas (closed form, no cap).
-            let expected_t = ((*t as u64) * (w_prime as u64)).div_ceil(w as u64) as u16;
-            let expected_f = ((*f as u64) * (w_prime as u64)).div_ceil(w as u64) as u16;
-            assert_eq!(t_prime, expected_t);
-            assert_eq!(f_prime, expected_f);
+            assert!(
+                prop_t <= new_t,
+                "epoch {} (t={}, f={}): prop t' should be ≤ new t' (prop={}, new={})",
+                epoch_name,
+                t,
+                f,
+                prop_t,
+                new_t
+            );
+            assert!(
+                prop_f <= new_f,
+                "epoch {} (t={}, f={}): prop f' should be ≤ new f' (prop={}, new={})",
+                epoch_name,
+                t,
+                f,
+                prop_f,
+                new_f
+            );
+
+            // 2. Stage-1 criterion holds for `new_reduced_with_f` (integer d).
+            let new_delta: u32 = nodes_vec.iter().map(|n| (n.weight % new_d) as u32).sum::<u32>()
+                + neg_mod_u32(*t, new_d)
+                + neg_mod_u32(*f, new_d);
+            assert!(
+                new_delta <= SUI_ALLOWED_DELTA as u32,
+                "epoch {} (t={}, f={}): new criterion violated (δ = {} > {})",
+                epoch_name,
+                t,
+                f,
+                new_delta,
+                SUI_ALLOWED_DELTA
+            );
+
+            // 3. Stage-1 criterion holds for `prop_reduce` (fractional d via x100).
+            //    Σ (w_i mod d) * 100 = W * 100 - W' * d_x100  (telescopes by floor).
+            let sum_mod_x100: u64 =
+                (total_weight as u64) * 100 - (prop_w as u64) * (prop_d_x100 as u64);
+            let prop_delta_x100: u64 = sum_mod_x100
+                + neg_mod_x100_check(*t, prop_d_x100)
+                + neg_mod_x100_check(*f, prop_d_x100);
+            assert!(
+                prop_delta_x100 <= (SUI_ALLOWED_DELTA as u64) * 100,
+                "epoch {} (t={}, f={}): prop criterion violated (δ × 100 = {} > {})",
+                epoch_name,
+                t,
+                f,
+                prop_delta_x100,
+                (SUI_ALLOWED_DELTA as u64) * 100
+            );
+
+            // 4. Stage-2 outputs match the closed-form ceilings against the
+            //    chosen d_x100 for prop_reduce.
+            let expected_t_prop = ((*t as u64) * 100).div_ceil(prop_d_x100 as u64) as u16;
+            let expected_f_prop = ((*f as u64) * 100).div_ceil(prop_d_x100 as u64) as u16;
+            assert_eq!(prop_t, expected_t_prop);
+            assert_eq!(prop_f, expected_f_prop);
+
+            println!(
+                "|  {:>3} | {:>4} | {:>4} | {:>7} | {:>7} | {:>7} | {:>6} | {:>8} | {:>8} | {:>8} | {:>6.2} |",
+                epoch_name,
+                t,
+                f,
+                new_w,
+                new_t,
+                new_f,
+                new_d,
+                prop_w,
+                prop_t,
+                prop_f,
+                (prop_d_x100 as f64) / 100.0,
+            );
         }
     }
 }
 
-#[test]
-fn test_prop_reduce_vs_new_reduced_on_sui_epochs() {
-    // prop_reduce uses fractional divisors and the exact δ accounting, so its W'
-    // should not exceed new_reduced_with_f's W' at the same budget - even
-    // though prop_reduce reserves an extra 2d for ceiling overheads in the
-    // search criterion.
-    println!(
-        "\nprop_reduce vs new_reduced_with_f on Sui epochs — t = {}, f = {}, δ_allowed = {}\n",
-        SUI_T, SUI_F, SUI_ALLOWED_DELTA
-    );
-    println!("| epoch | prop_reduce W' | new_reduced_with_f W' | smaller by |");
-    println!("|------:|---------------:|----------------------:|-----------:|");
+// Helpers re-derived locally for the test-side criterion checks.
+fn neg_mod_u32(x: u16, d: u16) -> u32 {
+    let r = (x as u32) % (d as u32);
+    if r == 0 {
+        0
+    } else {
+        (d as u32) - r
+    }
+}
 
-    for (epoch_name, contents) in SUI_EPOCH_DATA {
-        let weights = parse_sui_epoch(contents);
-        let nodes_vec = build_sui_nodes(&weights);
-
-        let prop_nodes =
-            Nodes::<RistrettoPoint>::prop_reduce(nodes_vec.clone(), SUI_ALLOWED_DELTA, 1).unwrap();
-        let (legacy_nodes, _, _) = Nodes::<RistrettoPoint>::new_reduced_with_f(
-            nodes_vec.clone(),
-            SUI_T,
-            SUI_F,
-            SUI_ALLOWED_DELTA,
-            1,
-        )
-        .unwrap();
-
-        let prop_w = prop_nodes.total_weight();
-        let legacy_w = legacy_nodes.total_weight();
-
-        assert!(
-            prop_w <= legacy_w,
-            "epoch {}: prop_reduce W' = {} should be ≤ new_reduced_with_f W' = {}",
-            epoch_name,
-            prop_w,
-            legacy_w
-        );
-
-        let ratio = (legacy_w as f64) / (prop_w as f64);
-        println!(
-            "|  {:>3} | {:>14} | {:>21} | {:>9.2}× |",
-            epoch_name, prop_w, legacy_w, ratio,
-        );
+fn neg_mod_x100_check(w: u16, d_x100: u32) -> u64 {
+    let r = ((w as u64) * 100) % (d_x100 as u64);
+    if r == 0 {
+        0
+    } else {
+        (d_x100 as u64) - r
     }
 }
 

--- a/fastcrypto-tbls/src/tests/nodes_tests.rs
+++ b/fastcrypto-tbls/src/tests/nodes_tests.rs
@@ -221,6 +221,33 @@ fn test_reduce() {
     }
 }
 
+#[test]
+fn test_reduce_with_lower_bounds() {
+    let number_of_nodes = 100;
+    let node_vec = get_nodes::<RistrettoPoint>(number_of_nodes);
+    let nodes = Nodes::new(node_vec.clone()).unwrap();
+    let t = nodes.total_weight() / 3;
+
+    // No extra gap, should return the inputs
+    let (new_nodes, new_t) = Nodes::new_reduced(node_vec.clone(), t, 1, 1).unwrap();
+    assert_eq!(nodes, new_nodes);
+    assert_eq!(t, new_t);
+
+    // 10% gap
+    let (new_nodes1, _new_t1) =
+        Nodes::new_reduced(node_vec.clone(), t, nodes.total_weight() / 10, 1).unwrap();
+    let (new_nodes2, _new_t2) = Nodes::new_reduced(
+        node_vec.clone(),
+        t,
+        nodes.total_weight() / 10,
+        nodes.total_weight() / 3,
+    )
+    .unwrap();
+    assert!(new_nodes1.total_weight() < new_nodes2.total_weight());
+    assert!(new_nodes2.total_weight() >= nodes.total_weight() / 3);
+    assert!(new_nodes2.total_weight() < nodes.total_weight());
+}
+
 /// Sui mainnet voting-power snapshots embedded at compile time. Each file is a CSV
 /// `Validator Name,Voting Power` with a single header line and basis-point weights
 /// summing to 10000.
@@ -277,38 +304,34 @@ const SUI_ALLOWED_DELTA: u16 = 800;
 
 #[test]
 fn test_prop_reduce_vs_new_reduced_with_f() {
-    // Compare the integer-only `new_reduced_with_f` (upward sweep) against
-    // `prop_reduce` (downward integer sweep + 0.01-granularity fractional
-    // sweep above the first feasible integer). Both apply the same
-    // criterion
-    //
-    //   Σ_i (w_i mod d) + neg_mod(t, d) + neg_mod(f, d) ≤ δ_allowed,
-    //
-    // extended naturally to fractional d in prop_reduce. Since prop_reduce
-    // evaluates a strict superset of new_reduced_with_f's candidates, we
-    // must always have W'_prop ≤ W'_new (and t'_prop ≤ t'_new, f'_prop ≤ f'_new).
+    // Side-by-side comparison of the integer-only `new_reduced_with_f` against
+    // `prop_reduce` (integer downward sweep + 0.01-granularity fractional
+    // refinement above the first feasible integer). Since prop_reduce considers
+    // a strict superset of new_reduced_with_f's candidates, the reduced total
+    // weight (and ceilings t', f') must be ≤ those of new_reduced_with_f on
+    // every input.
     let tf_pairs: &[(u16, u16)] = &[(3400, 3300), (5200, 2000)];
 
     println!(
-        "\nnew_reduced_with_f (integer, upward) vs prop_reduce (downward + 0.01 fractional), δ_allowed = {}\n",
+        "\nnew_reduced_with_f vs prop_reduce on Sui epochs, δ_allowed = {}\n",
         SUI_ALLOWED_DELTA
     );
     println!(
-        "| epoch |    t |    f | W'(new) | t'(new) | f'(new) | d(new) | W'(prop) | t'(prop) | f'(prop) | d(prop) |"
+        "| epoch |    t |    f | W'(new) | t'(new) | f'(new) | W'(prop) | t'(prop) | f'(prop) |"
     );
     println!(
-        "|------:|-----:|-----:|--------:|--------:|--------:|-------:|---------:|---------:|---------:|--------:|"
+        "|------:|-----:|-----:|--------:|--------:|--------:|---------:|---------:|---------:|"
     );
 
     for (epoch_name, contents) in SUI_EPOCH_DATA {
         let weights = parse_sui_epoch(contents);
         let nodes_vec = build_sui_nodes(&weights);
-        let total_weight = Nodes::<RistrettoPoint>::new(nodes_vec.clone())
-            .unwrap()
-            .total_weight();
         // Sanity: Sui basis-point convention.
         assert_eq!(
-            total_weight, 10000,
+            Nodes::<RistrettoPoint>::new(nodes_vec.clone())
+                .unwrap()
+                .total_weight(),
+            10000,
             "epoch {} should sum to 10000",
             epoch_name
         );
@@ -322,34 +345,22 @@ fn test_prop_reduce_vs_new_reduced_with_f() {
                 1,
             )
             .unwrap();
-            let (prop_nodes, prop_t, prop_f, prop_d_x100) =
-                Nodes::<RistrettoPoint>::prop_reduce(
-                    nodes_vec.clone(),
-                    *t,
-                    *f,
-                    SUI_ALLOWED_DELTA,
-                    1,
-                )
-                .unwrap();
+            let (prop_nodes, prop_t, prop_f) = Nodes::<RistrettoPoint>::prop_reduce(
+                nodes_vec.clone(),
+                *t,
+                *f,
+                SUI_ALLOWED_DELTA,
+                1,
+            )
+            .unwrap();
 
             let new_w = new_nodes.total_weight();
             let prop_w = prop_nodes.total_weight();
 
-            // Recover the integer divisor `new_reduced_with_f` actually used:
-            // w'_i = w_i / d for the same d ∈ [1, 40] across all parties.
-            let new_d: u16 = (1u16..=40)
-                .find(|&d| {
-                    nodes_vec
-                        .iter()
-                        .zip(new_nodes.iter())
-                        .all(|(o, r)| o.weight / d == r.weight)
-                })
-                .expect("new_reduced_with_f divisor must lie in [1, 40]");
-
-            // 1. prop is at least as good (smaller-or-equal W', t', f').
+            // prop is at least as good as new on (W', t', f').
             assert!(
                 prop_w <= new_w,
-                "epoch {} (t={}, f={}): prop should give W' ≤ new W' (prop={}, new={})",
+                "epoch {} (t={}, f={}): expected prop W' ≤ new W' (prop={}, new={})",
                 epoch_name,
                 t,
                 f,
@@ -358,7 +369,7 @@ fn test_prop_reduce_vs_new_reduced_with_f() {
             );
             assert!(
                 prop_t <= new_t,
-                "epoch {} (t={}, f={}): prop t' should be ≤ new t' (prop={}, new={})",
+                "epoch {} (t={}, f={}): expected prop t' ≤ new t' (prop={}, new={})",
                 epoch_name,
                 t,
                 f,
@@ -367,7 +378,7 @@ fn test_prop_reduce_vs_new_reduced_with_f() {
             );
             assert!(
                 prop_f <= new_f,
-                "epoch {} (t={}, f={}): prop f' should be ≤ new f' (prop={}, new={})",
+                "epoch {} (t={}, f={}): expected prop f' ≤ new f' (prop={}, new={})",
                 epoch_name,
                 t,
                 f,
@@ -375,104 +386,10 @@ fn test_prop_reduce_vs_new_reduced_with_f() {
                 new_f
             );
 
-            // 2. Stage-1 criterion holds for `new_reduced_with_f` (integer d).
-            let new_delta: u32 = nodes_vec.iter().map(|n| (n.weight % new_d) as u32).sum::<u32>()
-                + neg_mod_u32(*t, new_d)
-                + neg_mod_u32(*f, new_d);
-            assert!(
-                new_delta <= SUI_ALLOWED_DELTA as u32,
-                "epoch {} (t={}, f={}): new criterion violated (δ = {} > {})",
-                epoch_name,
-                t,
-                f,
-                new_delta,
-                SUI_ALLOWED_DELTA
-            );
-
-            // 3. Stage-1 criterion holds for `prop_reduce` (fractional d via x100).
-            //    Σ (w_i mod d) * 100 = W * 100 - W' * d_x100  (telescopes by floor).
-            let sum_mod_x100: u64 =
-                (total_weight as u64) * 100 - (prop_w as u64) * (prop_d_x100 as u64);
-            let prop_delta_x100: u64 = sum_mod_x100
-                + neg_mod_x100_check(*t, prop_d_x100)
-                + neg_mod_x100_check(*f, prop_d_x100);
-            assert!(
-                prop_delta_x100 <= (SUI_ALLOWED_DELTA as u64) * 100,
-                "epoch {} (t={}, f={}): prop criterion violated (δ × 100 = {} > {})",
-                epoch_name,
-                t,
-                f,
-                prop_delta_x100,
-                (SUI_ALLOWED_DELTA as u64) * 100
-            );
-
-            // 4. Stage-2 outputs match the closed-form ceilings against the
-            //    chosen d_x100 for prop_reduce.
-            let expected_t_prop = ((*t as u64) * 100).div_ceil(prop_d_x100 as u64) as u16;
-            let expected_f_prop = ((*f as u64) * 100).div_ceil(prop_d_x100 as u64) as u16;
-            assert_eq!(prop_t, expected_t_prop);
-            assert_eq!(prop_f, expected_f_prop);
-
             println!(
-                "|  {:>3} | {:>4} | {:>4} | {:>7} | {:>7} | {:>7} | {:>6} | {:>8} | {:>8} | {:>8} | {:>6.2} |",
-                epoch_name,
-                t,
-                f,
-                new_w,
-                new_t,
-                new_f,
-                new_d,
-                prop_w,
-                prop_t,
-                prop_f,
-                (prop_d_x100 as f64) / 100.0,
+                "|  {:>3} | {:>4} | {:>4} | {:>7} | {:>7} | {:>7} | {:>8} | {:>8} | {:>8} |",
+                epoch_name, t, f, new_w, new_t, new_f, prop_w, prop_t, prop_f,
             );
         }
     }
-}
-
-// Helpers re-derived locally for the test-side criterion checks.
-fn neg_mod_u32(x: u16, d: u16) -> u32 {
-    let r = (x as u32) % (d as u32);
-    if r == 0 {
-        0
-    } else {
-        (d as u32) - r
-    }
-}
-
-fn neg_mod_x100_check(w: u16, d_x100: u32) -> u64 {
-    let r = ((w as u64) * 100) % (d_x100 as u64);
-    if r == 0 {
-        0
-    } else {
-        (d_x100 as u64) - r
-    }
-}
-
-#[test]
-fn test_reduce_with_lower_bounds() {
-    let number_of_nodes = 100;
-    let node_vec = get_nodes::<RistrettoPoint>(number_of_nodes);
-    let nodes = Nodes::new(node_vec.clone()).unwrap();
-    let t = nodes.total_weight() / 3;
-
-    // No extra gap, should return the inputs
-    let (new_nodes, new_t) = Nodes::new_reduced(node_vec.clone(), t, 1, 1).unwrap();
-    assert_eq!(nodes, new_nodes);
-    assert_eq!(t, new_t);
-
-    // 10% gap
-    let (new_nodes1, _new_t1) =
-        Nodes::new_reduced(node_vec.clone(), t, nodes.total_weight() / 10, 1).unwrap();
-    let (new_nodes2, _new_t2) = Nodes::new_reduced(
-        node_vec.clone(),
-        t,
-        nodes.total_weight() / 10,
-        nodes.total_weight() / 3,
-    )
-    .unwrap();
-    assert!(new_nodes1.total_weight() < new_nodes2.total_weight());
-    assert!(new_nodes2.total_weight() >= nodes.total_weight() / 3);
-    assert!(new_nodes2.total_weight() < nodes.total_weight());
 }

--- a/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_100_details.txt
+++ b/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_100_details.txt
@@ -1,0 +1,106 @@
+Validator Name,Voting Power
+P2P.ORG,391
+Mysten-2,325
+Figment,286
+Triton One,275
+Mysten-1,255
+TestnetPride,238
+ContributionDAO,235
+StakingCabin,206
+Blockscope.net,206
+Bware Labs,198
+mrgn,193
+Overclock,192
+Chainode Tech,192
+Dankuzone_w_DAIC,190
+Shinlabs,188
+DSRV,186
+Ahoy Validator,186
+Nelrann,185
+Galaxy Digital,185
+Artifact,185
+HashedPotatoes,175
+Citadel.one,169
+Chainbase,158
+Nodes.Guru,158
+BartestneT,158
+TPT,158
+P-OPS Team,158
+Persimmon,151
+Durian,151
+Scale3Labs,146
+Aftermath,145
+Cogent Crypto,144
+Everstake,118
+Coinbase Cloud,110
+Luganodes,98
+Blockdaemon,94
+Staking Facilities,89
+Cosmostation,84
+OKXEarn,76
+Stardust Staking,71
+Chorus One,71
+Omnistake,64
+BlockVision,63
+Staking Defense League,62
+KiligLab,62
+Juicy Stake,60
+Chainflow,59
+Allnodes,57
+BiXinKelePool,57
+Anchorage Digital-2,57
+Kiln,54
+BlockEden.xyz,50
+Brightlystake,50
+ORBR,50
+Staked,49
+01node,48
+Swiss Staking,48
+ANodes,48
+SyncNode,48
+Astro-Stakers,47
+KingSuper,47
+n1stake,47
+B-Harvest,47
+Restake,47
+proofgroup,47
+Neuler,47
+[NODERS]TEAM x Criterion VC,47
+Peeranha,47
+StakeWithUs,47
+ONBUFF,47
+Imperator.co,47
+SynergyNodes,47
+Laine,45
+Anchorage Digital-1,41
+stakefish,40
+ComingChat,38
+XPRV,38
+A41,37
+Parasol,37
+Qredo,37
+BLRD,37
+Forbole,37
+Stakely,37
+QuantNode,37
+gumi,37
+Stakin,37
+flipside,37
+Moonlet,37
+MoveFuns DAO,37
+Node Guardians,37
+TDMTech,37
+Ankr,37
+HashQuark,37
+InfStones,36
+Gaucho,36
+H2O Nodes,36
+Cypher Capital,36
+SpartanLabs,36
+Staketab,36
+RepublicCrypto,36
+NodeReal,36
+Nodeinfra,36
+SenseiNode,36
+Latitude.sh,35
+MIDL.dev,35

--- a/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_200_details.txt
+++ b/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_200_details.txt
@@ -1,0 +1,106 @@
+Validator Name,Voting Power
+Figment,335
+Mysten-2,288
+Blockdaemon,285
+P2P.ORG,279
+Luganodes,261
+Triton One,243
+Chorus One,231
+Anchorage Digital-2,227
+TestnetPride,216
+Mysten-1,200
+ContributionDAO,196
+Kiln,189
+Blockscope.net,188
+StakingCabin,187
+Bware Labs,179
+mrgn,176
+Overclock,175
+Chainode Tech,175
+Everstake,174
+Shinlabs,171
+Dankuzone_w_DAIC,169
+DSRV,169
+Galaxy Digital,169
+Artifact,169
+Nelrann,168
+Ahoy Validator,168
+HashedPotatoes,160
+Chainbase,144
+Nodes.Guru,144
+BartestneT,144
+TPT,144
+P-OPS Team,144
+Persimmon,137
+Durian,137
+Cogent Crypto,131
+Citadel.one,131
+Scale3Labs,131
+Aftermath,131
+Coinbase Cloud,109
+BlockVision,83
+Staking Facilities,80
+Staked,72
+proofgroup,68
+StakeWithUs,68
+stakefish,66
+Ankr,64
+Cosmostation,61
+Juicy Stake,59
+KiligLab,56
+OKXEarn,55
+BiXinKelePool,52
+Staking Defense League,51
+Allnodes,51
+n1stake,49
+BlockEden.xyz,45
+Brightlystake,45
+Astro-Stakers,43
+01node,43
+KingSuper,43
+Stardust Staking,43
+B-Harvest,43
+Swiss Staking,43
+Restake,43
+Neuler,43
+[NODERS]TEAM x Criterion VC,43
+ANodes,43
+Peeranha,43
+ONBUFF,43
+Imperator.co,43
+SynergyNodes,43
+SyncNode,43
+ORBR,43
+Chainflow,41
+Omnistake,39
+Stakely,37
+Anchorage Digital-1,37
+ComingChat,34
+Parasol,34
+gumi,34
+XPRV,34
+InfStones,33
+Gaucho,33
+H2O Nodes,33
+A41,33
+Cypher Capital,33
+Qredo,33
+Laine,33
+BLRD,33
+Forbole,33
+QuantNode,33
+SpartanLabs,33
+Staketab,33
+RepublicCrypto,33
+NodeReal,33
+Nodeinfra,33
+Stakin,33
+SenseiNode,33
+flipside,33
+Moonlet,33
+MoveFuns DAO,33
+Node Guardians,33
+TDMTech,33
+HashQuark,33
+Latitude.sh,32
+MIDL.dev,32

--- a/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_400_details.txt
+++ b/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_400_details.txt
@@ -1,0 +1,107 @@
+Validator Name,Voting Power
+Figment,298
+Mysten-2,295
+P2P.ORG,293
+Mysten-1,277
+Triton One,258
+Blockdaemon,258
+Anchorage Digital-2,229
+Luganodes,209
+Chorus One,206
+Aftermath,179
+Cosmostation,178
+Everstake,176
+Overclock,169
+DSRV,169
+mrgn,160
+Kiln,152
+Blockscope.net,151
+Chainode Tech,151
+RepublicCrypto,150
+ContributionDAO,150
+Ahoy Validator,150
+BartestneT,147
+MoveFuns DAO,147
+Staketab,140
+n1stake,137
+Persimmon,137
+Durian,137
+BlockVision,131
+HashedPotatoes,125
+Coinbase Cloud,116
+Nodeinfra,116
+TrustedPoint,113
+P-OPS Team,109
+Dankuzone_w_DAIC,108
+TPT,108
+Artifact,108
+Bware Labs,106
+01node,105
+Laine,103
+Stakin,103
+Staking Defense League,102
+Galaxy Digital,102
+KingSuper,101
+ChainIDE,100
+KiligLab,99
+MIDL.dev,95
+Stardust Staking,93
+OKXEarn,91
+Chainflow,88
+ONBUFF,88
+ORBR,82
+StakingCabin,77
+Restake,77
+Staking Facilities,76
+Citadel.one,76
+Scale3Labs,75
+Ankr,62
+Shinlabs,56
+stakefish,55
+Allnodes,53
+Nelrann,50
+BiXinKelePool,49
+Cypher Capital,48
+ComingChat,46
+Cogent Crypto,46
+Brightlystake,46
+Staked,45
+Astro-Stakers,44
+Nodes.Guru,44
+B-Harvest,44
+Swiss Staking,44
+proofgroup,44
+Neuler,44
+[NODERS]TEAM x Criterion VC,44
+StakeWithUs,44
+Imperator.co,44
+SynergyNodes,44
+SyncNode,44
+Gaucho,41
+Peeranha,41
+Chainbase,40
+Anchorage Digital-1,38
+ZKValidator,37
+Suiet,37
+Studio Mirai,37
+InfStones,36
+Omnistake,35
+XPRV,35
+H2O Nodes,34
+A41,34
+Parasol,34
+BLRD,34
+Forbole,34
+Stakely,34
+QuantNode,34
+SpartanLabs,34
+NodeReal,34
+gumi,34
+SenseiNode,34
+Moonlet,34
+Juicy Stake,34
+Node Guardians,34
+TDMTech,34
+HashKey Cloud,34
+Latitude.sh,32
+BlockEden.xyz,31

--- a/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_800_details.txt
+++ b/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_800_details.txt
@@ -1,0 +1,117 @@
+Validator Name,Voting Power
+Mysten-2,285
+Mysten-1,278
+Aftermath,199
+DSRV,192
+Figment,189
+OKXEarn,181
+Coinbase,178
+Suilend,177
+Overclock,173
+Blockscope.net,167
+BartestneT,163
+Chainode Tech,159
+P2P.ORG,158
+RepublicCrypto,155
+n1stake,154
+Luganodes,154
+Persimmon,153
+Durian,153
+Chorus One,149
+Staketab,146
+BlockVision,145
+ContributionDAO,140
+Triton One,139
+mrgn,138
+Blockdaemon,135
+Everstake,130
+Kiln,123
+Cosmostation,120
+Nodeinfra,115
+Moonlet,115
+Staking Defense League,114
+Galaxy Digital,114
+Ahoy Validator,114
+KiligLab,111
+Alchemy,110
+TrustedPoint,107
+Coinage x DAIC,106
+Artifact,106
+Stardust Staking,105
+HashedPotatoes,104
+TPT,103
+P-OPS Team,102
+ChainIDE,100
+01node,98
+LumiWave,98
+Encapsulate (fka KingSuper),89
+HEEBOO,88
+StakingCabin,87
+Restake,87
+Chainflow,85
+Laine,85
+Staking Facilities,84
+Stakin,83
+Citadel.one,78
+ORBR,77
+Anchorage Digital-2,72
+Ankr,69
+Studio Mirai,68
+Shinlabs,61
+Scale3Labs,61
+Allnodes,59
+AlphaFi,59
+Cetus,58
+Nelrann,53
+Nansen,52
+BiXinKelePool,51
+Imperator.co,51
+Astro-Stakers,50
+H2O Nodes,50
+Nodes.Guru,50
+NAVI Protocol,50
+Haedal Protocol,50
+B-Harvest,49
+proofgroup,49
+SynergyNodes,49
+SyncNode,49
+Swiss Staking,48
+[NODERS] x Talentum,48
+Brightlystake,47
+Obelisk,46
+MIDL.dev,45
+Suiet,45
+Ika,45
+Chainbase Staking,44
+Kriya Validator,44
+Cogent Crypto,42
+Neuler,42
+Anchorage Digital-1,42
+Sentio,42
+Karrier One,42
+Stakely,41
+Surf,40
+iBriz.ai,40
+Bucket Protocol,40
+Omnistake,39
+gumi,39
+Asymmetric Research,39
+A41,38
+Cypher Capital,38
+BLRD,38
+QuantNode,38
+ProStaking,38
+TDMTech,38
+HashKey Cloud,38
+XPRV,37
+Forbole,36
+Staked,36
+Latitude.sh,36
+BlockEden.xyz,35
+stakefish,32
+Peeranha,31
+Node Guardians,31
+ZKV,29
+SenseiNode,28
+InfStones,26
+Scallop,19

--- a/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_974_details.txt
+++ b/fastcrypto-tbls/src/weight_reduction/data/sui_real_all_voting_power_epoch_974_details.txt
@@ -1,0 +1,128 @@
+Validator Name,Voting Power
+Mysten-1,282
+Mysten-2,253
+Galaxy Digital,217
+Luganodes,203
+Aftermath,201
+Coinbase,183
+DSRV,181
+Overclock,176
+Suilend,176
+Blockscope.net,169
+BartestneT,165
+Chainode Tech,160
+RepublicCrypto,157
+Persimmon,156
+Durian,156
+Blockdaemon,151
+Chorus One,149
+Figment,149
+n1stake,148
+Staketab,148
+BlockVision,147
+Triton One,140
+mrgn,139
+P2P.ORG,124
+Kraken,122
+Moonlet,117
+Everstake,115
+Staking Defense League,115
+ContributionDAO,112
+KiligLab,112
+Alchemy,108
+Artifact,108
+Nodeinfra,107
+Stardust Staking,106
+Kiln,105
+TPT,105
+P-OPS Team,103
+TrustedPoint,102
+LumiWave,100
+Coinage x DAIC,99
+ChainIDE,98
+Cosmostation,94
+OKXEarn,92
+HEEBOO,90
+StakingCabin,88
+01node,88
+Swyke,88
+Chainflow,87
+Laine,86
+Ankr,85
+Staking Facilities,84
+Stakin,83
+Haedal Protocol,82
+Citadel.one,77
+HashedPotatoes,75
+Ahoy Validator,75
+ORBR,75
+Anchorage Digital-2,72
+Studio Mirai,69
+Shinlabs,60
+Allnodes,60
+Cetus,60
+NAVI Protocol,59
+Nelrann,55
+Nansen | Stake to Stack Points,53
+H2O Nodes,52
+Nodes.Guru,52
+Astro-Stakers,51
+B-Harvest,51
+proofgroup,51
+Imperator.co,51
+SynergyNodes,51
+Anchorage Digital-1,48
+AlphaFi,48
+Obelisk,47
+SyncNode,47
+Suiet,47
+Interest Labs,47
+Chainbase Staking,45
+Ika,44
+Ledger by P2P.ORG,44
+Sentio,43
+Karrier One,43
+TradePort,42
+Stakely,41
+Surf,41
+Bluefin,41
+Bucket Protocol,40
+Asymmetric Research,40
+Hinode Technologies,39
+Brightlystake,39
+HashKey Cloud,39
+Encapsulate,39
+A41,38
+BLRD,38
+QuantNode,38
+ProStaking,38
+TDMTech,38
+iBriz.ai,38
+XPRV,37
+Latitude.sh,37
+Forbole,36
+GiveRep,36
+Cypher Capital,35
+Omnistake,35
+Swiss Staking,34
+[NODERS] x Talentum,34
+hoh.zone,34
+stakefish,33
+MIDL.dev,32
+Neuler,31
+Peeranha,31
+ZKV,30
+SenseiNode,29
+Cogent Crypto,26
+Scale3Labs,25
+BiXinKelePool,22
+Node Guardians,21
+DoubleUp,21
+Scallop,20
+FP Validated,20
+InfStones,18
+Lofi The Yeti,13
+Aphelion,7
+Kriya Validator,4
+TenX Protocols,4
+YOLOTRUMP,3


### PR DESCRIPTION
This PR adds Nodes::prop_reduce to fastcrypto-tbls mirroring new_reduced_with_f. It picks d on a 0.01 grid in [2,40], floors weights, ceilings t and f, and enforces the same budget: remainder mass plus ceiling slack for t and f must be at most allowed_delta. It scans integers down to the first feasible d, then refines (d,d+1) using scaled integer arithmetic only. The enlarged search never worsens reduced total weight and can improve it when slack falls between integer divisors. Embedded Sui mainnet voting‑power snapshot tests on five recent epochs assert prop_reduce is never looser than new_reduced_with_f across representative thresholds and budgets.