### PR TITLE
Bound input length in split_to_two_frs

### DIFF
--- a/fastcrypto-zkp/src/bn254/utils.rs
+++ b/fastcrypto-zkp/src/bn254/utils.rs
@@ -125,6 +125,10 @@ pub fn get_nonce(
     let hash = poseidon_zk_login(&[first, second, max_epoch, jwt_randomness])
         .expect("inputs is not too long");
     let data = BigUint::from(hash).to_bytes_be();
+    // NOTE: `data.len() - 20` would underflow if `BigUint::to_bytes_be` returns fewer than 20
+    // bytes, which happens iff the hash is `< 2^159`. Poseidon outputs are pseudo-random Fr
+    // elements (`< 2^254`), so the probability is ~2^-95 and this case is unreachable in
+    // practice. A future fix could left-zero-pad `data` to a canonical 32-byte representation.
     let truncated = &data[data.len() - 20..];
     let mut buf = vec![0; Base64UrlUnpadded::encoded_len(truncated)];
     Ok(Base64UrlUnpadded::encode(truncated, &mut buf)
@@ -197,13 +201,19 @@ pub async fn get_proof(
     Ok(get_proof_response)
 }
 
-/// Given a 33-byte public key bytes (flag || pk_bytes), returns the two Bn254Fr split at the 128 bit index.
+/// Given a `flag || pk_bytes` byte string of length 33 to 47, returns two `Bn254Fr` obtained
+/// by splitting the input 16 bytes from the end. Errors if the length is outside `[33, 47]`.
 pub fn split_to_two_frs(eph_pk_bytes: &[u8]) -> Result<(Bn254Fr, Bn254Fr), FastCryptoError> {
+    if eph_pk_bytes.len() < 33 {
+        return Err(FastCryptoError::InputTooShort(33));
+    }
+    if eph_pk_bytes.len() > 47 {
+        return Err(FastCryptoError::InputTooLong(47));
+    }
     // Split the bytes deterministically such that the first element contains the first 128
     // bits of the hash, and the second element contains the latter ones.
     let (first_half, second_half) = eph_pk_bytes.split_at(eph_pk_bytes.len() - 16);
     let first_bigint = BigUint::from_bytes_be(first_half);
-    // TODO: this is not safe if the buffer is large. Can we use a fixed size array for eph_pk_bytes?
     let second_bigint = BigUint::from_bytes_be(second_half);
 
     let eph_public_key_0 = Bn254Fr::from(first_bigint);


### PR DESCRIPTION
Reject inputs outside `[33, 47]` bytes in `split_to_two_frs`: shorter inputs would underflow `len() - 16`, and `≥ 48` byte inputs let the first half exceed the BN254 modulus and silently reduce (enabling collisions).

Also adds a note in `get_nonce` about a related latent underflow that is unreachable in practice.

This has **no** impact on Sui which always builds `extended_pk_bytes = flag (1 byte) || public_key_bytes`, producing 33 bytes for ed25519 and 34 bytes for compressed secp256k1 / secp256r1 both of which are inside the new bounds. The `verify_zk_login` path in `sui-types::zk_login_authenticator` and the CLI `keytool` nonce-generation path are both unaffected.