### PR TITLE
Add DST to bulletproofs, DDH and key consistency proofs

### DIFF
--- a/fastcrypto/benches/bulletproofs.rs
+++ b/fastcrypto/benches/bulletproofs.rs
@@ -23,11 +23,12 @@ fn verification(c: &mut Criterion) {
                 .iter()
                 .map(|&v| PedersenCommitment::commit(&RistrettoScalar::from(v), &mut rng))
                 .unzip();
-            let proof = RangeProof::prove_batch(&values, &blindings, range, &mut rng).unwrap();
+            let proof =
+                RangeProof::prove_batch(&values, &blindings, range, b"bench", &mut rng).unwrap();
             c.bench_function(
                 &format!("bulletproofs/verification/range={}/inputs={}", bits, size),
                 |b| {
-                    b.iter(|| proof.verify_batch(&commitments, range, &mut rng));
+                    b.iter(|| proof.verify_batch(&commitments, range, b"bench", &mut rng));
                 },
             );
         }

--- a/fastcrypto/src/bulletproofs.rs
+++ b/fastcrypto/src/bulletproofs.rs
@@ -15,9 +15,9 @@
 //! let mut rng = rand::thread_rng();
 //! let blinding = Blinding::rand(&mut rng);
 //! let proof =
-//!    RangeProof::prove(value, &blinding, &range, &mut rng).unwrap();
+//!    RangeProof::prove(value, &blinding, &range, b"dst", &mut rng).unwrap();
 //! let commitment = PedersenCommitment::new(&RistrettoScalar::from(value), &blinding);
-//! assert!(proof.verify(&commitment, &range, &mut rng).is_ok());
+//! assert!(proof.verify(&commitment, &range, b"dst", &mut rng).is_ok());
 //! ```
 
 use crate::error::FastCryptoError::{GeneralOpaqueError, InvalidInput, InvalidProof};
@@ -71,9 +71,10 @@ impl RangeProof {
         value: u64,
         blinding: &Blinding,
         range: &Range,
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<RangeProof> {
-        Self::prove_batch(&[value], std::slice::from_ref(blinding), range, rng)
+        Self::prove_batch(&[value], std::slice::from_ref(blinding), range, dst, rng)
     }
 
     /// Verifies a range proof: That the commitment is to a value in the given range.
@@ -81,9 +82,10 @@ impl RangeProof {
         &self,
         commitment: &PedersenCommitment,
         range: &Range,
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<()> {
-        self.verify_batch(std::slice::from_ref(commitment), range, rng)
+        self.verify_batch(std::slice::from_ref(commitment), range, dst, rng)
     }
 
     /// Create a proof that all the given `values` are in the range using the given commitment blindings.
@@ -97,6 +99,7 @@ impl RangeProof {
         values: &[u64],
         blindings: &[Blinding],
         range: &Range,
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<RangeProof> {
         if values.iter().any(|&v| !range.is_in_range(v))
@@ -109,6 +112,7 @@ impl RangeProof {
         let bits = range.upper_bound_in_bits() as usize;
         let bp_gens = BulletproofGens::new(bits, values.len());
         let mut prover_transcript = Transcript::new(&[]);
+        prover_transcript.append_message(b"DST", dst);
 
         // TODO: Can we avoid calculating the Pedersen commitments here?
         ExternalRangeProof::prove_multiple_with_rng(
@@ -129,11 +133,13 @@ impl RangeProof {
         &self,
         commitments: &[PedersenCommitment],
         range: &Range,
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<()> {
         let bits = range.upper_bound_in_bits() as usize;
         let bp_gens = BulletproofGens::new(bits, commitments.len());
         let mut verifier_transcript = Transcript::new(&[]);
+        verifier_transcript.append_message(b"DST", dst);
 
         self.0
             .verify_multiple_with_rng(
@@ -188,9 +194,9 @@ fn test_range_proof_valid() {
     let blinding = Blinding::rand(&mut rng);
 
     let value = 1u64;
-    let proof = RangeProof::prove(value, &blinding, &range, &mut rng).unwrap();
+    let proof = RangeProof::prove(value, &blinding, &range, b"test", &mut rng).unwrap();
     let commitment = PedersenCommitment::new(&RistrettoScalar::from(value), &blinding);
-    assert!(proof.verify(&commitment, &range, &mut rng).is_ok());
+    assert!(proof.verify(&commitment, &range, b"test", &mut rng).is_ok());
 }
 
 #[test]
@@ -203,15 +209,16 @@ fn test_batch_range_proof_valid() {
         .iter()
         .map(|&v| PedersenCommitment::commit(&RistrettoScalar::from(v), &mut rng))
         .unzip::<_, _, Vec<_>, Vec<_>>();
-    let proof = RangeProof::prove_batch(&values, &blindings, &range, &mut rng).unwrap();
-    assert!(proof.verify_batch(&commitments, &range, &mut rng).is_ok());
+    let proof =
+        RangeProof::prove_batch(&values, &blindings, &range, b"test_dst", &mut rng).unwrap();
+    assert!(proof
+        .verify_batch(&commitments, &range, b"test_dst", &mut rng)
+        .is_ok());
 }
 
 #[test]
 fn test_to_from_bytes() {
-    use crate::encoding::{Encoding, Hex};
     use crate::groups::ristretto255::RistrettoScalar;
-    use crate::serde_helpers::ToFromByteArray;
 
     let range = Range::Bits32;
     let mut rng = rand::thread_rng();
@@ -220,15 +227,11 @@ fn test_to_from_bytes() {
         .iter()
         .map(|&v| PedersenCommitment::commit(&RistrettoScalar::from(v), &mut rng))
         .unzip::<_, _, Vec<_>, Vec<_>>();
-    commitments
-        .iter()
-        .for_each(|c| println!("{}", Hex::encode(c.0.to_byte_array())));
-    let proof = RangeProof::prove_batch(&values, &blindings, &range, &mut rng).unwrap();
+    let proof = RangeProof::prove_batch(&values, &blindings, &range, b"test", &mut rng).unwrap();
     let proof_bytes = proof.to_bytes();
-    println!("{}", Hex::encode(&proof_bytes));
     let reconstructed_proof = RangeProof::from_bytes(&proof_bytes).unwrap();
     assert!(reconstructed_proof
-        .verify_batch(&commitments, &range, &mut rng)
+        .verify_batch(&commitments, &range, b"test", &mut rng)
         .is_ok());
 }
 
@@ -239,16 +242,16 @@ fn regression_test() {
     use crate::pedersen::PedersenCommitment;
     use crate::serde_helpers::ToFromByteArray;
 
-    let proof = RangeProof::from_bytes(&Hex::decode("483752e4e9be898bb7098adbe1cd4ec71614c7cf897de2d9e6b5d7615bb96b7b9ca3621b3fd885045903b82a4bc979094639f216c479362b0ab497dcbbe5600580c3a9e90d1fab586d7f3e8c9fcae71da9474c106610b5d473824a33e3472e20e04390d7052480b3500a96167e405a9b27f59a6b74f47457454014307a97e108ab6681983e5556fb19d2a33f753b364695cb7188948ff7f997a5fe3d55fcc902fcd5afcbd45a41ef298d6e16560fb407d29c81dac20705cd18d52f4925700003bf7b175cdf6d5d8c6eeef35f7357a88edac323eef8dda1f90ff4ebafab91650182d44889691ed4e1789891d7111c2adc97feb2e48e5bde1d3407f98e2a85b66c086bc4d03cbdd9237023bd601bbad70377345bafe027d2e794d702585a7ce72008cb2efec10638555841eb17917c1b6d41533e5a93496fbb2c8cf1e98830732290dd8d6b6a10c2622d866c6e0dbac2aee6c94409f5a50affbc47081cd24414414e080474c144f2b2e38d8c02a56c9dc8bc5ca6b342cfbec04c40b9e8225a7f1fb62b3ddc4ad00f7606ce2942f123503da272e2a6e25a6f0d0038030b489c8675d614bc0073056ffa2ec10231c50b7fcae9d961f66dd299da4b1985a2eb6c215aee1e41de609e70ffcf73bd2b1c677e7afe31c0d16c202dbc006f187266f94f2be44668778c18f0b76f9cb4608594350371c2e0391b6be322fbb78fa03400f272ecae55d95c3ddccfc76353753fa596ef076ac02084a9bcc525df5e5ab086850868c17b907c484553e19fd693702884c4745eb833bd27598a23ef0e68828c934b7a0a8f66e811bede8bf8a4e141a8f12f964e92e76d5af2b3e9f76792b935fc0d8cd906e7ab4f9e6a3bd9b826c0503a929634e7cdf8fdf5173772e372bb19862072ed0fb3afb44cae8b79caad81370ce67e4a1b44b8a56150219ca6982cf21c2fd80b4f8a675e585456223f60a96574c0972aa5f1ae68e04d9cf5b6e635f0903c3efe47d4c0c0d8d656d14928397d4e20806b50fb945d8c5b3af7b9c3b06dab726a41897ba3e94531eba51f7c16e390709a5efe407255dcfc40d86a1eb0fa4f01adee93fa6ed44a9ad03ba83b7d09f88bb4dbb51d8ef4b73b36b75dcaae04890a").unwrap()).unwrap();
+    let proof = RangeProof::from_bytes(&Hex::decode("e27e1f3db57f05833973ec4b3e9def2b660ef256e42be0ca2747d47ff1ccdb30e65730ffed8175c640a8bfaa6d8840baa74130b439e9270dcbb0ce041801040a00d0d7dcdcd088f6bb63320ec2c1c2db4b5634ec7b477c2685a390a76658a679809d44e5a62481597a843a0d93953ebc9dc0b4640a02408111e7ad82da6c7460334eb71999b7758f27ea76f76b5335b21398574525e04b1d609eca69080f250cd573edf050ca9cb0d152d493037b2f46b0d2a8db005ec2bb13cfc67829fd220c989e3e3b4ba93bd798ff45892f69b279bc3311ed19ab396c8ce7a81d314ef10ef6b7ce7d0d323ae8e03c69e38bc3dfc88f4930d69adc8661e577f7bcd10c7b3d0c2dd337a9149a90ef961b0ac7f39b43a9658698036bb94ec2fa30de9058c16e20a6a88b60adf0af37e01f90a51bf3353256f4ec10d862b1870b58dd4f0cea255891878a36e54ebbfc126d271e54459abcd74b1b05512e43ae8cd8df88d96159ae6e0b0dda3e0da88c8aad392d264e34c9cc40464d3cb24f39a25373104ff03cb45050dc9d65d5909a07bbbee45e875d48aa3e1355d7356a97d7d8a37fa88355b0115b8eeda7e2dbae17c4259b9a75d93830e9934781275e771263313824bb4f8439f882fba97f4bb8f5159a22640181d155f8ca342055654325a6d6ae25460d4075e595f8eb1cde6afd95a0c1eec6edcfc60c666501bfbb38098faec118672f622a484e848e1fc523bf6b09f4f03324ae2bc66f9eeffa4d9fd86392c1602b4d1e3fafd9db0f5d263cfdc98f7d65ad4cd6d765e7c151d7cd528839f4d6b8bd481203e7e5c3fcfa114f86bd71240b8a4e7efa760f6691d2d23120957d258915379a2bf98c4bb3c011e704ebdeb463dd53bbd3e6ca01a1dc070e4064b73e4d690a76ced51e0b0562783409c8c8cdff0864f7636641481562aaeb1c2c962ecd2a5e3e2b376ee5f0b1bcad29f0e3cd292144455c63b708154bca4f80d337f06bfe5f520750afaf6d2fa78e400a6bbf1625e8b262ea24539237fd365b4dd1fdc9644b2752bf6e6c0aa3bdd8332ebf9f34c32176e4fea97a5a185dd267e11f6283e20dce2a83e4fc1e1e848d6e1b3174564aa3b5eb9c523f35f1274b54da5a2a6d7905").unwrap()).unwrap();
     let commitments = [
-        "7c7ea4aadabb7162ed05f265527c50fb1a441b0ca655231bf6d7c45d6cf67e1d",
-        "702b85154cd2dd7d0505af8cc6484f0aa854549e64b87f07277af70d995a2d21",
-        "6693d794456c40fbcaaf0692c376aca4ba168782a6b76df49100b8d766a73b5c",
-        "1a7ff5f0f877da164da5630b280278e03e75cb19ed1469b1853df3fb8050a662",
-        "e25bae601d7113cd0db0603fe7072e88f5aeae6177e423bf2e22abf5f997ef6b",
-        "b6d98f2eae41a89e49fa2381a7b88517bfbe0fdebb656712e2e9d6f50df1720c",
-        "e2b788992088af1a3f9810a4c85fc4bfa4fc48e2cfcc3e546deb030e47e6cc7a",
-        "60d05a6cdd77f71b15356fb830eb3a5a26b79b2870df6a39dd704490e0e6162d",
+        "3864fd028e266349c38e76d2b3361e1a197084247dd9c7413c061bcbd2026634",
+        "0e95477497ebd8390b70fde21813ad0f060d2b5fe8ee300f045d5dc4941fd431",
+        "74a2b02427dd95fbe2e0fdc7c1fb046ad1bfec0cb7777581ccc2bc3fcb81462f",
+        "d65e1514458c92150f02ef24d9524490f26bdbba9302e7e06056007576bf8e44",
+        "a27f94f3d348cb67237a0e86beba42a20d6cd36b63ce7421e5a8fd2043f7727e",
+        "00f28f68b3dad813674a578644391e4faa272a6d29522eb38e1773c72cfed145",
+        "6afc2e4d5d9924b8359a25cefe49a04ea8b1cab5b03c17d535a69b4603350e52",
+        "d0983791c005d212e98659c181e72f187680f2675b163dc817d8dc41d03b3c7c",
     ]
     .iter()
     .map(|s| Hex::decode(s).unwrap())
@@ -256,6 +259,11 @@ fn regression_test() {
     .map(PedersenCommitment)
     .collect::<Vec<_>>();
     assert!(proof
-        .verify_batch(&commitments, &Range::Bits32, &mut rand::thread_rng())
+        .verify_batch(
+            &commitments,
+            &Range::Bits32,
+            b"test",
+            &mut rand::thread_rng()
+        )
         .is_ok());
 }

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -10,7 +10,7 @@ use crate::groups::{
     Doubling, FiatShamirChallenge, FromTrustedByteArray, GroupElement, HashToGroupElement,
     MultiScalarMul, Scalar,
 };
-use crate::hash::{ReverseWrapper, Sha512};
+use crate::hash::{Blake2b256, ReverseWrapper, Sha512};
 use crate::serde_helpers::ToFromByteArray;
 use crate::traits::AllowedRng;
 use crate::{
@@ -223,7 +223,10 @@ impl HashToGroupElement for RistrettoScalar {
 
 impl FiatShamirChallenge for RistrettoScalar {
     fn fiat_shamir_reduction_to_group_element(msg: &[u8]) -> Self {
-        Self::hash_to_group_element(msg)
+        // Matches Contra's Move/TS Fiat-Shamir construction.
+        let mut digest = Blake2b256::digest(msg).digest;
+        digest[RISTRETTO_SCALAR_BYTE_LENGTH - 1] = 0;
+        Self::from_byte_array(&digest).expect("Top byte is zero so the scalar is always canonical")
     }
 }
 

--- a/fastcrypto/src/nizk.rs
+++ b/fastcrypto/src/nizk.rs
@@ -4,7 +4,6 @@
 use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::groups::MultiScalarMul;
 use crate::groups::{FiatShamirChallenge, GroupElement, Scalar};
-use crate::hash::{HashFunction, Sha3_256};
 use crate::traits::AllowedRng;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::ops::Neg;
@@ -28,31 +27,34 @@ pub struct DdhTupleNizk<G: GroupElement + Serialize + for<'d> Deserialize<'d>> {
 impl<G> DdhTupleNizk<G>
 where
     G: MultiScalarMul + Serialize + for<'d> Deserialize<'d>,
-    <G as GroupElement>::ScalarType: FiatShamirChallenge,
+    G::ScalarType: FiatShamirChallenge,
 {
     /// Create a new NIZKPoK for the DDH tuple `(G, H=eG, xG, xH)` using the given RNG.
+    /// The generators `g` and `h` are not bound into the challenge, so the soundness relies
+    /// on `dst` being unique to the calling context and fixed with the choice of `g` and `h`.
     pub fn create<R: AllowedRng>(
         x: &G::ScalarType,
         g: &G,
         h: &G,
         x_g: &G,
         x_h: &G,
+        dst: &[u8],
         rng: &mut R,
     ) -> Self {
         let r = G::ScalarType::rand(rng);
         let a = *g * r;
         let b = *h * r;
-        let challenge = Self::fiat_shamir_challenge(g, h, x_g, x_h, &a, &b);
+        let challenge = Self::challenge(x_g, x_h, &a, &b, dst);
         let z = challenge * x + r;
         DdhTupleNizk { a, b, z }
     }
 
-    /// Verify this NIZKPoK.
-    pub fn verify(&self, g: &G, h: &G, x_g: &G, x_h: &G) -> FastCryptoResult<()> {
+    /// Verify this NIZKPoK. `dst` must match the value used in [Self::create].
+    pub fn verify(&self, g: &G, h: &G, x_g: &G, x_h: &G, dst: &[u8]) -> FastCryptoResult<()> {
         if *g == G::zero() || *h == G::zero() || *x_g == G::zero() || *x_h == G::zero() {
             return Err(FastCryptoError::InvalidProof);
         }
-        let challenge = Self::fiat_shamir_challenge(g, h, x_g, x_h, &self.a, &self.b);
+        let challenge = Self::challenge(x_g, x_h, &self.a, &self.b, dst);
         if !is_valid_relation(&self.a, x_g, g, &self.z, &challenge)
             || !is_valid_relation(
                 &self.b, // B
@@ -65,10 +67,20 @@ where
         }
     }
 
-    /// Returns the challenge for Fiat-Shamir.
-    fn fiat_shamir_challenge(g: &G, h: &G, x_g: &G, x_h: &G, a: &G, b: &G) -> G::ScalarType {
-        let output = Sha3_256::digest(bcs::to_bytes(&(g, h, x_g, x_h, a, b)).unwrap());
-        G::ScalarType::fiat_shamir_reduction_to_group_element(&output.digest)
+    /// DDH-tuple Fiat-Shamir challenge: bcs-encoded `vector<vector<u8>>` of `[dst, xG, xH, A, B]`
+    /// reduced via the scalar's [FiatShamirChallenge] impl. For Ristretto255 this matches Contra's
+    /// Move/TS construction.
+    fn challenge(x_g: &G, x_h: &G, a: &G, b: &G, dst: &[u8]) -> G::ScalarType {
+        let chunks: Vec<Vec<u8>> = vec![
+            dst.to_vec(),
+            bcs::to_bytes(x_g).expect("Serialization succeeds"),
+            bcs::to_bytes(x_h).expect("Serialization succeeds"),
+            bcs::to_bytes(a).expect("Serialization succeeds"),
+            bcs::to_bytes(b).expect("Serialization succeeds"),
+        ];
+        G::ScalarType::fiat_shamir_reduction_to_group_element(
+            &bcs::to_bytes(&chunks).expect("Serialization succeeds"),
+        )
     }
 }
 
@@ -107,80 +119,88 @@ mod tests {
 
     #[test]
     fn test_nizk_flow() {
+        let dst = b"test";
         let e = S::rand(&mut thread_rng());
         let x = S::rand(&mut thread_rng());
         let g = G::generator() * S::rand(&mut thread_rng());
         let h = g * e;
         let x_g = g * x;
         let x_h = h * x;
-        let nizk = DdhTupleNizk::create(&x, &g, &h, &x_g, &x_h, &mut thread_rng());
-        assert!(nizk.verify(&g, &h, &x_g, &x_h).is_ok());
+        let nizk = DdhTupleNizk::create(&x, &g, &h, &x_g, &x_h, dst, &mut thread_rng());
+        assert!(nizk.verify(&g, &h, &x_g, &x_h, dst).is_ok());
+
+        // A different DST must not verify
+        assert!(nizk.verify(&g, &h, &x_g, &x_h, b"other").is_err());
 
         let invalid_witness = x + S::generator();
         let invalid_nizk =
-            DdhTupleNizk::create(&invalid_witness, &g, &h, &x_g, &x_h, &mut thread_rng());
-        assert!(invalid_nizk.verify(&g, &h, &x_g, &x_h).is_err());
+            DdhTupleNizk::create(&invalid_witness, &g, &h, &x_g, &x_h, dst, &mut thread_rng());
+        assert!(invalid_nizk.verify(&g, &h, &x_g, &x_h, dst).is_err());
 
         let other_g = g + G::generator();
-        assert!(nizk.verify(&other_g, &h, &x_g, &x_h).is_err());
+        assert!(nizk.verify(&other_g, &h, &x_g, &x_h, dst).is_err());
 
         let other_h = h + G::generator();
-        assert!(nizk.verify(&g, &other_h, &x_g, &x_h).is_err());
+        assert!(nizk.verify(&g, &other_h, &x_g, &x_h, dst).is_err());
 
         let other_x_g = x_g + G::generator();
-        assert!(nizk.verify(&g, &h, &other_x_g, &x_h).is_err());
+        assert!(nizk.verify(&g, &h, &other_x_g, &x_h, dst).is_err());
 
         let other_x_h = x_h + G::generator();
-        assert!(nizk.verify(&g, &h, &x_g, &other_x_h).is_err());
+        assert!(nizk.verify(&g, &h, &x_g, &other_x_h, dst).is_err());
     }
 
     #[test]
     fn challenge_regression_test() {
-        let e = S::from(7u64);
+        let dst = b"test";
         let x = S::from(31u64);
         let g = G::generator() * S::from(71u64);
-        let h = g * e;
         let x_g = g * x;
-        let x_h = h * x;
+        let x_h = g * S::from(7u64) * x;
         let r = S::from(91u64);
         let a = g * r;
-        let b = h * r;
-        let c = DdhTupleNizk::fiat_shamir_challenge(&g, &h, &x_g, &x_h, &a, &b);
+        let b = (g * S::from(7u64)) * r;
+        let c = DdhTupleNizk::<G>::challenge(&x_g, &x_h, &a, &b, dst);
         assert_eq!(
             &c.to_byte_array(),
-            Hex::decode("30db2f4121471c4af67d2dcfdede1f4aefb15475867c20c0dd5c228c0721f80e")
+            Hex::decode("0fcba8670c851477df01c27dcd01ba6b780eca4f7c2cb6cd168578430c8fff00")
                 .unwrap()
                 .as_slice()
         );
+        // The challenge must depend on the DST.
+        let other = DdhTupleNizk::<G>::challenge(&x_g, &x_h, &a, &b, b"other");
+        assert_ne!(c.to_byte_array(), other.to_byte_array());
     }
 
     #[test]
     fn test_invalid_proofs() {
         // x_g/h_g/h=inf should be rejected
+        let dst = b"test";
         let e = S::zero();
         let x = S::rand(&mut thread_rng());
         let g = G::generator() * S::rand(&mut thread_rng());
         let h = g * e;
         let x_g = g * x;
         let x_h = h * x;
-        let nizk = DdhTupleNizk::create(&x, &g, &h, &x_g, &x_h, &mut thread_rng());
+        let nizk = DdhTupleNizk::create(&x, &g, &h, &x_g, &x_h, dst, &mut thread_rng());
 
-        assert!(nizk.verify(&G::zero(), &h, &x_g, &x_h).is_err());
-        assert!(nizk.verify(&g, &G::zero(), &x_g, &x_h).is_err());
-        assert!(nizk.verify(&g, &h, &G::zero(), &x_h).is_err());
-        assert!(nizk.verify(&g, &h, &x_g, &G::zero()).is_err());
+        assert!(nizk.verify(&G::zero(), &h, &x_g, &x_h, dst).is_err());
+        assert!(nizk.verify(&g, &G::zero(), &x_g, &x_h, dst).is_err());
+        assert!(nizk.verify(&g, &h, &G::zero(), &x_h, dst).is_err());
+        assert!(nizk.verify(&g, &h, &x_g, &G::zero(), dst).is_err());
     }
 
     #[test]
     fn test_serde() {
+        let dst = b"test";
         let e = S::rand(&mut thread_rng());
         let x2 = S::rand(&mut thread_rng());
         let g = G::generator() * S::rand(&mut thread_rng());
         let h = g * e;
         let x_g = g * x2;
         let x_h = h * x2;
-        let nizk = DdhTupleNizk::create(&x2, &g, &h, &x_g, &x_h, &mut thread_rng());
-        assert!(nizk.verify(&g, &h, &x_g, &x_h).is_ok());
+        let nizk = DdhTupleNizk::create(&x2, &g, &h, &x_g, &x_h, dst, &mut thread_rng());
+        assert!(nizk.verify(&g, &h, &x_g, &x_h, dst).is_ok());
 
         let as_bytes = bcs::to_bytes(&nizk).unwrap();
         let nizk2: DdhTupleNizk<G> = bcs::from_bytes(&as_bytes).unwrap();

--- a/fastcrypto/src/nizk.rs
+++ b/fastcrypto/src/nizk.rs
@@ -30,8 +30,6 @@ where
     G::ScalarType: FiatShamirChallenge,
 {
     /// Create a new NIZKPoK for the DDH tuple `(G, H=eG, xG, xH)` using the given RNG.
-    /// The generators `g` and `h` are not bound into the challenge, so the soundness relies
-    /// on `dst` being unique to the calling context and fixed with the choice of `g` and `h`.
     pub fn create<R: AllowedRng>(
         x: &G::ScalarType,
         g: &G,
@@ -44,7 +42,7 @@ where
         let r = G::ScalarType::rand(rng);
         let a = *g * r;
         let b = *h * r;
-        let challenge = Self::challenge(x_g, x_h, &a, &b, dst);
+        let challenge = Self::challenge(g, h, x_g, x_h, &a, &b, dst);
         let z = challenge * x + r;
         DdhTupleNizk { a, b, z }
     }
@@ -54,7 +52,7 @@ where
         if *g == G::zero() || *h == G::zero() || *x_g == G::zero() || *x_h == G::zero() {
             return Err(FastCryptoError::InvalidProof);
         }
-        let challenge = Self::challenge(x_g, x_h, &self.a, &self.b, dst);
+        let challenge = Self::challenge(g, h, x_g, x_h, &self.a, &self.b, dst);
         if !is_valid_relation(&self.a, x_g, g, &self.z, &challenge)
             || !is_valid_relation(
                 &self.b, // B
@@ -67,12 +65,14 @@ where
         }
     }
 
-    /// DDH-tuple Fiat-Shamir challenge: bcs-encoded `vector<vector<u8>>` of `[dst, xG, xH, A, B]`
+    /// DDH-tuple Fiat-Shamir challenge: bcs-encoded `vector<vector<u8>>` of `[dst, g, h, xG, xH, A, B]`
     /// reduced via the scalar's [FiatShamirChallenge] impl. For Ristretto255 this matches Contra's
-    /// Move/TS construction.
-    fn challenge(x_g: &G, x_h: &G, a: &G, b: &G, dst: &[u8]) -> G::ScalarType {
+    /// Move/TS construction, which binds the generators `g` and `h` into the challenge.
+    fn challenge(g: &G, h: &G, x_g: &G, x_h: &G, a: &G, b: &G, dst: &[u8]) -> G::ScalarType {
         let chunks: Vec<Vec<u8>> = vec![
             dst.to_vec(),
+            bcs::to_bytes(g).expect("Serialization succeeds"),
+            bcs::to_bytes(h).expect("Serialization succeeds"),
             bcs::to_bytes(x_g).expect("Serialization succeeds"),
             bcs::to_bytes(x_h).expect("Serialization succeeds"),
             bcs::to_bytes(a).expect("Serialization succeeds"),
@@ -155,20 +155,21 @@ mod tests {
         let dst = b"test";
         let x = S::from(31u64);
         let g = G::generator() * S::from(71u64);
+        let h = g * S::from(7u64);
         let x_g = g * x;
-        let x_h = g * S::from(7u64) * x;
+        let x_h = h * x;
         let r = S::from(91u64);
         let a = g * r;
-        let b = (g * S::from(7u64)) * r;
-        let c = DdhTupleNizk::<G>::challenge(&x_g, &x_h, &a, &b, dst);
+        let b = h * r;
+        let c = DdhTupleNizk::<G>::challenge(&g, &h, &x_g, &x_h, &a, &b, dst);
         assert_eq!(
             &c.to_byte_array(),
-            Hex::decode("0fcba8670c851477df01c27dcd01ba6b780eca4f7c2cb6cd168578430c8fff00")
+            Hex::decode("22605808865698055d1f48c40db0af96d1f3b2b335bdd9d636e0b66b5871ef00")
                 .unwrap()
                 .as_slice()
         );
         // The challenge must depend on the DST.
-        let other = DdhTupleNizk::<G>::challenge(&x_g, &x_h, &a, &b, b"other");
+        let other = DdhTupleNizk::<G>::challenge(&g, &h, &x_g, &x_h, &a, &b, b"other");
         assert_ne!(c.to_byte_array(), other.to_byte_array());
     }
 

--- a/fastcrypto/src/twisted_elgamal.rs
+++ b/fastcrypto/src/twisted_elgamal.rs
@@ -305,14 +305,14 @@ impl<const N: usize> KeyConsistencyProof<N> {
     ///   blinding r_i as the commitment via
     ///     A1_ij + c * D_ij == z_1i * S_j
     ///   for all limbs i and recipients j where D_ij = r_i * S_j is the decryption handle and S_j is recipient j's public key.
-    ///   Combined equations using scalars mu_ij derived from the random batching value r:
+    ///   Combined equations using fresh random scalars mu_ij:
     ///     \sum_j (\sum_i mu_ij * z_1i) * S_j - \sum_{i,j} mu_ij * A1_ij - \sum_{i,j} (c * mu_ij) * D_ij == 0
     ///
     ///   Check 2 (commitment consistency): Verifies knowledge of the blinding r_i and message u_i opening the
     ///   commitment via
     ///     A2_i + c * C_i == z_1i * G + z_2i * H
     ///   for all limbs i where C_i = r_i * G + u_i * H is the Pedersen commitment.
-    ///   Combined equations using scalars rho_i derived from the random batching value r:
+    ///   Combined equations using fresh random scalars rho_i:
     ///     (\sum_i rho_i * z_1i) * G + (\sum_i rho_i * z_2i) * H - \sum_i rho_i * A2_i - \sum_i (c * rho_i) * C_i == 0
     ///
     ///   Check 3 (public key consistency): Verifies that the encrypted 32-bit key limbs u_i reconstruct to the
@@ -322,12 +322,12 @@ impl<const N: usize> KeyConsistencyProof<N> {
     ///
     ///   We combine the individual checks as
     ///     (check 1) + alpha * (check 2) + beta * (check 3) == 0
-    ///   using outer scalars alpha and beta derived from the random batching value r to ensure soundness.
+    ///   using fresh random outer scalars alpha and beta to ensure soundness.
     ///
     /// Here `c` is the Fiat-Shamir challenge binding the proof, while the batching scalars
-    /// (mu, rho, alpha, beta) are expanded from a fresh random value `r` sampled from `rng`. Since
-    /// `r` is drawn by the verifier after the proof is fixed, the prover cannot predict the batching
-    /// scalars, so a malformed proof passes the combined MSM only with negligible probability.
+    /// (mu, rho, alpha, beta) are each sampled uniformly at random from `rng`. Since they are drawn
+    /// by the verifier after the proof is fixed, the prover cannot predict them, so a malformed proof
+    /// passes the combined MSM only with negligible probability.
     pub fn verify(
         &self,
         sender_public_key: &PublicKey,
@@ -347,24 +347,19 @@ impl<const N: usize> KeyConsistencyProof<N> {
             dst,
         );
 
-        // Fresh random value used only to expand the batching scalars below.
-        let r = RistrettoScalar::rand(rng);
-
         // Number of recipients
         let m = recipient_encryption_keys.len();
 
-        // Compute inner scalars mu_ij from the random batching value r for all i and j used in check 1
-        let mu: Vec<RistrettoScalar> = (0..N)
-            .flat_map(|i| (0..m).map(move |j| batching_coefficient(b"mu", &r, &[i, j])))
-            .collect();
+        // Sample fresh random inner scalars mu_ij for all i and j used in check 1
+        let mu: Vec<RistrettoScalar> = (0..N * m).map(|_| RistrettoScalar::rand(rng)).collect();
 
-        // Compute inner scalars rho_i from the random batching value r for all i used in check 2
-        let rho: [RistrettoScalar; N] = from_fn(|i| batching_coefficient(b"rho", &r, &[i]));
+        // Sample fresh random inner scalars rho_i for all i used in check 2
+        let rho: [RistrettoScalar; N] = from_fn(|_| RistrettoScalar::rand(rng));
 
-        // Compute outer scalars alpha and beta from the random batching value r, combining the three zero-expressions:
+        // Sample fresh random outer scalars alpha and beta combining the three zero-expressions:
         //   (check 1) + alpha * (check 2) + beta * (check 3) == 0
-        let alpha = batching_coefficient(b"alpha", &r, &[]);
-        let beta = batching_coefficient(b"beta", &r, &[]);
+        let alpha = RistrettoScalar::rand(rng);
+        let beta = RistrettoScalar::rand(rng);
 
         // Check 2: compute sum_i(rho_i * z_1i) and sum_i(rho_i * z_2i)
         let rho_z1 = RistrettoScalar::inner_product(rho, self.z1);
@@ -611,18 +606,6 @@ pub fn precompute_table() -> HashMap<[u8; RISTRETTO_POINT_BYTE_LENGTH], u16> {
         .map(|(i, p)| (p.to_byte_array(), i as u16))
         .take(1 << 16)
         .collect()
-}
-
-/// Expand the verifier's random value `r` into a batching coefficient for the given `label` and
-/// (optional) indices. Verifier-internal; not part of the proof.
-fn batching_coefficient(label: &[u8], r: &RistrettoScalar, indices: &[usize]) -> RistrettoScalar {
-    RistrettoScalar::fiat_shamir_reduction_to_group_element(
-        &bcs::to_bytes(&vec![
-            label.to_vec(),
-            bcs::to_bytes(&(r, indices)).expect("Serialization succeeds"),
-        ])
-        .expect("Serialization succeeds"),
-    )
 }
 
 #[test]

--- a/fastcrypto/src/twisted_elgamal.rs
+++ b/fastcrypto/src/twisted_elgamal.rs
@@ -60,14 +60,6 @@ pub struct KeyConsistencyProof<const N: usize> {
     z2: [RistrettoScalar; N],
 }
 
-/// Sigma protocol that a Twisted ElGamal ciphertext encrypts the message 0.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ZeroProof {
-    a1: RistrettoPoint,
-    a2: RistrettoPoint,
-    z: RistrettoScalar,
-}
-
 /// Sigma protocol that a Twisted ElGamal ciphertext is a valid encryption of some message (without revealing the message).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConsistencyProof {
@@ -139,75 +131,6 @@ impl Ciphertext {
         }
         Err(InvalidInput)
     }
-
-    /// Create a PoK of a private key such that the given encryption is of the message 0.
-    pub fn zero_proof(
-        &self,
-        private_key: &PrivateKey,
-        dst: &[u8],
-        rng: &mut impl AllowedRng,
-    ) -> ZeroProof {
-        ZeroProof::create(self, private_key, dst, rng)
-    }
-}
-
-impl ZeroProof {
-    pub fn create<R: AllowedRng>(
-        encryption: &Ciphertext,
-        private_key: &PrivateKey,
-        dst: &[u8],
-        rng: &mut R,
-    ) -> Self {
-        let r = RistrettoScalar::rand(rng);
-        let a1 = RistrettoPoint::generator() * r;
-        let a2 = encryption.commitment.0 * r;
-        let pk = PublicKey::from(private_key);
-        let challenge = Self::challenge(&a1, &a2, encryption, &pk, dst);
-        let z = challenge * private_key.0 + r;
-        ZeroProof { a1, a2, z }
-    }
-
-    pub fn verify(
-        &self,
-        encryption: &Ciphertext,
-        pk: &PublicKey,
-        dst: &[u8],
-    ) -> FastCryptoResult<()> {
-        let c = Self::challenge(&self.a1, &self.a2, encryption, pk, dst);
-        if self.a1
-            != RistrettoPoint::multi_scalar_mul(&[-c, self.z], &[pk.0, *G])
-                .expect("Constant lengths")
-            || self.a2
-                != RistrettoPoint::multi_scalar_mul(
-                    &[-c, self.z],
-                    &[encryption.decryption_handle, encryption.commitment.0],
-                )
-                .expect("Constant lengths")
-        {
-            Err(InvalidProof)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn challenge(
-        a1: &RistrettoPoint,
-        a2: &RistrettoPoint,
-        encryption: &Ciphertext,
-        pk: &PublicKey,
-        dst: &[u8],
-    ) -> RistrettoScalar {
-        RistrettoScalar::fiat_shamir_reduction_to_group_element(
-            &bcs::to_bytes(&vec![
-                dst.to_vec(),
-                pk.0.to_byte_array().to_vec(),
-                encryption.decryption_handle.to_byte_array().to_vec(),
-                a1.to_byte_array().to_vec(),
-                a2.to_byte_array().to_vec(),
-            ])
-            .expect("Serialization succeeds"),
-        )
-    }
 }
 
 impl ConsistencyProof {
@@ -266,6 +189,8 @@ impl ConsistencyProof {
         RistrettoScalar::fiat_shamir_reduction_to_group_element(
             &bcs::to_bytes(&vec![
                 dst.to_vec(),
+                G.to_byte_array().to_vec(),
+                H.to_byte_array().to_vec(),
                 encryption_key.0.to_byte_array().to_vec(),
                 ciphertext.commitment.0.to_byte_array().to_vec(),
                 ciphertext.decryption_handle.to_byte_array().to_vec(),
@@ -374,20 +299,20 @@ impl<const N: usize> KeyConsistencyProof<N> {
     }
 
     /// Verify checks the provided consistency proof. To do so, it batches all three groups of verification equations
-    /// into a single MSM using hash-derived scalars. The three groups of equations that must hold for a valid proof are:
+    /// into a single MSM using random scalars. The three groups of equations that must hold for a valid proof are:
     ///
     ///   Check 1 (decryption handle consistency): Verifies that each decryption handle was formed with the same
     ///   blinding r_i as the commitment via
     ///     A1_ij + c * D_ij == z_1i * S_j
     ///   for all limbs i and recipients j where D_ij = r_i * S_j is the decryption handle and S_j is recipient j's public key.
-    ///   Combined equations using scalars mu_ij = Hash("mu", c, i, j):
+    ///   Combined equations using scalars mu_ij derived from the random batching value r:
     ///     \sum_j (\sum_i mu_ij * z_1i) * S_j - \sum_{i,j} mu_ij * A1_ij - \sum_{i,j} (c * mu_ij) * D_ij == 0
     ///
     ///   Check 2 (commitment consistency): Verifies knowledge of the blinding r_i and message u_i opening the
     ///   commitment via
     ///     A2_i + c * C_i == z_1i * G + z_2i * H
     ///   for all limbs i where C_i = r_i * G + u_i * H is the Pedersen commitment.
-    ///   Combined equations using scalars rho_i = Hash("rho", c, i):
+    ///   Combined equations using scalars rho_i derived from the random batching value r:
     ///     (\sum_i rho_i * z_1i) * G + (\sum_i rho_i * z_2i) * H - \sum_i rho_i * A2_i - \sum_i (c * rho_i) * C_i == 0
     ///
     ///   Check 3 (public key consistency): Verifies that the encrypted 32-bit key limbs u_i reconstruct to the
@@ -397,15 +322,21 @@ impl<const N: usize> KeyConsistencyProof<N> {
     ///
     ///   We combine the individual checks as
     ///     (check 1) + alpha * (check 2) + beta * (check 3) == 0
-    ///   using hash-derived outer scalars alpha = Hash("alpha", c) and beta = Hash("beta", c) to ensure soundness.
+    ///   using outer scalars alpha and beta derived from the random batching value r to ensure soundness.
+    ///
+    /// Here `c` is the Fiat-Shamir challenge binding the proof, while the batching scalars
+    /// (mu, rho, alpha, beta) are expanded from a fresh random value `r` sampled from `rng`. Since
+    /// `r` is drawn by the verifier after the proof is fixed, the prover cannot predict the batching
+    /// scalars, so a malformed proof passes the combined MSM only with negligible probability.
     pub fn verify(
         &self,
         sender_public_key: &PublicKey,
         recipient_encryption_keys: &[PublicKey],
         ciphertexts: &[MultiRecipientCiphertext; N],
         dst: &[u8],
+        rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<()> {
-        // Fiat-Shamir challenge
+        // Fiat-Shamir challenge binding the proof
         let c = Self::challenge(
             sender_public_key,
             recipient_encryption_keys,
@@ -416,21 +347,25 @@ impl<const N: usize> KeyConsistencyProof<N> {
             dst,
         );
 
+        // Fresh random value used only to expand the batching scalars below. Sampling it here (after
+        // the proof is fixed) keeps the batching coefficients unpredictable to the prover.
+        let r = RistrettoScalar::rand(rng);
+
         // Number of recipients
         let m = recipient_encryption_keys.len();
 
-        // Compute inner scalars mu_ij = Hash("mu", c, i, j) for all i and j used in check 1
+        // Compute inner scalars mu_ij from the random batching value r for all i and j used in check 1
         let mu: Vec<RistrettoScalar> = (0..N)
-            .flat_map(|i| (0..m).map(move |j| batching_coefficient(b"mu", &c, &[i, j])))
+            .flat_map(|i| (0..m).map(move |j| batching_coefficient(b"mu", &r, &[i, j])))
             .collect();
 
-        // Compute inner scalars rho_i = Hash("rho", c, i) for all i used in check 2
-        let rho: [RistrettoScalar; N] = from_fn(|i| batching_coefficient(b"rho", &c, &[i]));
+        // Compute inner scalars rho_i from the random batching value r for all i used in check 2
+        let rho: [RistrettoScalar; N] = from_fn(|i| batching_coefficient(b"rho", &r, &[i]));
 
-        // Compute outer scalars alpha = Hash("alpha", c) and beta = Hash("beta", c) combining the three zero-expressions:
+        // Compute outer scalars alpha and beta from the random batching value r, combining the three zero-expressions:
         //   (check 1) + alpha * (check 2) + beta * (check 3) == 0
-        let alpha = batching_coefficient(b"alpha", &c, &[]);
-        let beta = batching_coefficient(b"beta", &c, &[]);
+        let alpha = batching_coefficient(b"alpha", &r, &[]);
+        let beta = batching_coefficient(b"beta", &r, &[]);
 
         // Check 2: compute sum_i(rho_i * z_1i) and sum_i(rho_i * z_2i)
         let rho_z1 = RistrettoScalar::inner_product(rho, self.z1);
@@ -500,6 +435,8 @@ impl<const N: usize> KeyConsistencyProof<N> {
         dst: &[u8],
     ) -> RistrettoScalar {
         let chunks: Vec<Vec<u8>> = std::iter::once(dst.to_vec())
+            .chain(std::iter::once(G.to_byte_array().to_vec()))
+            .chain(std::iter::once(H.to_byte_array().to_vec()))
             .chain(std::iter::once(
                 sender_public_key.0.to_byte_array().to_vec(),
             ))
@@ -618,6 +555,7 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
             recipient_encryption_keys,
             &self.ciphertexts,
             consistency_proof_dst,
+            rng,
         )
     }
 
@@ -676,15 +614,13 @@ pub fn precompute_table() -> HashMap<[u8; RISTRETTO_POINT_BYTE_LENGTH], u16> {
         .collect()
 }
 
-/// Derive an internal batching coefficient labelled `label` from the challenge `c` and (optional)
-/// indices. Used only by the [KeyConsistencyProof] verifier to randomize its single combined
-/// multi-scalar multiplication. These coefficients are _not_ part of the proof and need not match
-/// any other implementation.
-fn batching_coefficient(label: &[u8], c: &RistrettoScalar, indices: &[usize]) -> RistrettoScalar {
+/// Expand the verifier's random value `r` into a batching coefficient for the given `label` and
+/// (optional) indices. Verifier-internal; not part of the proof.
+fn batching_coefficient(label: &[u8], r: &RistrettoScalar, indices: &[usize]) -> RistrettoScalar {
     RistrettoScalar::fiat_shamir_reduction_to_group_element(
         &bcs::to_bytes(&vec![
             label.to_vec(),
-            bcs::to_bytes(&(c, indices)).expect("Serialization succeeds"),
+            bcs::to_bytes(&(r, indices)).expect("Serialization succeeds"),
         ])
         .expect("Serialization succeeds"),
     )
@@ -723,23 +659,6 @@ fn test_round_trip_with_consistency_proof() {
 }
 
 #[test]
-fn test_zero_proof() {
-    let dst = b"test";
-    let mut rng = rand::thread_rng();
-    let (pk, sk) = generate_keypair(&mut rng);
-    let (ciphertext, _) = Ciphertext::encrypt(&pk, 0, &mut rng);
-    let zero_proof = ciphertext.zero_proof(&sk, dst, &mut rng);
-    zero_proof.verify(&ciphertext, &pk, dst).unwrap();
-
-    // A different DST must not verify
-    zero_proof.verify(&ciphertext, &pk, b"other").unwrap_err();
-
-    let (other_ciphertext, _) = Ciphertext::encrypt(&pk, 1, &mut rng);
-    let other_zero_proof = other_ciphertext.zero_proof(&sk, dst, &mut rng);
-    other_zero_proof.verify(&ciphertext, &pk, dst).unwrap_err();
-}
-
-#[test]
 fn encrypt_and_range_proof() {
     let value = 1234u32;
     let range = crate::bulletproofs::Range::Bits32;
@@ -770,31 +689,6 @@ fn linear_encryptions() {
         ciphertext_3.decrypt(&sk, &precompute_table()).unwrap(),
         value_1 + value_2 * s
     );
-}
-
-#[test]
-fn test_equality() {
-    let dst = b"test";
-    let value = 123u32;
-    let (pk, sk) = generate_keypair(&mut rand::thread_rng());
-    let encryption_1 = Ciphertext::encrypt(&pk, value, &mut rand::thread_rng());
-    let encryption_2 = Ciphertext::encrypt(&pk, value, &mut rand::thread_rng());
-
-    let diff = encryption_1.0.clone() - encryption_2.0;
-
-    let mut rng = rand::thread_rng();
-
-    diff.zero_proof(&sk, dst, &mut rng)
-        .verify(&diff, &pk, dst)
-        .unwrap();
-
-    let other_value = 1234u32;
-    let encryption_3 = Ciphertext::encrypt(&pk, other_value, &mut rand::thread_rng());
-    let other_diff = encryption_1.0 - encryption_3.0;
-    other_diff
-        .zero_proof(&sk, dst, &mut rng)
-        .verify(&other_diff, &pk, dst)
-        .unwrap_err();
 }
 
 #[test]
@@ -836,7 +730,13 @@ fn test_key_consistency_proof() {
 
     // Verification passes with correct sender public key
     assert!(proof
-        .verify(&pk_snd, std::slice::from_ref(&pk_rcv), &ciphertexts, dst)
+        .verify(
+            &pk_snd,
+            std::slice::from_ref(&pk_rcv),
+            &ciphertexts,
+            dst,
+            &mut rng
+        )
         .is_ok());
 
     // A different DST must not verify
@@ -845,14 +745,15 @@ fn test_key_consistency_proof() {
             &pk_snd,
             std::slice::from_ref(&pk_rcv),
             &ciphertexts,
-            b"other"
+            b"other",
+            &mut rng
         )
         .is_err());
 
     // Verification fails with a different sender public key
     let (other_pk_snd, _) = generate_keypair(&mut rng);
     assert!(proof
-        .verify(&other_pk_snd, &[pk_rcv], &ciphertexts, dst)
+        .verify(&other_pk_snd, &[pk_rcv], &ciphertexts, dst, &mut rng)
         .is_err());
 }
 

--- a/fastcrypto/src/twisted_elgamal.rs
+++ b/fastcrypto/src/twisted_elgamal.rs
@@ -278,7 +278,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
         )
         .expect("Consistent lengths");
 
-        // c = Hash(dst, sender_public_key, recipient_encryption_keys, ciphertexts, a1, a2, a3)
+        // c = Hash(dst, G, H, sender_public_key, recipient_encryption_keys, ciphertexts, a1, a2, a3)
         let c = Self::challenge(
             sender_public_key,
             recipient_encryption_keys,
@@ -347,8 +347,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
             dst,
         );
 
-        // Fresh random value used only to expand the batching scalars below. Sampling it here (after
-        // the proof is fixed) keeps the batching coefficients unpredictable to the prover.
+        // Fresh random value used only to expand the batching scalars below.
         let r = RistrettoScalar::rand(rng);
 
         // Number of recipients
@@ -424,7 +423,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
     }
 
     /// Fiat-Shamir challenge over the proof's public inputs, matching Contra's Move/TS
-    /// `contra::key_consistency_proof::challenge_key_consistency`.
+    /// `contra::nizk::challenge_key_consistency`.
     fn challenge(
         sender_public_key: &PublicKey,
         recipient_encryption_keys: &[PublicKey],

--- a/fastcrypto/src/twisted_elgamal.rs
+++ b/fastcrypto/src/twisted_elgamal.rs
@@ -5,8 +5,7 @@ use crate::bulletproofs::{Range, RangeProof};
 use crate::error::FastCryptoError::{InvalidInput, InvalidProof};
 use crate::error::FastCryptoResult;
 use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar, RISTRETTO_POINT_BYTE_LENGTH};
-use crate::groups::{Doubling, GroupElement, MultiScalarMul, Scalar};
-use crate::hash::{Blake2b256, HashFunction};
+use crate::groups::{Doubling, FiatShamirChallenge, GroupElement, MultiScalarMul, Scalar};
 use crate::pedersen::{Blinding, PedersenCommitment, G, H};
 use crate::serde_helpers::ToFromByteArray;
 use crate::traits::AllowedRng;
@@ -56,7 +55,7 @@ pub struct VerifiableKeyEncapsulation<const N: usize> {
 pub struct KeyConsistencyProof<const N: usize> {
     a1: Vec<RistrettoPoint>,
     a2: [RistrettoPoint; N],
-    a3: [RistrettoPoint; N],
+    a3: RistrettoPoint,
     z1: [RistrettoScalar; N],
     z2: [RistrettoScalar; N],
 }
@@ -111,6 +110,7 @@ impl Ciphertext {
     pub fn encrypt_with_consistency_proof(
         encryption_key: &PublicKey,
         message: u32,
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<(Self, Blinding, ConsistencyProof)> {
         let (ciphertext, blinding) = Self::encrypt(encryption_key, message, rng);
@@ -119,6 +119,7 @@ impl Ciphertext {
             &ciphertext,
             &blinding,
             encryption_key,
+            dst,
             rng,
         )?;
         Ok((ciphertext, blinding, proof))
@@ -140,8 +141,13 @@ impl Ciphertext {
     }
 
     /// Create a PoK of a private key such that the given encryption is of the message 0.
-    pub fn zero_proof(&self, private_key: &PrivateKey, rng: &mut impl AllowedRng) -> ZeroProof {
-        ZeroProof::create(self, private_key, rng)
+    pub fn zero_proof(
+        &self,
+        private_key: &PrivateKey,
+        dst: &[u8],
+        rng: &mut impl AllowedRng,
+    ) -> ZeroProof {
+        ZeroProof::create(self, private_key, dst, rng)
     }
 }
 
@@ -149,19 +155,25 @@ impl ZeroProof {
     pub fn create<R: AllowedRng>(
         encryption: &Ciphertext,
         private_key: &PrivateKey,
+        dst: &[u8],
         rng: &mut R,
     ) -> Self {
         let r = RistrettoScalar::rand(rng);
         let a1 = RistrettoPoint::generator() * r;
         let a2 = encryption.commitment.0 * r;
         let pk = PublicKey::from(private_key);
-        let challenge = fiat_shamir_challenge(&(&a1, &a2, &pk, &encryption));
+        let challenge = Self::challenge(&a1, &a2, encryption, &pk, dst);
         let z = challenge * private_key.0 + r;
         ZeroProof { a1, a2, z }
     }
 
-    pub fn verify(&self, encryption: &Ciphertext, pk: &PublicKey) -> FastCryptoResult<()> {
-        let c = fiat_shamir_challenge(&(&self.a1, &self.a2, &pk, &encryption));
+    pub fn verify(
+        &self,
+        encryption: &Ciphertext,
+        pk: &PublicKey,
+        dst: &[u8],
+    ) -> FastCryptoResult<()> {
+        let c = Self::challenge(&self.a1, &self.a2, encryption, pk, dst);
         if self.a1
             != RistrettoPoint::multi_scalar_mul(&[-c, self.z], &[pk.0, *G])
                 .expect("Constant lengths")
@@ -177,6 +189,25 @@ impl ZeroProof {
             Ok(())
         }
     }
+
+    fn challenge(
+        a1: &RistrettoPoint,
+        a2: &RistrettoPoint,
+        encryption: &Ciphertext,
+        pk: &PublicKey,
+        dst: &[u8],
+    ) -> RistrettoScalar {
+        RistrettoScalar::fiat_shamir_reduction_to_group_element(
+            &bcs::to_bytes(&vec![
+                dst.to_vec(),
+                pk.0.to_byte_array().to_vec(),
+                encryption.decryption_handle.to_byte_array().to_vec(),
+                a1.to_byte_array().to_vec(),
+                a2.to_byte_array().to_vec(),
+            ])
+            .expect("Serialization succeeds"),
+        )
+    }
 }
 
 impl ConsistencyProof {
@@ -185,6 +216,7 @@ impl ConsistencyProof {
         ciphertext: &Ciphertext,
         blinding: &Blinding,
         encryption_key: &PublicKey,
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<Self> {
         let r1 = RistrettoScalar::rand(rng);
@@ -192,36 +224,20 @@ impl ConsistencyProof {
         let a1 = encryption_key.0 * r1;
         let a2 = RistrettoPoint::multi_scalar_mul(&[r1, r2], &[*G, *H]).expect("Constant length");
 
-        let c = Self::challenge(&a1, &a2, ciphertext, encryption_key);
+        let c = Self::challenge(&a1, &a2, ciphertext, encryption_key, dst);
         let z1 = r1 + c * blinding.0;
         let z2 = r2 + c * message;
 
         Ok(Self { a1, a2, z1, z2 })
     }
 
-    pub fn challenge(
-        a: &RistrettoPoint,
-        b: &RistrettoPoint,
-        ciphertext: &Ciphertext,
-        encryption_key: &PublicKey,
-    ) -> RistrettoScalar {
-        fiat_shamir_challenge(&(
-            &*G,
-            &*H,
-            a,
-            b,
-            &ciphertext.commitment,
-            &ciphertext.decryption_handle,
-            encryption_key,
-        ))
-    }
-
     pub fn verify(
         &self,
         ciphertext: &Ciphertext,
         encryption_key: &PublicKey,
+        dst: &[u8],
     ) -> FastCryptoResult<()> {
-        let c = Self::challenge(&self.a1, &self.a2, ciphertext, encryption_key);
+        let c = Self::challenge(&self.a1, &self.a2, ciphertext, encryption_key, dst);
         if self.a1
             != RistrettoPoint::multi_scalar_mul(
                 &[-c, self.z1],
@@ -238,6 +254,26 @@ impl ConsistencyProof {
             return Err(InvalidProof);
         }
         Ok(())
+    }
+
+    fn challenge(
+        a1: &RistrettoPoint,
+        a2: &RistrettoPoint,
+        ciphertext: &Ciphertext,
+        encryption_key: &PublicKey,
+        dst: &[u8],
+    ) -> RistrettoScalar {
+        RistrettoScalar::fiat_shamir_reduction_to_group_element(
+            &bcs::to_bytes(&vec![
+                dst.to_vec(),
+                encryption_key.0.to_byte_array().to_vec(),
+                ciphertext.commitment.0.to_byte_array().to_vec(),
+                ciphertext.decryption_handle.to_byte_array().to_vec(),
+                a1.to_byte_array().to_vec(),
+                a2.to_byte_array().to_vec(),
+            ])
+            .expect("Serialization succeeds"),
+        )
     }
 }
 
@@ -289,6 +325,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
         recipient_encryption_keys: &[PublicKey],
         ciphertexts: &[MultiRecipientCiphertext; N],
         blindings: &[Blinding; N],
+        dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> Self {
         // Sample N random a_i and b_i
@@ -305,9 +342,18 @@ impl<const N: usize> KeyConsistencyProof<N> {
         let a2 = from_fn(|i| *G * a[i] + *H * b[i]);
 
         // A_3i = b_i * G for all i
-        let a3 = from_fn(|i| *G * b[i]);
+        let a3_per_limb: [RistrettoPoint; N] = from_fn(|i| *G * b[i]);
+        // Aggregate `A_3 = \sum_i A_3i * 2^{32i}` (equivalent to `(\sum_i b_i * 2^{32i}) * G`).
+        let base = RistrettoScalar::from(1u64 << 32);
+        let a3 = RistrettoPoint::multi_scalar_mul(
+            &iterate(RistrettoScalar::generator(), |e| e * base)
+                .take(N)
+                .collect_vec(),
+            &a3_per_limb,
+        )
+        .expect("Consistent lengths");
 
-        // c = Hash(G, H, sender_public_key, recipient_encryption_keys, ciphertexts, a1, a2, a3)
+        // c = Hash(dst, sender_public_key, recipient_encryption_keys, ciphertexts, a1, a2, a3)
         let c = Self::challenge(
             sender_public_key,
             recipient_encryption_keys,
@@ -315,6 +361,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
             &a1,
             &a2,
             &a3,
+            dst,
         );
 
         // z_1i = a_i + c * r_i
@@ -356,6 +403,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
         sender_public_key: &PublicKey,
         recipient_encryption_keys: &[PublicKey],
         ciphertexts: &[MultiRecipientCiphertext; N],
+        dst: &[u8],
     ) -> FastCryptoResult<()> {
         // Fiat-Shamir challenge
         let c = Self::challenge(
@@ -365,6 +413,7 @@ impl<const N: usize> KeyConsistencyProof<N> {
             &self.a1,
             &self.a2,
             &self.a3,
+            dst,
         );
 
         // Number of recipients
@@ -372,16 +421,16 @@ impl<const N: usize> KeyConsistencyProof<N> {
 
         // Compute inner scalars mu_ij = Hash("mu", c, i, j) for all i and j used in check 1
         let mu: Vec<RistrettoScalar> = (0..N)
-            .flat_map(|i| (0..m).map(move |j| fiat_shamir_challenge(&("mu", &c, i, j))))
+            .flat_map(|i| (0..m).map(move |j| batching_coefficient(b"mu", &c, &[i, j])))
             .collect();
 
         // Compute inner scalars rho_i = Hash("rho", c, i) for all i used in check 2
-        let rho: [RistrettoScalar; N] = from_fn(|i| fiat_shamir_challenge(&("rho", &c, i)));
+        let rho: [RistrettoScalar; N] = from_fn(|i| batching_coefficient(b"rho", &c, &[i]));
 
         // Compute outer scalars alpha = Hash("alpha", c) and beta = Hash("beta", c) combining the three zero-expressions:
         //   (check 1) + alpha * (check 2) + beta * (check 3) == 0
-        let alpha = fiat_shamir_challenge(&("alpha", &c));
-        let beta = fiat_shamir_challenge(&("beta", &c));
+        let alpha = batching_coefficient(b"alpha", &c, &[]);
+        let beta = batching_coefficient(b"beta", &c, &[]);
 
         // Check 2: compute sum_i(rho_i * z_1i) and sum_i(rho_i * z_2i)
         let rho_z1 = RistrettoScalar::inner_product(rho, self.z1);
@@ -424,15 +473,11 @@ impl<const N: usize> KeyConsistencyProof<N> {
             points.push(ci.commitment.0);
         }
 
-        // Check 3: Append (-beta * c, U) and (-beta * 2^{32i}, A3_i) terms
+        // Check 3: Append (-beta * c, U) and (-beta, A3) terms (a3 is the aggregate mask).
         scalars.push(-(beta * c));
         points.push(sender_public_key.0);
-        let mut exp = RistrettoScalar::generator();
-        for a3i in self.a3 {
-            scalars.push(-(beta * exp));
-            points.push(a3i);
-            exp *= b;
-        }
+        scalars.push(-beta);
+        points.push(self.a3);
 
         if RistrettoPoint::multi_scalar_mul(&scalars, &points).expect("Consistent lengths")
             != RistrettoPoint::zero()
@@ -443,24 +488,40 @@ impl<const N: usize> KeyConsistencyProof<N> {
         Ok(())
     }
 
-    pub fn challenge(
+    /// Fiat-Shamir challenge over the proof's public inputs, matching Contra's Move/TS
+    /// `contra::key_consistency_proof::challenge_key_consistency`.
+    fn challenge(
         sender_public_key: &PublicKey,
         recipient_encryption_keys: &[PublicKey],
         ciphertexts: &[MultiRecipientCiphertext; N],
         a1: &[RistrettoPoint],
         a2: &[RistrettoPoint],
-        a3: &[RistrettoPoint],
+        a3: &RistrettoPoint,
+        dst: &[u8],
     ) -> RistrettoScalar {
-        fiat_shamir_challenge(&(
-            &*G,
-            &*H,
-            sender_public_key,
-            recipient_encryption_keys,
-            ciphertexts.as_slice(),
-            a1,
-            a2,
-            a3,
-        ))
+        let chunks: Vec<Vec<u8>> = std::iter::once(dst.to_vec())
+            .chain(std::iter::once(
+                sender_public_key.0.to_byte_array().to_vec(),
+            ))
+            .chain(
+                recipient_encryption_keys
+                    .iter()
+                    .map(|pk| pk.0.to_byte_array().to_vec()),
+            )
+            .chain(ciphertexts.iter().flat_map(|ct| {
+                std::iter::once(ct.commitment.0.to_byte_array().to_vec()).chain(
+                    ct.decryption_handles
+                        .iter()
+                        .map(|dh| dh.to_byte_array().to_vec()),
+                )
+            }))
+            .chain(a1.iter().map(|p| p.to_byte_array().to_vec()))
+            .chain(a2.iter().map(|p| p.to_byte_array().to_vec()))
+            .chain(std::iter::once(a3.to_byte_array().to_vec()))
+            .collect();
+        RistrettoScalar::fiat_shamir_reduction_to_group_element(
+            &bcs::to_bytes(&chunks).expect("Serialization succeeds"),
+        )
     }
 }
 
@@ -469,6 +530,8 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
     pub fn batch_seal(
         sender_private_key: &PrivateKey,
         recipient_encryption_keys: &[PublicKey],
+        range_proof_dst: &[u8],
+        consistency_proof_dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> VerifiableKeyEncapsulation<N> {
         // Re-arrange private key into N 32-bit limbs
@@ -489,9 +552,14 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
         let ciphertexts: [MultiRecipientCiphertext; N] = ciphertexts.try_into().unwrap();
 
         // Create range proof
-        let range_proof =
-            RangeProof::prove_batch(&limbs.map(|m| m as u64), &blindings, &Range::Bits32, rng)
-                .unwrap();
+        let range_proof = RangeProof::prove_batch(
+            &limbs.map(|m| m as u64),
+            &blindings,
+            &Range::Bits32,
+            range_proof_dst,
+            rng,
+        )
+        .unwrap();
 
         // Create consistency proof
         let consistency_proof = KeyConsistencyProof::prove(
@@ -500,6 +568,7 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
             recipient_encryption_keys,
             &ciphertexts,
             &blindings.try_into().unwrap(),
+            consistency_proof_dst,
             rng,
         );
 
@@ -514,11 +583,15 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
     pub fn seal(
         sender_private_key: &PrivateKey,
         recipient_encryption_key: &PublicKey,
+        range_proof_dst: &[u8],
+        consistency_proof_dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> VerifiableKeyEncapsulation<N> {
         Self::batch_seal(
             sender_private_key,
             std::slice::from_ref(recipient_encryption_key),
+            range_proof_dst,
+            consistency_proof_dst,
             rng,
         )
     }
@@ -528,6 +601,8 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
         &self,
         sender_public_key: &PublicKey,
         recipient_encryption_keys: &[PublicKey],
+        range_proof_dst: &[u8],
+        consistency_proof_dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<()> {
         // Verify range proof over the Pedersen commitments of all limb ciphertexts
@@ -537,17 +612,19 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
             .map(|c| c.commitment.clone())
             .collect::<Vec<_>>();
         self.range_proof
-            .verify_batch(&commitments, &Range::Bits32, rng)?;
+            .verify_batch(&commitments, &Range::Bits32, range_proof_dst, rng)?;
         self.consistency_proof.verify(
             sender_public_key,
             recipient_encryption_keys,
             &self.ciphertexts,
+            consistency_proof_dst,
         )
     }
 
     /// Open the key encapsulation for a single recipient decryption key identified by the provided index using the
     /// provided 16-bit discrete log decryption table. All recipient public keys must be provided to verify the
     /// consistency proof, which is bound to the full set of recipients.
+    #[allow(clippy::too_many_arguments)]
     pub fn open(
         &self,
         index: usize,
@@ -555,10 +632,18 @@ impl<const N: usize> VerifiableKeyEncapsulation<N> {
         recipient_public_keys: &[PublicKey],
         sender_public_key: &PublicKey,
         table: &HashMap<[u8; RISTRETTO_POINT_BYTE_LENGTH], u16>,
+        range_proof_dst: &[u8],
+        consistency_proof_dst: &[u8],
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<PrivateKey> {
         // Verify consistency proofs against all recipient keys
-        self.verify(sender_public_key, recipient_public_keys, rng)?;
+        self.verify(
+            sender_public_key,
+            recipient_public_keys,
+            range_proof_dst,
+            consistency_proof_dst,
+            rng,
+        )?;
 
         // Decrypt each limb ciphertext using the recipient's decryption key
         let limbs = self
@@ -591,13 +676,18 @@ pub fn precompute_table() -> HashMap<[u8; RISTRETTO_POINT_BYTE_LENGTH], u16> {
         .collect()
 }
 
-/// Derive a Fiat-Shamir challenge scalar from any serializable message.
-///
-/// TODO: Add domain seperation
-fn fiat_shamir_challenge<T: Serialize>(msg: &T) -> RistrettoScalar {
-    let mut digest = Blake2b256::digest(bcs::to_bytes(msg).unwrap()).digest;
-    digest[31] = 0;
-    RistrettoScalar::from_byte_array(&digest).expect("Always in field")
+/// Derive an internal batching coefficient labelled `label` from the challenge `c` and (optional)
+/// indices. Used only by the [KeyConsistencyProof] verifier to randomize its single combined
+/// multi-scalar multiplication. These coefficients are _not_ part of the proof and need not match
+/// any other implementation.
+fn batching_coefficient(label: &[u8], c: &RistrettoScalar, indices: &[usize]) -> RistrettoScalar {
+    RistrettoScalar::fiat_shamir_reduction_to_group_element(
+        &bcs::to_bytes(&vec![
+            label.to_vec(),
+            bcs::to_bytes(&(c, indices)).expect("Serialization succeeds"),
+        ])
+        .expect("Serialization succeeds"),
+    )
 }
 
 #[test]
@@ -613,14 +703,19 @@ fn test_round_trip() {
 
 #[test]
 fn test_round_trip_with_consistency_proof() {
+    let dst = b"test";
     let (pk, sk) = generate_keypair(&mut rand::thread_rng());
     let message = 1234567890u32;
     let (ciphertext, _, proof) =
-        Ciphertext::encrypt_with_consistency_proof(&pk, message, &mut rand::thread_rng()).unwrap();
-    assert!(proof.verify(&ciphertext, &pk).is_ok());
+        Ciphertext::encrypt_with_consistency_proof(&pk, message, dst, &mut rand::thread_rng())
+            .unwrap();
+    assert!(proof.verify(&ciphertext, &pk, dst).is_ok());
+
+    // A different DST must not verify
+    assert!(proof.verify(&ciphertext, &pk, b"other").is_err());
 
     let (other_pk, _) = generate_keypair(&mut rand::thread_rng());
-    assert!(proof.verify(&ciphertext, &other_pk).is_err());
+    assert!(proof.verify(&ciphertext, &other_pk, dst).is_err());
 
     // This table can be reused, so it only has to be computed once
     let table = precompute_table();
@@ -629,15 +724,19 @@ fn test_round_trip_with_consistency_proof() {
 
 #[test]
 fn test_zero_proof() {
+    let dst = b"test";
     let mut rng = rand::thread_rng();
     let (pk, sk) = generate_keypair(&mut rng);
     let (ciphertext, _) = Ciphertext::encrypt(&pk, 0, &mut rng);
-    let zero_proof = ciphertext.zero_proof(&sk, &mut rng);
-    zero_proof.verify(&ciphertext, &pk).unwrap();
+    let zero_proof = ciphertext.zero_proof(&sk, dst, &mut rng);
+    zero_proof.verify(&ciphertext, &pk, dst).unwrap();
+
+    // A different DST must not verify
+    zero_proof.verify(&ciphertext, &pk, b"other").unwrap_err();
 
     let (other_ciphertext, _) = Ciphertext::encrypt(&pk, 1, &mut rng);
-    let other_zero_proof = other_ciphertext.zero_proof(&sk, &mut rng);
-    other_zero_proof.verify(&ciphertext, &pk).unwrap_err();
+    let other_zero_proof = other_ciphertext.zero_proof(&sk, dst, &mut rng);
+    other_zero_proof.verify(&ciphertext, &pk, dst).unwrap_err();
 }
 
 #[test]
@@ -648,10 +747,11 @@ fn encrypt_and_range_proof() {
     let (pk, sk) = generate_keypair(&mut rng);
     let (ciphertext, blinding) = Ciphertext::encrypt(&pk, value, &mut rng);
     let range_proof =
-        crate::bulletproofs::RangeProof::prove(value as u64, &blinding, &range, &mut rng).unwrap();
+        crate::bulletproofs::RangeProof::prove(value as u64, &blinding, &range, b"test", &mut rng)
+            .unwrap();
 
     assert!(range_proof
-        .verify(&ciphertext.commitment, &range, &mut rng)
+        .verify(&ciphertext.commitment, &range, b"test", &mut rng)
         .is_ok());
 
     assert_eq!(ciphertext.decrypt(&sk, &precompute_table()).unwrap(), value);
@@ -674,6 +774,7 @@ fn linear_encryptions() {
 
 #[test]
 fn test_equality() {
+    let dst = b"test";
     let value = 123u32;
     let (pk, sk) = generate_keypair(&mut rand::thread_rng());
     let encryption_1 = Ciphertext::encrypt(&pk, value, &mut rand::thread_rng());
@@ -683,14 +784,16 @@ fn test_equality() {
 
     let mut rng = rand::thread_rng();
 
-    diff.zero_proof(&sk, &mut rng).verify(&diff, &pk).unwrap();
+    diff.zero_proof(&sk, dst, &mut rng)
+        .verify(&diff, &pk, dst)
+        .unwrap();
 
     let other_value = 1234u32;
     let encryption_3 = Ciphertext::encrypt(&pk, other_value, &mut rand::thread_rng());
     let other_diff = encryption_1.0 - encryption_3.0;
     other_diff
-        .zero_proof(&sk, &mut rng)
-        .verify(&other_diff, &pk)
+        .zero_proof(&sk, dst, &mut rng)
+        .verify(&other_diff, &pk, dst)
         .unwrap_err();
 }
 
@@ -720,30 +823,44 @@ fn test_key_consistency_proof() {
     let blindings: [Blinding; N] = blindings.try_into().unwrap();
 
     // Prove
+    let dst = b"test";
     let proof = KeyConsistencyProof::<N>::prove(
         &limbs,
         &pk_snd,
         std::slice::from_ref(&pk_rcv),
         &ciphertexts,
         &blindings,
+        dst,
         &mut rng,
     );
 
     // Verification passes with correct sender public key
     assert!(proof
-        .verify(&pk_snd, std::slice::from_ref(&pk_rcv), &ciphertexts)
+        .verify(&pk_snd, std::slice::from_ref(&pk_rcv), &ciphertexts, dst)
         .is_ok());
+
+    // A different DST must not verify
+    assert!(proof
+        .verify(
+            &pk_snd,
+            std::slice::from_ref(&pk_rcv),
+            &ciphertexts,
+            b"other"
+        )
+        .is_err());
 
     // Verification fails with a different sender public key
     let (other_pk_snd, _) = generate_keypair(&mut rng);
     assert!(proof
-        .verify(&other_pk_snd, &[pk_rcv], &ciphertexts)
+        .verify(&other_pk_snd, &[pk_rcv], &ciphertexts, dst)
         .is_err());
 }
 
 #[test]
 fn test_verifiable_key_encapsulation() {
     const N: usize = 8;
+    let range_dst = b"range";
+    let consistency_dst = b"consistency";
     let mut rng = rand::thread_rng();
     let table = precompute_table();
 
@@ -758,29 +875,89 @@ fn test_verifiable_key_encapsulation() {
     let recipient_keys = [pk_rcv_0.clone(), pk_rcv_1.clone(), pk_rcv_2.clone()];
 
     // Seal the sender's private key to all three recipients
-    let encapsulation =
-        VerifiableKeyEncapsulation::<N>::batch_seal(&sk_snd, &recipient_keys, &mut rng);
+    let encapsulation = VerifiableKeyEncapsulation::<N>::batch_seal(
+        &sk_snd,
+        &recipient_keys,
+        range_dst,
+        consistency_dst,
+        &mut rng,
+    );
 
     // Verification passes for the correct sender public key and recipient keys
     assert!(encapsulation
-        .verify(&pk_snd, &recipient_keys, &mut rng)
+        .verify(
+            &pk_snd,
+            &recipient_keys,
+            range_dst,
+            consistency_dst,
+            &mut rng
+        )
         .is_ok());
+
+    // Verification fails with a different range proof DST
+    assert!(encapsulation
+        .verify(
+            &pk_snd,
+            &recipient_keys,
+            b"other",
+            consistency_dst,
+            &mut rng
+        )
+        .is_err());
+
+    // Verification fails with a different key consistency DST
+    assert!(encapsulation
+        .verify(&pk_snd, &recipient_keys, range_dst, b"other", &mut rng)
+        .is_err());
 
     // Verification fails with a wrong sender public key
     let (other_pk, _) = generate_keypair(&mut rng);
     assert!(encapsulation
-        .verify(&other_pk, &recipient_keys, &mut rng)
+        .verify(
+            &other_pk,
+            &recipient_keys,
+            range_dst,
+            consistency_dst,
+            &mut rng
+        )
         .is_err());
 
     // Each recipient can independently recover the sender's private key
     let recovered_0 = encapsulation
-        .open(0, &sk_rcv_0, &recipient_keys, &pk_snd, &table, &mut rng)
+        .open(
+            0,
+            &sk_rcv_0,
+            &recipient_keys,
+            &pk_snd,
+            &table,
+            range_dst,
+            consistency_dst,
+            &mut rng,
+        )
         .unwrap();
     let recovered_1 = encapsulation
-        .open(1, &sk_rcv_1, &recipient_keys, &pk_snd, &table, &mut rng)
+        .open(
+            1,
+            &sk_rcv_1,
+            &recipient_keys,
+            &pk_snd,
+            &table,
+            range_dst,
+            consistency_dst,
+            &mut rng,
+        )
         .unwrap();
     let recovered_2 = encapsulation
-        .open(2, &sk_rcv_2, &recipient_keys, &pk_snd, &table, &mut rng)
+        .open(
+            2,
+            &sk_rcv_2,
+            &recipient_keys,
+            &pk_snd,
+            &table,
+            range_dst,
+            consistency_dst,
+            &mut rng,
+        )
         .unwrap();
 
     assert_eq!(recovered_0.0, sk_snd.0);
@@ -789,7 +966,16 @@ fn test_verifiable_key_encapsulation() {
 
     // A recipient cannot open another recipient's slot with their own key
     assert!(encapsulation
-        .open(1, &sk_rcv_0, &recipient_keys, &pk_snd, &table, &mut rng)
+        .open(
+            1,
+            &sk_rcv_0,
+            &recipient_keys,
+            &pk_snd,
+            &table,
+            range_dst,
+            consistency_dst,
+            &mut rng
+        )
         .is_err());
 }
 
@@ -802,12 +988,23 @@ fn test_fiat_shamir_regression() {
         7u64,
     );
     let expected = RistrettoScalar::from_byte_array(
-        &Hex::decode("418b0d04de7cf9c3366c542fe4e91d675220c7a571cb8f320d2fbb9cf4a34200")
+        &Hex::decode("1e8fa9e453ab773a8ac1dd02d9602f45962c3d2061c543d7b9a33de8f51c4000")
             .unwrap()
             .try_into()
             .unwrap(),
     )
     .unwrap();
-    let actual = fiat_shamir_challenge(&challenge_input);
+    let msg = bcs::to_bytes(&challenge_input).unwrap();
+    let actual = RistrettoScalar::fiat_shamir_reduction_to_group_element(
+        &bcs::to_bytes(&vec![b"".to_vec(), msg.clone()]).unwrap(),
+    );
     assert_eq!(actual, expected);
+
+    // A non-empty DST must change the challenge.
+    assert_ne!(
+        RistrettoScalar::fiat_shamir_reduction_to_group_element(
+            &bcs::to_bytes(&vec![b"dst".to_vec(), msg.clone()]).unwrap(),
+        ),
+        expected
+    );
 }


### PR DESCRIPTION
Adds a domain-separation-tag (`dst`) to the bulletproof range proofs and the Twisted ElGamal / DDH sigma proofs (`DdhTupleNizk`, `ZeroProof`, `ConsistencyProof`, `KeyConsistencyProof`).

The sigma-proof challenges are made byte-for-byte compatible with Contra's Move/TS implementations: `blake2b256(dst || canonical-element-bytes…)`, top byte zeroed, canonical LE scalar (`RistrettoScalar::fiat_shamir_challenge`). Breaking change: prove/verify call sites now require a `dst`.

This changes range proof verification, so Sui must be updated.

## Test plan
- [x] `cargo test -p fastcrypto --lib` (nizk, twisted_elgamal, bulletproofs)
- [x] `cargo fmt --check` + `cargo xclippy -D warnings`