### PR TITLE
Document that FromTrustedByteArray skips validation

### DIFF
--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -131,7 +131,16 @@ pub trait MultiScalarMul: GroupElement {
     fn multi_scalar_mul(scalars: &[Self::ScalarType], points: &[Self]) -> FastCryptoResult<Self>;
 }
 
-/// Faster deserialization in case the input is trusted (otherwise it can be insecure).
+/// Deserialization from a byte array that skips validation of the result.
+///
+/// This is faster than [`crate::serde_helpers::ToFromByteArray::from_byte_array`], but it does
+/// *not* check that the result is a canonical, valid element: for curve points the subgroup
+/// membership check is skipped, and for scalars the canonical range check is skipped. It is only
+/// safe to use when the input is known to come from a trusted source. For attacker-controlled or
+/// otherwise untrusted input, use [`crate::serde_helpers::ToFromByteArray::from_byte_array`]
+/// instead.
 pub trait FromTrustedByteArray<const LENGTH: usize>: Sized {
+    /// Deserialize a trusted byte array without validating the result. See the
+    /// [trait documentation](FromTrustedByteArray) for the validation that is skipped.
     fn from_trusted_byte_array(bytes: &[u8; LENGTH]) -> FastCryptoResult<Self>;
 }

--- a/fastcrypto/src/groups/mod.rs
+++ b/fastcrypto/src/groups/mod.rs
@@ -131,16 +131,9 @@ pub trait MultiScalarMul: GroupElement {
     fn multi_scalar_mul(scalars: &[Self::ScalarType], points: &[Self]) -> FastCryptoResult<Self>;
 }
 
-/// Deserialization from a byte array that skips validation of the result.
-///
-/// This is faster than [`crate::serde_helpers::ToFromByteArray::from_byte_array`], but it does
-/// *not* check that the result is a canonical, valid element: for curve points the subgroup
-/// membership check is skipped, and for scalars the canonical range check is skipped. It is only
-/// safe to use when the input is known to come from a trusted source. For attacker-controlled or
-/// otherwise untrusted input, use [`crate::serde_helpers::ToFromByteArray::from_byte_array`]
-/// instead.
+/// Faster deserialization that skips validation of the result: the subgroup membership check for
+/// curve points and the canonical range check for scalars. Only safe for trusted input; otherwise
+/// use [`crate::serde_helpers::ToFromByteArray::from_byte_array`].
 pub trait FromTrustedByteArray<const LENGTH: usize>: Sized {
-    /// Deserialize a trusted byte array without validating the result. See the
-    /// [trait documentation](FromTrustedByteArray) for the validation that is skipped.
     fn from_trusted_byte_array(bytes: &[u8; LENGTH]) -> FastCryptoResult<Self>;
 }


### PR DESCRIPTION
## Summary
- `FromTrustedByteArray` only carried a vague one-line comment ("Faster deserialization in case the input is trusted").
- Subgroup checks are otherwise applied consistently: every untrusted path (`from_byte_array`, which serde routes through) validates G1/G2/GT membership and scalar canonical range. The `from_trusted_byte_array` fast path skips this — but, unlike the well-documented `G1ElementUncompressed::from_trusted_byte_array` and the BLS public-key path, the trait did not say so.
- Expanded the doc to spell out that the subgroup membership check (curve points) and canonical range check (scalars) are skipped, and to point callers to `from_byte_array` for untrusted input.

## Test plan
- [x] `cargo doc -p fastcrypto --no-deps` — intra-doc links resolve, no new warnings.
- Docs-only change; no behavior modified.