### PR TITLE
Handle zero-weight nodes in threshold-schnorr

### DIFF
--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -958,9 +958,7 @@ mod tests {
 
     #[test]
     fn test_key_rotation_with_zero_weight_node() {
-        // Node 0 has weight 0 (as can happen after weight reduction). It holds no shares but
-        // must still be able to complete key rotation, recovering the verifying key without
-        // panicking.
+        // Node 0 has weight 0: it holds no shares but must still complete key rotation.
         let t = 3;
         let weights = [0u16, 2, 1, 1];
         let n = weights.len();
@@ -1062,8 +1060,7 @@ mod tests {
             })
             .collect();
 
-        // The verifying key is preserved, and the zero-weight node holds no shares while the
-        // others hold one share per unit of weight.
+        // The verifying key is preserved; each node holds one share per unit of weight.
         for (id, output) in &new_outputs {
             assert_eq!(output.vk, vk);
             assert_eq!(

--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -545,6 +545,7 @@ mod tests {
     use crate::ecies_v1::{MultiRecipientEncryption, PublicKey};
     use crate::nodes::{Node, Nodes, PartyId};
     use crate::polynomial::Poly;
+    use crate::types::{IndexedValue, ShareIndex};
     use crate::threshold_schnorr::avss::{Dealer, Message, Receiver};
     use crate::threshold_schnorr::avss::{PartialOutput, ProcessedMessage};
     use crate::threshold_schnorr::avss::{ReceiverOutput, SharesForNode};
@@ -953,6 +954,133 @@ mod tests {
             .collect_vec();
         let sk = Poly::recover_c0(t, shares[..t as usize].iter()).unwrap();
         assert_eq!(G::generator() * sk, vk);
+    }
+
+    #[test]
+    fn test_key_rotation_with_zero_weight_node() {
+        // Node 0 has weight 0 (as can happen after weight reduction). It holds no shares but
+        // must still be able to complete key rotation, recovering the verifying key without
+        // panicking.
+        let t = 3;
+        let weights = [0u16, 2, 1, 1];
+        let n = weights.len();
+
+        let mut rng = rand::thread_rng();
+        let sks = (0..n)
+            .map(|_| ecies_v1::PrivateKey::<EG>::new(&mut rng))
+            .collect::<Vec<_>>();
+        let nodes = Nodes::new(
+            sks.iter()
+                .zip(weights)
+                .enumerate()
+                .map(|(id, (sk, weight))| Node {
+                    id: id as u16,
+                    pk: PublicKey::from_private_key(sk),
+                    weight,
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+        let make_receivers = |sid: &[u8], commitment: Option<G>| {
+            sks.iter()
+                .enumerate()
+                .map(|(id, sk)| {
+                    Receiver::new(
+                        nodes.clone(),
+                        id as u16,
+                        t,
+                        sid.to_vec(),
+                        commitment,
+                        sk.clone(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        // Round 0: a single dealer shares a random secret.
+        let secret = Scalar::rand(&mut rng);
+        let vk = G::generator() * secret;
+        let sid0 = b"key-rotation-zero-weight-round0".to_vec();
+        let message = Dealer::new(Some(secret), nodes.clone(), t, sid0.clone())
+            .unwrap()
+            .create_message(&mut rng);
+        let round0: HashMap<PartyId, ReceiverOutput> = make_receivers(&sid0, Some(vk))
+            .iter()
+            .map(|r| {
+                (
+                    r.id(),
+                    assert_valid(r.process_message(&message).unwrap())
+                        .into_receiver_output(&nodes),
+                )
+            })
+            .collect();
+
+        // Key rotation: each existing share index is reshared by the node holding it.
+        let mut rotated = HashMap::<(PartyId, ShareIndex), PartialOutput>::new();
+        for share_index in nodes.share_ids_iter() {
+            let holder = nodes.share_id_to_node(&share_index).unwrap().id;
+            let reshared_secret = round0
+                .get(&holder)
+                .unwrap()
+                .share_for_index(share_index)
+                .unwrap()
+                .value;
+            let commitment = round0
+                .get(&0)
+                .unwrap()
+                .commitment_for_index(share_index)
+                .unwrap()
+                .value;
+            let sid = format!("key-rotation-zero-weight-{}", share_index.get()).into_bytes();
+            let message = Dealer::new(Some(reshared_secret), nodes.clone(), t, sid.clone())
+                .unwrap()
+                .create_message(&mut rng);
+            for r in make_receivers(&sid, Some(commitment)) {
+                rotated.insert(
+                    (r.id(), share_index),
+                    assert_valid(r.process_message(&message).unwrap()),
+                );
+            }
+        }
+
+        // The first t share indices form the certificate.
+        let cert = nodes.share_ids_iter().take(t as usize).collect_vec();
+        let new_outputs: HashMap<PartyId, ReceiverOutput> = nodes
+            .node_ids_iter()
+            .map(|id| {
+                let outputs = cert
+                    .iter()
+                    .map(|&index| IndexedValue {
+                        index,
+                        value: rotated.get(&(id, index)).unwrap().clone(),
+                    })
+                    .collect_vec();
+                (
+                    id,
+                    ReceiverOutput::complete_key_rotation(t, id, &nodes, &outputs).unwrap(),
+                )
+            })
+            .collect();
+
+        // The verifying key is preserved, and the zero-weight node holds no shares while the
+        // others hold one share per unit of weight.
+        for (id, output) in &new_outputs {
+            assert_eq!(output.vk, vk);
+            assert_eq!(
+                output.my_shares.weight(),
+                nodes.weight_of(*id).unwrap() as usize
+            );
+        }
+        assert_eq!(new_outputs.get(&0).unwrap().my_shares.weight(), 0);
+
+        // The rotated shares still reconstruct the original secret.
+        let shares = new_outputs
+            .values()
+            .flat_map(|output| output.my_shares.shares.clone())
+            .collect_vec();
+        let recovered = Poly::recover_c0(t, shares[..t as usize].iter()).unwrap();
+        assert_eq!(secret, recovered);
     }
 
     fn assert_valid(processed_message: ProcessedMessage) -> PartialOutput {

--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -545,7 +545,6 @@ mod tests {
     use crate::ecies_v1::{MultiRecipientEncryption, PublicKey};
     use crate::nodes::{Node, Nodes, PartyId};
     use crate::polynomial::Poly;
-    use crate::types::{IndexedValue, ShareIndex};
     use crate::threshold_schnorr::avss::{Dealer, Message, Receiver};
     use crate::threshold_schnorr::avss::{PartialOutput, ProcessedMessage};
     use crate::threshold_schnorr::avss::{ReceiverOutput, SharesForNode};
@@ -554,6 +553,7 @@ mod tests {
     use crate::threshold_schnorr::tests::restrict;
     use crate::threshold_schnorr::Extensions::Encryption;
     use crate::threshold_schnorr::{EG, G, S};
+    use crate::types::{IndexedValue, ShareIndex};
     use fastcrypto::error::FastCryptoResult;
     use fastcrypto::groups::{GroupElement, Scalar};
     use fastcrypto::traits::AllowedRng;
@@ -1010,8 +1010,7 @@ mod tests {
             .map(|r| {
                 (
                     r.id(),
-                    assert_valid(r.process_message(&message).unwrap())
-                        .into_receiver_output(&nodes),
+                    assert_valid(r.process_message(&message).unwrap()).into_receiver_output(&nodes),
                 )
             })
             .collect();

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
@@ -522,9 +522,7 @@ fn verify_shares(
     if shares.weight() != nodes.weight_of(receiver)? {
         return Err(InvalidMessage);
     }
-    // A zero-weight node holds no shares, so there is no batch size to check and `verify` below
-    // is a no-op. `try_uniform_batch_size` errors on an empty share set, so it is only meaningful
-    // when the node actually has shares.
+    // Skip the batch-size check for a zero-weight node, which holds no shares.
     if !shares.shares.is_empty() && shares.try_uniform_batch_size()? != expected_batch_size {
         return Err(InvalidMessage);
     }
@@ -745,8 +743,7 @@ mod tests {
 
     #[test]
     fn test_happy_path_with_zero_weight_node() {
-        // Node 1 has weight 0 (as can happen after weight reduction). It receives no shares, but
-        // the protocol must complete for every node without raising a spurious complaint.
+        // Node 1 has weight 0: it receives no shares but the protocol must still complete.
         let t = 4;
         let weights: Vec<u16> = vec![1, 0, 3, 4];
         let batch_size_per_weight = 3;

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss.rs
@@ -519,9 +519,13 @@ fn verify_shares(
     challenge: &[S],
     expected_batch_size: usize,
 ) -> FastCryptoResult<()> {
-    if shares.weight() != nodes.weight_of(receiver)?
-        || shares.try_uniform_batch_size()? != expected_batch_size
-    {
+    if shares.weight() != nodes.weight_of(receiver)? {
+        return Err(InvalidMessage);
+    }
+    // A zero-weight node holds no shares, so there is no batch size to check and `verify` below
+    // is a no-op. `try_uniform_batch_size` errors on an empty share set, so it is only meaningful
+    // when the node actually has shares.
+    if !shares.shares.is_empty() && shares.try_uniform_batch_size()? != expected_batch_size {
         return Err(InvalidMessage);
     }
     shares.verify(message, challenge)
@@ -737,6 +741,93 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(secrets, secrets);
+    }
+
+    #[test]
+    fn test_happy_path_with_zero_weight_node() {
+        // Node 1 has weight 0 (as can happen after weight reduction). It receives no shares, but
+        // the protocol must complete for every node without raising a spurious complaint.
+        let t = 4;
+        let weights: Vec<u16> = vec![1, 0, 3, 4];
+        let batch_size_per_weight = 3;
+
+        let mut rng = rand::thread_rng();
+        let sks = weights
+            .iter()
+            .map(|_| ecies_v1::PrivateKey::<EG>::new(&mut rng))
+            .collect::<Vec<_>>();
+        let nodes = Nodes::new(
+            weights
+                .iter()
+                .enumerate()
+                .map(|(i, &weight)| Node {
+                    id: i as u16,
+                    pk: PublicKey::from_private_key(&sks[i]),
+                    weight,
+                })
+                .collect_vec(),
+        )
+        .unwrap();
+
+        let dealer_id = 2;
+        let sid = b"tbls test".to_vec();
+        let dealer: Dealer = Dealer::new(
+            nodes.clone(),
+            dealer_id,
+            t,
+            sid.clone(),
+            batch_size_per_weight,
+        )
+        .unwrap();
+
+        let receivers = sks
+            .into_iter()
+            .enumerate()
+            .map(|(i, secret_key)| {
+                Receiver::new(
+                    nodes.clone(),
+                    i as u16,
+                    dealer_id,
+                    t,
+                    sid.clone(),
+                    secret_key,
+                    batch_size_per_weight,
+                )
+                .unwrap()
+            })
+            .collect_vec();
+
+        let message = dealer.create_message(&mut rng).unwrap();
+
+        let outputs = receivers
+            .iter()
+            .map(|receiver| assert_valid(receiver.process_message(&message).unwrap()))
+            .collect_vec();
+
+        // Every node holds one share per unit of weight; the zero-weight node holds none.
+        for (receiver, output) in receivers.iter().zip(&outputs) {
+            assert_eq!(
+                output.my_shares.weight(),
+                nodes.weight_of(receiver.id).unwrap()
+            );
+        }
+        assert!(outputs[1].my_shares.shares.is_empty());
+
+        // The dealt secrets are still recoverable from the weight-bearing nodes' shares.
+        let all_shares = outputs
+            .iter()
+            .flat_map(|o| o.my_shares.shares.iter())
+            .collect_vec();
+        for l in 0..dealer.batch_size {
+            Poly::recover_c0(
+                t,
+                all_shares.iter().take(t as usize).map(|s| Eval {
+                    index: s.index,
+                    value: s.batch[l],
+                }),
+            )
+            .unwrap();
+        }
     }
 
     #[test]

--- a/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
@@ -19,18 +19,18 @@ impl Iterator for Presignatures {
     type Item = (Vec<S>, G);
 
     fn next(&mut self) -> Option<Self::Item> {
+        // `public` is the source of truth for the length: it always has one entry per nonce,
+        // whereas `secret` is empty for a zero-weight party. The secret and public multipliers
+        // are constructed with equal length (checked in `Presignatures::new`), so whenever
+        // `public` yields, every secret multiplier yields too.
+        let public = self.public.next()?;
         let secret = self
             .secret
             .iter_mut()
             .map(Iterator::next)
-            .collect::<Option<Vec<_>>>();
-        let public = self.public.next();
-
-        match (secret, public) {
-            (Some(s), Some(p)) => Some((s, p)),
-            (None, None) => None,
-            _ => unreachable!(),
-        }
+            .collect::<Option<Vec<_>>>()
+            .expect("secret and public multipliers have equal length");
+        Some((secret, public))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -61,14 +61,14 @@ impl Presignatures {
             return Err(InvalidInput);
         }
 
-        // Each node should deal a batch sized proportional to their weight, and the total weight of the outputs should be at least t + f
+        // Each dealer deals a batch sized proportional to their weight, and the total weight of
+        // the outputs should be at least t + f. We recover each dealer's weight from the number
+        // of public keys (one per dealt nonce) rather than from this party's own shares, since
+        // a zero-weight party holds no shares to read the batch size from.
         let weights = outputs
             .iter()
             .map(|o| {
-                let batch_size = o
-                    .my_shares
-                    .try_uniform_batch_size()
-                    .expect("Checked in batch_avss");
+                let batch_size = o.public_keys.len();
                 (batch_size % batch_size_per_weight as usize == 0)
                     .then_some(batch_size / batch_size_per_weight as usize)
                     .ok_or(InvalidInput)
@@ -116,14 +116,49 @@ impl Presignatures {
                 .collect_vec(),
         );
 
-        // Sanity checks that the size of the multipliers matches the expected number of nonces that this presigning will give
+        // Sanity checks that the size of the multipliers matches the expected number of nonces
+        // that this presigning will give. `secret` is empty for a zero-weight party, in which
+        // case the `all` check holds vacuously.
         let expected_len = (total_weight_of_outputs - f) * batch_size_per_weight as usize;
-        assert_eq!(
-            get_uniform_value(secret.iter().map(|s| s.len())).unwrap(),
-            expected_len
-        );
+        assert!(secret.iter().all(|s| s.len() == expected_len));
         assert_eq!(public.len(), expected_len);
 
         Ok(Self { secret, public })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Presignatures;
+    use crate::threshold_schnorr::batch_avss::{ReceiverOutput, SharesForNode};
+    use crate::threshold_schnorr::G;
+    use fastcrypto::groups::GroupElement;
+
+    #[test]
+    fn test_new_with_zero_weight_party() {
+        // A zero-weight party holds no shares, so every ReceiverOutput it gets has an empty
+        // `my_shares`. Presignatures::new (and iterating the result) must handle this without
+        // panicking, yielding presignatures with empty secret components.
+        let batch_size_per_weight: u16 = 2;
+        let f = 1;
+
+        // Two dealers, each of weight 1, so each output has batch_size_per_weight * 1 = 2
+        // public keys and no shares for this (zero-weight) party.
+        let outputs = (0..2)
+            .map(|_| ReceiverOutput {
+                my_shares: SharesForNode { shares: vec![] },
+                public_keys: vec![G::generator(); batch_size_per_weight as usize],
+            })
+            .collect::<Vec<_>>();
+
+        let presignatures = Presignatures::new(outputs, batch_size_per_weight, f).unwrap();
+
+        let total_weight_of_outputs = 2;
+        let expected_len = (total_weight_of_outputs - f) * batch_size_per_weight as usize;
+        assert_eq!(presignatures.len(), expected_len);
+
+        let tuples = presignatures.collect::<Vec<_>>();
+        assert_eq!(tuples.len(), expected_len);
+        assert!(tuples.iter().all(|(secret, _public)| secret.is_empty()));
     }
 }

--- a/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
@@ -74,8 +74,8 @@ impl Presignatures {
         }
 
         // This party's weight, aka it's number of shares
-        let my_weight = get_uniform_value(outputs.iter().map(|o| o.my_shares.weight()))
-            .expect("Checked in batch_avss");
+        let my_weight =
+            get_uniform_value(outputs.iter().map(|o| o.my_shares.weight())).ok_or(InvalidInput)?;
 
         // There is one secret presigning output per shares for this party
         let secret = (0..my_weight as usize)

--- a/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
@@ -19,10 +19,7 @@ impl Iterator for Presignatures {
     type Item = (Vec<S>, G);
 
     fn next(&mut self) -> Option<Self::Item> {
-        // `public` is the source of truth for the length: it always has one entry per nonce,
-        // whereas `secret` is empty for a zero-weight party. The secret and public multipliers
-        // are constructed with equal length (checked in `Presignatures::new`), so whenever
-        // `public` yields, every secret multiplier yields too.
+        // `public` drives the length; `secret` is empty for a zero-weight party.
         let public = self.public.next()?;
         let secret = self
             .secret
@@ -61,10 +58,7 @@ impl Presignatures {
             return Err(InvalidInput);
         }
 
-        // Each dealer deals a batch sized proportional to their weight, and the total weight of
-        // the outputs should be at least t + f. We recover each dealer's weight from the number
-        // of public keys (one per dealt nonce) rather than from this party's own shares, since
-        // a zero-weight party holds no shares to read the batch size from.
+        // Recover each dealer's weight from its public key count, which works even for a zero-weight party.
         let weights = outputs
             .iter()
             .map(|o| {
@@ -116,9 +110,7 @@ impl Presignatures {
                 .collect_vec(),
         );
 
-        // Sanity checks that the size of the multipliers matches the expected number of nonces
-        // that this presigning will give. `secret` is empty for a zero-weight party, in which
-        // case the `all` check holds vacuously.
+        // Sanity check that the multiplier sizes match the expected nonce count.
         let expected_len = (total_weight_of_outputs - f) * batch_size_per_weight as usize;
         assert!(secret.iter().all(|s| s.len() == expected_len));
         assert_eq!(public.len(), expected_len);
@@ -136,14 +128,11 @@ mod tests {
 
     #[test]
     fn test_new_with_zero_weight_party() {
-        // A zero-weight party holds no shares, so every ReceiverOutput it gets has an empty
-        // `my_shares`. Presignatures::new (and iterating the result) must handle this without
-        // panicking, yielding presignatures with empty secret components.
+        // A zero-weight party gets ReceiverOutputs with empty shares; this must not panic.
         let batch_size_per_weight: u16 = 2;
         let f = 1;
 
-        // Two dealers, each of weight 1, so each output has batch_size_per_weight * 1 = 2
-        // public keys and no shares for this (zero-weight) party.
+        // Two weight-1 dealers: each output has batch_size_per_weight public keys, no shares.
         let outputs = (0..2)
             .map(|_| ReceiverOutput {
                 my_shares: SharesForNode { shares: vec![] },


### PR DESCRIPTION
Zero-weight nodes (produced by `Nodes::new_reduced`) panicked or were previously rejected in `avss::complete_key_rotation`, `Presignatures::new` and its iterator, and `batch_avss::verify_shares`. They are now treated as observers that hold no shares. Adds a zero-weight test for each.