### PR TITLE
Take indices instead of shares when computing Lagrange coefficients

### DIFF
--- a/fastcrypto-tbls/src/polynomial.rs
+++ b/fastcrypto-tbls/src/polynomial.rs
@@ -201,19 +201,19 @@ impl<C: GroupElement> Poly<C> {
 
     pub(crate) fn get_lagrange_coefficients_for_c0(
         t: u16,
-        shares: impl Iterator<Item = impl Borrow<Eval<C>>>,
+        indices: impl Iterator<Item = impl Borrow<ShareIndex>>,
     ) -> FastCryptoResult<(C::ScalarType, Vec<C::ScalarType>)> {
-        Self::get_lagrange_coefficients_for(0, t, shares)
+        Self::get_lagrange_coefficients_for(0, t, indices)
     }
 
-    /// Expects exactly t unique shares.
+    /// Expects exactly t unique indices.
     /// Returns an error if x is one of the indices.
     fn get_lagrange_coefficients_for(
         x: u128,
         t: u16,
-        shares: impl Iterator<Item = impl Borrow<Eval<C>>>,
+        indices: impl Iterator<Item = impl Borrow<ShareIndex>>,
     ) -> FastCryptoResult<(C::ScalarType, Vec<C::ScalarType>)> {
-        let indices = shares.map(|s| s.borrow().index.get() as u128).collect_vec();
+        let indices = indices.map(|i| i.borrow().get() as u128).collect_vec();
         if !indices.iter().all_unique() || indices.len() != t as usize || indices.contains(&x) {
             return Err(FastCryptoError::InvalidInput);
         }
@@ -258,7 +258,8 @@ impl<C: GroupElement> Poly<C> {
         t: u16,
         shares: impl Iterator<Item = impl Borrow<Eval<C>>> + Clone,
     ) -> FastCryptoResult<C> {
-        let coeffs = Self::get_lagrange_coefficients_for_c0(t, shares.clone())?;
+        let coeffs =
+            Self::get_lagrange_coefficients_for_c0(t, shares.clone().map(|s| s.borrow().index))?;
         Ok(C::sum(
             shares
                 .map(|s| s.borrow().value)
@@ -362,7 +363,7 @@ impl<C: Scalar> Poly<C> {
         let lagrange_coefficients = Self::get_lagrange_coefficients_for(
             index.get() as u128,
             points.len() as u16,
-            points.iter(),
+            points.iter().map(|p| p.index),
         )?;
         let value = C::sum(
             lagrange_coefficients
@@ -489,7 +490,8 @@ impl<C: GroupElement + MultiScalarMul> Poly<C> {
         t: u16,
         shares: impl Iterator<Item = impl Borrow<Eval<C>>> + Clone,
     ) -> Result<C, FastCryptoError> {
-        let coeffs = Self::get_lagrange_coefficients_for_c0(t, shares.clone())?;
+        let coeffs =
+            Self::get_lagrange_coefficients_for_c0(t, shares.clone().map(|s| s.borrow().index))?;
         let plain_shares = shares.map(|s| s.borrow().value).collect::<Vec<_>>();
         let res = C::multi_scalar_mul(&coeffs.1, &plain_shares).expect("sizes match") * coeffs.0;
         Ok(res)

--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -446,13 +446,9 @@ impl ReceiverOutput {
 
         let my_indices = nodes.share_ids_of(my_id)?;
 
-        // We only need to compute the lagrange coefficients for one of the indices this party controls
-        let lagrange_coefficients: Vec<S> = Poly::get_lagrange_coefficients_for_c0(
+        let lagrange_coefficients: Vec<S> = Poly::<G>::get_lagrange_coefficients_for_c0(
             t,
-            outputs.iter().map(|output| Eval {
-                index: output.index,
-                value: output.value.share_for_index(my_indices[0]).unwrap().value,
-            }),
+            outputs.iter().map(|output| output.index),
         )
         .map(|c| c.1.iter().map(|s| s * c.0).collect_vec())?;
 


### PR DESCRIPTION
## Summary
- `Poly::get_lagrange_coefficients_for_c0` (and the private `get_lagrange_coefficients_for` it delegates to) now accept `impl Iterator<Item = impl Borrow<ShareIndex>>` instead of full shares — only the indices were ever used.
- Updated internal callers (`recover_c0`, `recover_c0_msm`, `recover_at`) to pass `.index`.
- The AVSS `merge` caller no longer constructs throwaway `Eval` structs solely to supply indices.

## Test plan
- [x] `cargo build -p fastcrypto-tbls --tests`
- [x] `cargo fmt` / `cargo clippy -p fastcrypto-tbls --tests`
- [x] `cargo test -p fastcrypto-tbls polynomial`