### PR TITLE
Reject empty Ed25519AggregateSignature on verify

### DIFF
--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -465,8 +465,6 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         pks: &[<Self::Sig as Authenticator>::PubKey],
         message: &[u8],
     ) -> Result<(), FastCryptoError> {
-        // Reject empty aggregates: an empty batch verifies trivially, which is meaningless
-        // and a footgun for callers that forget to bound the signer set.
         if self.sigs.is_empty() {
             return Err(FastCryptoError::InvalidInput);
         }
@@ -490,7 +488,6 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         pks: &[<Self::Sig as Authenticator>::PubKey],
         messages: &[&[u8]],
     ) -> Result<(), FastCryptoError> {
-        // Reject empty aggregates: see comment in verify().
         if self.sigs.is_empty() {
             return Err(FastCryptoError::InvalidInput);
         }
@@ -512,7 +509,6 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         pks: Vec<impl ExactSizeIterator<Item = &'a Self::PubKey>>,
         messages: &[&[u8]],
     ) -> Result<(), FastCryptoError> {
-        // Reject empty batches and batches containing an empty aggregate: see comment in verify().
         if sigs.is_empty() || sigs.iter().any(|s| s.sigs.is_empty()) {
             return Err(FastCryptoError::InvalidInput);
         }

--- a/fastcrypto/src/ed25519.rs
+++ b/fastcrypto/src/ed25519.rs
@@ -465,6 +465,11 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         pks: &[<Self::Sig as Authenticator>::PubKey],
         message: &[u8],
     ) -> Result<(), FastCryptoError> {
+        // Reject empty aggregates: an empty batch verifies trivially, which is meaningless
+        // and a footgun for callers that forget to bound the signer set.
+        if self.sigs.is_empty() {
+            return Err(FastCryptoError::InvalidInput);
+        }
         if pks.len() != self.sigs.len() {
             return Err(FastCryptoError::InputLengthWrong(self.sigs.len()));
         }
@@ -485,6 +490,10 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         pks: &[<Self::Sig as Authenticator>::PubKey],
         messages: &[&[u8]],
     ) -> Result<(), FastCryptoError> {
+        // Reject empty aggregates: see comment in verify().
+        if self.sigs.is_empty() {
+            return Err(FastCryptoError::InvalidInput);
+        }
         if pks.len() != self.sigs.len() || messages.len() != self.sigs.len() {
             return Err(FastCryptoError::InputLengthWrong(self.sigs.len()));
         }
@@ -503,6 +512,10 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         pks: Vec<impl ExactSizeIterator<Item = &'a Self::PubKey>>,
         messages: &[&[u8]],
     ) -> Result<(), FastCryptoError> {
+        // Reject empty batches and batches containing an empty aggregate: see comment in verify().
+        if sigs.is_empty() || sigs.iter().any(|s| s.sigs.is_empty()) {
+            return Err(FastCryptoError::InvalidInput);
+        }
         if pks.len() != messages.len() || messages.len() != sigs.len() {
             return Err(FastCryptoError::InputLengthWrong(sigs.len()));
         }

--- a/fastcrypto/src/tests/ed25519_tests.rs
+++ b/fastcrypto/src/tests/ed25519_tests.rs
@@ -261,6 +261,37 @@ fn verify_invalid_aggregate_signature_length_mismatch() {
 }
 
 #[test]
+fn verify_empty_aggregate_signature_is_rejected() {
+    // An empty Ed25519 aggregate signature must NOT verify trivially against any message; previously
+    // `verify(empty_agg, &[], msg)` returned `Ok(())` because the batch verifier accepts an empty
+    // batch as valid.
+    let empty_agg: Ed25519AggregateSignature =
+        Ed25519AggregateSignature::aggregate(std::iter::empty::<&Ed25519Signature>()).unwrap();
+    assert!(empty_agg.verify(&[], b"attacker-chosen message").is_err());
+    assert!(empty_agg
+        .verify_different_msg(&[], &[b"attacker-chosen message"])
+        .is_err());
+
+    // batch_verify on an empty outer slice, or a batch that contains an empty aggregate, must
+    // also be rejected.
+    assert!(Ed25519AggregateSignature::batch_verify(
+        &[],
+        Vec::<std::slice::Iter<'_, Ed25519PublicKey>>::new(),
+        &[]
+    )
+    .is_err());
+    let (digest, pubkeys, signatures) = signature_test_inputs();
+    let real_agg = Ed25519AggregateSignature::aggregate(&signatures).unwrap();
+    let pk_lists = vec![pubkeys.iter(), [].iter()];
+    assert!(Ed25519AggregateSignature::batch_verify(
+        &[&real_agg, &empty_agg],
+        pk_lists,
+        &[&digest[..], b"anything"]
+    )
+    .is_err());
+}
+
+#[test]
 fn verify_invalid_aggregate_signature_public_key_switch() {
     let (digest, mut pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = Ed25519AggregateSignature::aggregate(&signatures).unwrap();


### PR DESCRIPTION
`Ed25519AggregateSignature::verify(empty, &[], msg)` returned `Ok(())` because `ed25519_consensus::batch::Verifier` accepts an empty batch. Add an `is_empty` guard to `verify`, `verify_different_msg`, and `batch_verify`. Experimental-feature-gated so not used in production.