### PR TITLE
Reject non-canonical input in Ed25519AggregateSignature::from_bytes

### DIFF
--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -408,11 +408,17 @@ impl AsRef<[u8]> for Ed25519AggregateSignature {
 
 impl ToFromBytes for Ed25519AggregateSignature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
+        // Reject inputs whose length is not a multiple of the signature length. Otherwise
+        // `chunks_exact` would silently drop trailing bytes, making the encoding non-canonical.
+        if !bytes.len().is_multiple_of(ED25519_SIGNATURE_LENGTH) {
+            return Err(InvalidInput);
+        }
         let sigs = bytes
             .chunks_exact(ED25519_SIGNATURE_LENGTH)
-            .map(|chunk| <Ed25519Signature as traits::ToFromBytes>::from_bytes(chunk).unwrap())
-            .map(|s| s.sig)
-            .collect();
+            .map(|chunk| {
+                <Ed25519Signature as traits::ToFromBytes>::from_bytes(chunk).map(|s| s.sig)
+            })
+            .collect::<Result<_, _>>()?;
         Ok(Ed25519AggregateSignature {
             sigs,
             bytes: OnceCell::new(),

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -555,7 +555,7 @@ impl<'de> DeserializeAs<'de, ed25519_consensus::Signature> for SingleSignature {
     {
         let bytes = if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            base64ct::Base64::decode_vec(&s).map_err(to_custom_error::<'de, D, _>)?
+            Base64::decode(&s).map_err(to_custom_error::<'de, D, _>)?
         } else {
             SerdeBytes::deserialize_as(deserializer)?
         };

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -20,7 +20,6 @@ use std::{
     str::FromStr,
 };
 
-use base64ct::Encoding as _;
 use derive_more::AsRef;
 #[cfg(any(test, feature = "experimental"))]
 use ed25519_consensus::{batch, VerificationKeyBytes};

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -408,8 +408,6 @@ impl AsRef<[u8]> for Ed25519AggregateSignature {
 
 impl ToFromBytes for Ed25519AggregateSignature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
-        // Reject inputs whose length is not a multiple of the signature length. Otherwise
-        // `chunks_exact` would silently drop trailing bytes, making the encoding non-canonical.
         if !bytes.len().is_multiple_of(ED25519_SIGNATURE_LENGTH) {
             return Err(InvalidInput);
         }

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -427,6 +427,13 @@ fn test_to_from_bytes_aggregate_signatures() {
     let serialized = sig.as_bytes();
     let deserialized = Ed25519AggregateSignature::from_bytes(serialized).unwrap();
     assert_eq!(deserialized, sig);
+
+    // Inputs whose length is not a multiple of the signature length must be rejected instead of
+    // silently dropping the trailing bytes.
+    let mut with_trailing_byte = serialized.to_vec();
+    with_trailing_byte.push(0);
+    assert!(Ed25519AggregateSignature::from_bytes(&with_trailing_byte).is_err());
+    assert!(Ed25519AggregateSignature::from_bytes(&[0u8; 1]).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `Ed25519AggregateSignature::from_bytes` parsed the input with `chunks_exact(ED25519_SIGNATURE_LENGTH)`, which **silently drops a trailing partial chunk**. An input whose length is not a multiple of 64 deserialized successfully and re-serialized to a shorter, different byte string — a non-canonical / malleable encoding.
- Now rejects such inputs with `InvalidInput`, and propagates per-chunk parse errors instead of `.unwrap()`.

## Notes
- `Ed25519AggregateSignature` is gated behind the `experimental` feature and disabled by default, so impact is limited.
- This PR does **not** touch the separate, intentional divergence between the serde representation (length-prefixed `Vec`) and the `ToFromBytes`/`AsRef` representation (bare concatenation) — that is documented on the struct and changing it would be a breaking wire-format change.

## Test plan
- [x] `cargo test -p fastcrypto --lib ed25519_tests` (40 passed)
- [x] Extended `test_to_from_bytes_aggregate_signatures` to assert that inputs with a trailing byte and a 1-byte input are rejected.