### PR TITLE
Helpers used by the AVID/AVSS PR: ecies, nodes, RS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -565,6 +576,12 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1425,8 +1442,8 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
+ "reed-solomon-erasure",
  "serde",
- "serde-big-array",
  "sha3",
  "tap",
  "tracing",
@@ -1755,11 +1772,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2087,6 +2113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,10 +2250,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "lru"
@@ -2391,7 +2444,7 @@ checksum = "b285c575532a33ef6fdd3a57640d0b1c70e6ca48644d6df7bbd4b7a0cfbbb12d"
 dependencies = [
  "bitvec",
  "either",
- "lru",
+ "lru 0.16.3",
  "num-bigint 0.4.6",
  "num-integer",
  "num-modular",
@@ -2473,6 +2526,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group 0.13.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.4",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2693,7 +2771,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2920,6 +2998,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
+dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot",
+ "smallvec",
+ "spin",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,7 +3180,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3178,6 +3278,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -3776,7 +3882,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4084,7 +4190,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4120,6 +4226,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4249,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -4348,7 +4476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/fastcrypto-tbls/Cargo.toml
+++ b/fastcrypto-tbls/Cargo.toml
@@ -23,7 +23,7 @@ zeroize.workspace = true
 itertools = "0.10.5"
 hex = "0.4.3"
 tap = { version = "1.0.1", features = [] }
-serde-big-array = "0.5.1"
+reed-solomon-erasure = "6.0.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/fastcrypto-tbls/src/ecies_v1.rs
+++ b/fastcrypto-tbls/src/ecies_v1.rs
@@ -8,6 +8,7 @@ use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{FiatShamirChallenge, GroupElement, HashToGroupElement, Scalar};
 use fastcrypto::traits::{AllowedRng, ToFromBytes};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::marker::PhantomData;
 use typenum::consts::{U16, U32};
 use typenum::Unsigned;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -45,8 +46,21 @@ pub const AES_KEY_LENGTH: usize = 32;
 pub struct MultiRecipientEncryption<G: GroupElement> {
     c: G,
     c_hat: G,
-    encs: Vec<Vec<u8>>,
+    pub(crate) encs: Vec<Vec<u8>>,
     proof: DdhTupleNizk<G>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharedComponents<G: GroupElement> {
+    c: G,
+    c_hat: G,
+    proof: DdhTupleNizk<G>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptedPart<G> {
+    enc: Vec<u8>,
+    g: PhantomData<G>,
 }
 
 impl<G: GroupElement + Serialize> MultiRecipientEncryption<G>
@@ -194,6 +208,24 @@ where
         &self.proof
     }
 
+    pub fn into_parts(self) -> (SharedComponents<G>, Vec<Vec<u8>>) {
+        let MultiRecipientEncryption {
+            c,
+            c_hat,
+            encs,
+            proof,
+        } = self;
+        (SharedComponents { c, c_hat, proof }, encs)
+    }
+
+    pub fn shared(&self) -> SharedComponents<G> {
+        SharedComponents {
+            c: self.c,
+            c_hat: self.c_hat,
+            proof: self.proof.clone(),
+        }
+    }
+
     fn encs_random_oracle(encryption_random_oracle: &RandomOracle) -> RandomOracle {
         encryption_random_oracle.extend("encs")
     }
@@ -227,6 +259,92 @@ fn sym_cipher(k: &[u8; 64]) -> Aes256Ctr {
         AesKey::<U32>::from_bytes(&k[0..U32::USIZE])
             .expect("New shouldn't fail as use fixed size key is used"),
     )
+}
+
+impl<G: GroupElement + Serialize> SharedComponents<G>
+where
+    <G as GroupElement>::ScalarType: FiatShamirChallenge + Zeroize,
+    G: HashToGroupElement,
+{
+    pub fn decrypt(
+        &self,
+        enc: &[u8],
+        sk: &PrivateKey<G>,
+        encryption_random_oracle: &RandomOracle,
+        receiver_index: usize,
+    ) -> Vec<u8> {
+        let enc_ro = MultiRecipientEncryption::<G>::encs_random_oracle(encryption_random_oracle);
+        let ephemeral_key = self.c * sk.0;
+        let k = enc_ro.evaluate(&(receiver_index, ephemeral_key));
+        let cipher = sym_cipher(&k);
+        cipher
+            .decrypt(&fixed_zero_nonce(), enc)
+            .expect("Decrypt should never fail for CTR mode")
+    }
+
+    pub fn ephemeral_key(&self) -> &G {
+        &self.c
+    }
+
+    pub fn verify(&self, encryption_random_oracle: &RandomOracle) -> FastCryptoResult<()> {
+        let g_hat = G::hash_to_group_element(
+            &MultiRecipientEncryption::<G>::g_hat_random_oracle(encryption_random_oracle)
+                .evaluate(&self.c),
+        );
+        self.proof.verify(
+            &g_hat,
+            &self.c,
+            &self.c_hat,
+            &MultiRecipientEncryption::<G>::zk_random_oracle(encryption_random_oracle),
+        )
+    }
+
+    pub fn create_recovery_package<R: AllowedRng>(
+        &self,
+        sk: &PrivateKey<G>,
+        recovery_random_oracle: &RandomOracle,
+        rng: &mut R,
+    ) -> RecoveryPackage<G> {
+        let pk = G::generator() * sk.0;
+        let ephemeral_key = self.c * sk.0;
+
+        let proof = DdhTupleNizk::<G>::create(
+            &sk.0,
+            &self.c,
+            &pk,
+            &ephemeral_key,
+            recovery_random_oracle,
+            rng,
+        );
+
+        RecoveryPackage {
+            ephemeral_key,
+            proof,
+        }
+    }
+
+    pub fn decrypt_with_recovery_package(
+        &self,
+        enc: &[u8],
+        pkg: &RecoveryPackage<G>,
+        recovery_random_oracle: &RandomOracle,
+        encryption_random_oracle: &RandomOracle,
+        receiver_pk: &PublicKey<G>,
+        receiver_index: usize,
+    ) -> FastCryptoResult<Vec<u8>> {
+        pkg.proof.verify(
+            &self.c,
+            &receiver_pk.0,
+            &pkg.ephemeral_key,
+            recovery_random_oracle,
+        )?;
+        let encs_ro = MultiRecipientEncryption::<G>::encs_random_oracle(encryption_random_oracle);
+        let k = encs_ro.evaluate(&(receiver_index, pkg.ephemeral_key));
+        let cipher = sym_cipher(&k);
+        Ok(cipher
+            .decrypt(&fixed_zero_nonce(), enc)
+            .expect("Decrypt should never fail for CTR mode"))
+    }
 }
 
 impl<G> PrivateKey<G>

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -6,6 +6,7 @@ use crate::types::ShareIndex;
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::GroupElement;
 use fastcrypto::hash::{Blake2b256, Digest, HashFunction};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -155,6 +156,28 @@ impl<G: GroupElement + Serialize> Nodes<G> {
         let mut hash = Blake2b256::default();
         hash.update(bcs::to_bytes(&self.nodes).expect("should serialize"));
         hash.finalize()
+    }
+
+    /// Given an iterator over a set of items, one per share index, this function groups them into
+    /// a vector of vectors, one per node, according to the share ids of the nodes.
+    /// Returns error if the number of items does not match the total weight.
+    pub fn collect_to_nodes<T>(
+        &self,
+        items: impl ExactSizeIterator<Item = T>,
+    ) -> FastCryptoResult<Vec<Vec<T>>> {
+        if items.len() != self.total_weight as usize {
+            return Err(FastCryptoError::InvalidInput);
+        }
+        let mut items = items;
+        Ok(self
+            .node_ids_iter()
+            .map(|id| {
+                items
+                    .by_ref()
+                    .take(self.weight_of(id).unwrap() as usize)
+                    .collect_vec()
+            })
+            .collect_vec())
     }
 
     /// Create a new set of nodes. Nodes must have consecutive ids starting from 0.

--- a/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
+++ b/fastcrypto-tbls/src/tests/ecies_v1_tests.rs
@@ -59,6 +59,13 @@ mod point_tests {
             assert_eq!(msg.as_bytes(), &decrypted);
         }
 
+        let (common, parts) = mr_enc.clone().into_parts();
+        assert!(common.verify(&ro).is_ok());
+        for (i, (part, (sk, _, msg))) in parts.iter().zip(keys_and_msg.iter()).enumerate() {
+            // Using parts should work as well
+            assert_eq!(msg.as_bytes(), common.decrypt(part, sk, &ro, i));
+        }
+
         // test empty messages
         let mr_enc2 = MultiRecipientEncryption::encrypt(
             &keys_and_msg

--- a/fastcrypto-tbls/src/threshold_schnorr/reed_solomon.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/reed_solomon.rs
@@ -4,9 +4,13 @@
 use crate::polynomial::{Eval, MonicLinear, Poly};
 use crate::threshold_schnorr::S;
 use crate::types::{to_scalar, ShareIndex};
-use fastcrypto::error::FastCryptoError::{InputLengthWrong, InvalidInput, TooManyErrors};
+use fastcrypto::error::FastCryptoError::{
+    InputLengthWrong, InputTooShort, InvalidInput, TooManyErrors,
+};
 use fastcrypto::error::FastCryptoResult;
 use itertools::Itertools;
+use reed_solomon_erasure::galois_8::ReedSolomon;
+use serde::{Deserialize, Serialize};
 
 /// Decoder for Reed-Solomon codes.
 /// This can correct up to (d-1)/2 errors, where d is the distance of the code.
@@ -123,6 +127,87 @@ impl RSDecoder {
     }
 }
 
+/// A wrapper struct for the Reed-Solomon erasure coding library.
+pub struct ErasureCoder(ReedSolomon);
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Shard(pub(crate) Vec<u8>);
+
+impl ErasureCoder {
+    /// Create a new erasure encoder/decoder.
+    ///
+    /// # Parameters
+    /// - `n`: Total number of shards.
+    /// - `k`: Number of data shards.
+    ///
+    /// # Errors
+    /// Returns [`FastCryptoError::InvalidInput`] if `k == 0`, `n <= k` or `n > 256`.
+    pub fn new(n: usize, k: usize) -> FastCryptoResult<Self> {
+        if k == 0 || n <= k || n > 256 {
+            return Err(InvalidInput);
+        }
+        ReedSolomon::new(k, n - k)
+            .map_err(|_| InvalidInput)
+            .map(Self)
+    }
+
+    /// Encode `data` into `n` shards of equal size, the first `k` of which hold the (zero-padded)
+    /// data and the remaining `n - k` parity. Any `k` shards suffice to reconstruct the data.
+    pub fn encode(&self, data: &[u8]) -> FastCryptoResult<Vec<Shard>> {
+        // Define a shard size such that the data can be contained in `k` shards.
+        let shard_size = data.len().div_ceil(self.0.data_shard_count());
+        let mut data = data.to_vec();
+        data.resize(shard_size * self.0.total_shard_count(), 0);
+        let mut shards = data
+            .chunks_exact(shard_size)
+            .map(|c| c.to_vec())
+            .collect_vec();
+        self.0.encode(&mut shards).map_err(|_| InvalidInput)?;
+        Ok(shards.into_iter().map(Shard).collect_vec())
+    }
+
+    /// Reconstruct the original data from `n` (possibly missing) shards, returning the first
+    /// `expected_len` bytes. Fails if more than `n - k` shards are missing or if the present
+    /// shards are inconsistent with any single codeword.
+    pub fn decode(
+        &self,
+        shards: Vec<Option<Shard>>,
+        expected_len: usize,
+    ) -> FastCryptoResult<Vec<u8>> {
+        if shards.len() != self.0.total_shard_count() {
+            return Err(InputTooShort(self.0.total_shard_count()));
+        }
+
+        if shards.iter().filter(|s| s.is_none()).count() > self.0.parity_shard_count() {
+            return Err(InvalidInput);
+        }
+
+        let mut shards = shards.into_iter().map(|s| s.map(|s| s.0)).collect_vec();
+        self.0.reconstruct(&mut shards).map_err(|_| InvalidInput)?;
+        let shards = shards
+            .into_iter()
+            .map(|s| s.ok_or(InvalidInput))
+            .collect::<FastCryptoResult<Vec<_>>>()?;
+
+        // Ensure the reconstructed shards are consistent
+        if !self.0.verify(&shards).map_err(|_| InvalidInput)? {
+            return Err(TooManyErrors(0)); // This is just an erasure code, so we can't correct errors.
+        }
+
+        let mut data = shards
+            .into_iter()
+            .take(self.0.data_shard_count())
+            .flatten()
+            .collect_vec();
+        if data.len() < expected_len {
+            return Err(InvalidInput);
+        }
+        data.truncate(expected_len);
+        Ok(data)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -163,5 +248,74 @@ mod tests {
             .decode(&received)
             .unwrap();
         assert_eq!(decoded_message, message);
+    }
+
+    #[test]
+    fn test_erasure_coder_new_rejects_invalid_parameters() {
+        assert!(matches!(ErasureCoder::new(10, 0), Err(InvalidInput)));
+        assert!(matches!(ErasureCoder::new(10, 10), Err(InvalidInput)));
+        assert!(matches!(ErasureCoder::new(9, 10), Err(InvalidInput)));
+        assert!(matches!(ErasureCoder::new(257, 1), Err(InvalidInput)));
+    }
+
+    #[test]
+    fn test_erasure_coder_roundtrip() {
+        let n = 10;
+        let k = 6;
+        let coder = ErasureCoder::new(n, k).unwrap();
+
+        for len in [1usize, 2, 3, 7, 8, 31, 32, 33, 100, 255] {
+            let data: Vec<u8> = (0..len)
+                .map(|i| (i as u8).wrapping_mul(31).wrapping_add(7))
+                .collect();
+            let shards = coder.encode(&data).unwrap();
+            assert_eq!(shards.len(), n);
+
+            // Remove up to `parity` shards (erasures) and reconstruct.
+            let mut opt_shards: Vec<Option<Shard>> = shards.into_iter().map(Some).collect();
+            for shard in opt_shards.iter_mut().take(n - k) {
+                *shard = None;
+            }
+
+            let coder = ErasureCoder::new(n, k).unwrap();
+            let recovered = coder.decode(opt_shards, len).unwrap();
+            assert_eq!(recovered, data);
+        }
+    }
+
+    #[test]
+    fn test_erasure_coder_decode_rejects_too_many_missing_shards() {
+        let n = 9;
+        let k = 5;
+        let coder = ErasureCoder::new(n, k).unwrap();
+        let data: Vec<u8> = (0..123).map(|i| i as u8).collect();
+        let shards = coder.encode(&data).unwrap();
+
+        // Parity is `n - k` -- remove more shards than that.
+        let mut opt_shards: Vec<Option<Shard>> = shards.into_iter().map(Some).collect();
+        for shard in opt_shards.iter_mut().take(n - k + 1) {
+            *shard = None;
+        }
+
+        assert!(matches!(coder.decode(opt_shards, 123), Err(InvalidInput)));
+    }
+
+    #[test]
+    fn test_erasure_coder_detects_corrupted_shard() {
+        let n = 8;
+        let k = 5;
+        let coder = ErasureCoder::new(n, k).unwrap();
+        let data: Vec<u8> = (0..200).map(|i| (i as u8) ^ 0xAA).collect();
+        let mut shards = coder.encode(&data).unwrap();
+
+        // Corrupt one shard (without declaring it missing). Reconstruction will succeed,
+        // but verification should fail.
+        shards[0].0[0] ^= 1;
+        let opt_shards = shards.into_iter().map(Some).collect_vec();
+
+        assert!(matches!(
+            coder.decode(opt_shards, 200),
+            Err(TooManyErrors(_))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Splits the support-module changes out of [#954](https://github.com/MystenLabs/fastcrypto/pull/954) so that PR can focus on the AVID/AVSS protocol itself. No protocol changes here:

- **Cargo.toml**: drop `serde-big-array` (unused), add `reed-solomon-erasure` for the RS code.
- **ecies_v1.rs**: small additions used by the AVSS complaint flow, with a regression test.
- **nodes.rs**: prune unused methods; `nodes_tests.rs` updated to drop the now-unused property test.
- **reed_solomon.rs**: extend the RS wrapper used for AVID dispersal, with doc comments on `encode`/`decode`.

## Test plan
- [x] cargo test -p fastcrypto-tbls (90 passed)
- [x] cargo clippy --all-targets --all-features -p fastcrypto-tbls -- -D warnings