### PR TITLE
Bundle UnsignedAvssCert into AvidMessage for the pessimistic phase

### DIFF
--- a/fastcrypto-tbls/benches/batch_avss_avid.rs
+++ b/fastcrypto-tbls/benches/batch_avss_avid.rs
@@ -82,33 +82,75 @@ pub fn setup_dealer(
 
 mod batch_avss_benches {
     use super::*;
+    use fastcrypto::error::FastCryptoResult;
     use fastcrypto::traits::AllowedRng;
     use fastcrypto_tbls::threshold_schnorr::batch_avss_avid::{
-        self as batch_avss, AvidMessageBuilder, AvssCommonMessage, Dealer, UnsignedAvidCert,
-        UnsignedAvssCert,
+        self as batch_avss, AvidMessageBuilder, AvidVote, AvssCommonMessage, AvssVote, Dealer,
     };
     use fastcrypto_tbls::threshold_schnorr::presigning::Presignatures;
+    use fastcrypto_tbls::threshold_schnorr::Certificate;
     use itertools::Itertools;
-    use std::collections::BTreeMap;
+    use serde::{Deserialize, Serialize};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    /// Concrete [Certificate] over [AvssVote] used by these benches.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct AvssCert {
+        voters: BTreeSet<PartyId>,
+        vote: AvssVote,
+    }
+
+    impl Certificate for AvssCert {
+        type Payload = AvssVote;
+        fn signers(&self) -> &BTreeSet<PartyId> {
+            &self.voters
+        }
+        fn payload(&self) -> &AvssVote {
+            &self.vote
+        }
+        fn verify(&self) -> FastCryptoResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Concrete [Certificate] over [AvidVote] used by these benches.
+    #[derive(Clone, Debug)]
+    struct AvidCert {
+        signers: BTreeSet<PartyId>,
+        vote: AvidVote,
+    }
+
+    impl Certificate for AvidCert {
+        type Payload = AvidVote;
+        fn signers(&self) -> &BTreeSet<PartyId> {
+            &self.signers
+        }
+        fn payload(&self) -> &AvidVote {
+            &self.vote
+        }
+        fn verify(&self) -> FastCryptoResult<()> {
+            Ok(())
+        }
+    }
 
     /// The single straggler / pending recipient in [pessimistic_with_one_straggler]. The benches
     /// reconstruct this receiver's ciphertext, so it must be the one whose shares are dispersed.
     const STRAGGLER: PartyId = 1;
 
     /// Run a "one straggler" pessimistic round: every receiver but [STRAGGLER] is treated as
-    /// having confirmed in the optimistic phase; [STRAGGLER] is the straggler. Returns `v`, an
-    /// [AvidMessageBuilder] that mints per-receiver messages on demand, and the
-    /// [UnsignedAvssCert] (all parties except the straggler).
+    /// having confirmed in the optimistic phase; [STRAGGLER] is the straggler.
     fn pessimistic_with_one_straggler(
         dealer: &Dealer,
         n: u16,
         rng: &mut impl AllowedRng,
-    ) -> (AvssCommonMessage, AvidMessageBuilder, UnsignedAvssCert) {
+    ) -> (AvssCommonMessage, AvidMessageBuilder<AvssCert>, AvssCert) {
         let (state, _) = dealer.create_avss_messages(rng).unwrap();
         let common = state.common.clone();
-        let cert = UnsignedAvssCert {
+        let cert = AvssCert {
             voters: (0..n).filter(|&i| i != STRAGGLER).collect(),
-            common_message_hash: common.hash(),
+            vote: AvssVote {
+                common_message_hash: common.hash(),
+            },
         };
         let messages = dealer.create_avid_messages(&state, cert.clone()).unwrap();
         (common, messages, cert)
@@ -206,10 +248,12 @@ mod batch_avss_benches {
                 let (_, vote1) = r1
                     .process_avid_message(messages.message_for(r1.id).unwrap())
                     .unwrap();
-                let avid_cert = UnsignedAvidCert {
-                    top_root: vote1.top_root,
-                    pending_recipients: vote1.pending_recipients,
-                };
+                let avid_cert = AvidCert {
+                    signers: (0..*n).collect(),
+                    vote: vote1,
+                }
+                .into_verified()
+                .unwrap();
                 verify_echo.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
                     |b| {
@@ -246,10 +290,14 @@ mod batch_avss_benches {
                             .process_avid_message(messages.message_for(r.id).unwrap())
                             .unwrap();
                         if r.id == 1 {
-                            avid_cert = Some(UnsignedAvidCert {
-                                top_root: vote.top_root,
-                                pending_recipients: vote.pending_recipients,
-                            });
+                            avid_cert = Some(
+                                AvidCert {
+                                    signers: (0..*n).collect(),
+                                    vote,
+                                }
+                                .into_verified()
+                                .unwrap(),
+                            );
                         }
                         builder
                             .recipients()
@@ -277,7 +325,12 @@ mod batch_avss_benches {
 
                 process.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
-                    |b| b.iter(|| r1.decode_ciphertext(&echoes_for_party_1, &vcm1).unwrap()),
+                    |b| {
+                        b.iter(|| {
+                            r1.decode_ciphertext(&echoes_for_party_1, &vcm1, &avid_cert)
+                                .unwrap()
+                        })
+                    },
                 );
             }
         }
@@ -306,10 +359,14 @@ mod batch_avss_benches {
                             .process_avid_message(messages.message_for(r.id).unwrap())
                             .unwrap();
                         if r.id == 1 {
-                            avid_cert = Some(UnsignedAvidCert {
-                                top_root: vote.top_root,
-                                pending_recipients: vote.pending_recipients,
-                            });
+                            avid_cert = Some(
+                                AvidCert {
+                                    signers: (0..*n).collect(),
+                                    vote,
+                                }
+                                .into_verified()
+                                .unwrap(),
+                            );
                         }
                         builder
                             .recipients()
@@ -334,14 +391,22 @@ mod batch_avss_benches {
                     })
                     .collect();
                 let r1 = &receivers[1];
-                let ciphertext = match r1.decode_ciphertext(&echoes_for_party_1, &vcm1).unwrap() {
+                let ciphertext = match r1
+                    .decode_ciphertext(&echoes_for_party_1, &vcm1, &avid_cert)
+                    .unwrap()
+                {
                     batch_avss::DecodeOutcome::Decoded(c) => c,
                     _ => panic!("expected Decoded outcome"),
                 };
 
                 verify_decrypt.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
-                    |b| b.iter(|| r1.decrypt_and_verify(&ciphertext, &vcm1).unwrap()),
+                    |b| {
+                        b.iter(|| {
+                            r1.decrypt_and_verify(&ciphertext, &vcm1, &avid_cert)
+                                .unwrap()
+                        })
+                    },
                 );
             }
         }
@@ -386,10 +451,14 @@ mod batch_avss_benches {
                                     .process_avid_message(messages.message_for(r.id).unwrap())
                                     .unwrap();
                                 if r.id == 1 {
-                                    avid_cert = Some(UnsignedAvidCert {
-                                        top_root: vote.top_root,
-                                        pending_recipients: vote.pending_recipients,
-                                    });
+                                    avid_cert = Some(
+                                        AvidCert {
+                                            signers: (0..*n).collect(),
+                                            vote,
+                                        }
+                                        .into_verified()
+                                        .unwrap(),
+                                    );
                                 }
                                 builder
                                     .recipients()
@@ -414,14 +483,16 @@ mod batch_avss_benches {
                             })
                             .collect();
                         let ciphertext = match receivers[1]
-                            .decode_ciphertext(&echoes_for_party_1, &vcm1)
+                            .decode_ciphertext(&echoes_for_party_1, &vcm1, &avid_cert)
                             .unwrap()
                         {
                             batch_avss::DecodeOutcome::Decoded(c) => c,
                             _ => panic!("expected Decoded outcome"),
                         };
                         let output = assert_valid_batch(
-                            receivers[1].decrypt_and_verify(&ciphertext, &vcm1).unwrap(),
+                            receivers[1]
+                                .decrypt_and_verify(&ciphertext, &vcm1, &avid_cert)
+                                .unwrap(),
                         );
                         // presigning consumes the legacy `batch_avss` output types; convert here
                         // while `receivers[1]` is still in scope to derive the share indices.

--- a/fastcrypto-tbls/benches/batch_avss_avid.rs
+++ b/fastcrypto-tbls/benches/batch_avss_avid.rs
@@ -84,11 +84,11 @@ mod batch_avss_benches {
     use super::*;
     use fastcrypto::traits::AllowedRng;
     use fastcrypto_tbls::threshold_schnorr::batch_avss_avid::{
-        self as batch_avss, AvidDispersal, AvssCommonMessage, Dealer, UnsignedAvssCert,
+        self as batch_avss, AvidMessage, AvssCommonMessage, Dealer, UnsignedAvssCert,
     };
     use fastcrypto_tbls::threshold_schnorr::presigning::Presignatures;
     use itertools::Itertools;
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeMap;
 
     /// The single straggler / pending recipient in [pessimistic_with_one_straggler]. The benches
     /// reconstruct this receiver's ciphertext, so it must be the one whose shares are dispersed.
@@ -96,25 +96,24 @@ mod batch_avss_benches {
 
     /// Run a "one straggler" pessimistic round: every receiver but [STRAGGLER] is treated as
     /// having confirmed in the optimistic phase; [STRAGGLER] is the straggler. Returns `v`, the
-    /// per-recipient [AvidDispersal]s, and the [UnsignedAvssCert] (all parties except the
-    /// straggler) the receivers need to call [batch_avss::Receiver::prepare_avid_echo_messages].
+    /// per-recipient [AvidMessage]s, and the [UnsignedAvssCert] (all parties except the
+    /// straggler) — the cert is also bundled into each [AvidMessage].
     fn pessimistic_with_one_straggler(
         dealer: &Dealer,
+        n: u16,
         rng: &mut impl AllowedRng,
     ) -> (
         AvssCommonMessage,
-        BTreeMap<PartyId, AvidDispersal>,
+        BTreeMap<PartyId, AvidMessage>,
         UnsignedAvssCert,
     ) {
         let (state, _) = dealer.create_avss_messages(rng).unwrap();
         let common = state.common.clone();
-        let pending: BTreeSet<PartyId> = std::iter::once(STRAGGLER).collect();
-        let messages = dealer.create_avid_dispersals(&state, pending).unwrap();
-        let n = messages.len() as u16;
         let cert = UnsignedAvssCert {
             voters: (0..n).filter(|&i| i != STRAGGLER).collect(),
             common_message_hash: common.hash(),
         };
+        let messages = dealer.create_avid_dispersals(&state, cert.clone()).unwrap();
         (common, messages, cert)
     }
 
@@ -158,7 +157,7 @@ mod batch_avss_benches {
                 let keys = generate_ecies_keys(*n);
                 let d0 = setup_dealer(0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
-                let (common, _, _) = pessimistic_with_one_straggler(&d0, &mut thread_rng());
+                let (common, _, _) = pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 verify_common.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
                     |b| b.iter(|| r1.verify_common_message(common.clone()).unwrap()),
@@ -178,18 +177,13 @@ mod batch_avss_benches {
                 let keys = generate_ecies_keys(*n);
                 let d0 = setup_dealer(0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
-                let (common, messages, cert) =
-                    pessimistic_with_one_straggler(&d0, &mut thread_rng());
+                let (common, messages, _cert) =
+                    pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 let vcm = r1.verify_common_message(common).unwrap();
                 let message = &messages[&1];
                 echo.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
-                    |b| {
-                        b.iter(|| {
-                            r1.prepare_avid_echo_messages_and_vote(message.clone(), &vcm, &cert)
-                                .unwrap()
-                        })
-                    },
+                    |b| b.iter(|| r1.process_avid_message(message.clone(), &vcm).unwrap()),
                 );
             }
         }
@@ -208,15 +202,15 @@ mod batch_avss_benches {
                 let r0 = setup_receiver(0, 0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
                 let (common, messages, cert) =
-                    pessimistic_with_one_straggler(&d0, &mut thread_rng());
+                    pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 let vcm0 = r0.verify_common_message(common.clone()).unwrap();
                 let vcm1 = r1.verify_common_message(common).unwrap();
                 let (builder0, _) = r0
-                    .prepare_avid_echo_messages_and_vote(messages[&0].clone(), &vcm0, &cert)
+                    .process_avid_message(messages[&0].clone(), &vcm0)
                     .unwrap();
                 let echo_for_r1 = builder0.create_echo(1).unwrap();
                 let (_, vote1) = r1
-                    .prepare_avid_echo_messages_and_vote(messages[&r1.id].clone(), &vcm1, &cert)
+                    .process_avid_message(messages[&r1.id].clone(), &vcm1)
                     .unwrap();
                 let top_root = vote1.top_root;
                 verify_echo.bench_function(
@@ -251,18 +245,14 @@ mod batch_avss_benches {
                     .map(|id| setup_receiver(id, 0, f, t, w, &keys, batch_size_per_weight))
                     .collect();
                 let (common, messages, cert) =
-                    pessimistic_with_one_straggler(&d0, &mut thread_rng());
+                    pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 let mut top_root = None;
                 let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                     .iter()
                     .map(|r| {
                         let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .prepare_avid_echo_messages_and_vote(
-                                messages[&r.id].clone(),
-                                &vcm,
-                                &cert,
-                            )
+                            .process_avid_message(messages[&r.id].clone(), &vcm)
                             .unwrap();
                         if r.id == 1 {
                             top_root = Some(vote.top_root);
@@ -314,18 +304,14 @@ mod batch_avss_benches {
                     .map(|id| setup_receiver(id, 0, f, t, w, &keys, batch_size_per_weight))
                     .collect();
                 let (common, messages, cert) =
-                    pessimistic_with_one_straggler(&d0, &mut thread_rng());
+                    pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 let mut top_root = None;
                 let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                     .iter()
                     .map(|r| {
                         let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .prepare_avid_echo_messages_and_vote(
-                                messages[&r.id].clone(),
-                                &vcm,
-                                &cert,
-                            )
+                            .process_avid_message(messages[&r.id].clone(), &vcm)
                             .unwrap();
                         if r.id == 1 {
                             top_root = Some(vote.top_root);
@@ -384,7 +370,7 @@ mod batch_avss_benches {
                     .enumerate()
                     .map(|(dealer_id, d)| {
                         let (common, messages, cert) =
-                            pessimistic_with_one_straggler(d, &mut thread_rng());
+                            pessimistic_with_one_straggler(d, *n, &mut thread_rng());
                         let receivers: Vec<batch_avss::Receiver> = (0..*n)
                             .map(|id| {
                                 setup_receiver(
@@ -404,11 +390,7 @@ mod batch_avss_benches {
                             .map(|r| {
                                 let vcm = r.verify_common_message(common.clone()).unwrap();
                                 let (builder, vote) = r
-                                    .prepare_avid_echo_messages_and_vote(
-                                        messages[&r.id].clone(),
-                                        &vcm,
-                                        &cert,
-                                    )
+                                    .process_avid_message(messages[&r.id].clone(), &vcm)
                                     .unwrap();
                                 if r.id == 1 {
                                     top_root = Some(vote.top_root);

--- a/fastcrypto-tbls/benches/batch_avss_avid.rs
+++ b/fastcrypto-tbls/benches/batch_avss_avid.rs
@@ -84,7 +84,8 @@ mod batch_avss_benches {
     use super::*;
     use fastcrypto::traits::AllowedRng;
     use fastcrypto_tbls::threshold_schnorr::batch_avss_avid::{
-        self as batch_avss, AvidMessageBuilder, AvssCommonMessage, Dealer, UnsignedAvssCert,
+        self as batch_avss, AvidMessageBuilder, AvssCommonMessage, Dealer, UnsignedAvidCert,
+        UnsignedAvssCert,
     };
     use fastcrypto_tbls::threshold_schnorr::presigning::Presignatures;
     use itertools::Itertools;
@@ -109,7 +110,7 @@ mod batch_avss_benches {
             voters: (0..n).filter(|&i| i != STRAGGLER).collect(),
             common_message_hash: common.hash(),
         };
-        let messages = dealer.create_avid_dispersals(&state, cert.clone()).unwrap();
+        let messages = dealer.create_avid_messages(&state, cert.clone()).unwrap();
         (common, messages, cert)
     }
 
@@ -173,13 +174,12 @@ mod batch_avss_benches {
                 let keys = generate_ecies_keys(*n);
                 let d0 = setup_dealer(0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
-                let (common, messages, _cert) =
+                let (_common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
-                let vcm = r1.verify_common_message(common).unwrap();
                 let message = messages.message_for(1).unwrap();
                 echo.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
-                    |b| b.iter(|| r1.process_avid_message(message.clone(), &vcm).unwrap()),
+                    |b| b.iter(|| r1.process_avid_message(message.clone()).unwrap()),
                 );
             }
         }
@@ -197,29 +197,25 @@ mod batch_avss_benches {
                 let d0 = setup_dealer(0, f, t, w, &keys, batch_size_per_weight);
                 let r0 = setup_receiver(0, 0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
-                let (common, messages, cert) =
+                let (_common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
-                let vcm0 = r0.verify_common_message(common.clone()).unwrap();
-                let vcm1 = r1.verify_common_message(common).unwrap();
                 let (builder0, _) = r0
-                    .process_avid_message(messages.message_for(0).unwrap(), &vcm0)
+                    .process_avid_message(messages.message_for(0).unwrap())
                     .unwrap();
                 let echo_for_r1 = builder0.create_echo(1).unwrap();
                 let (_, vote1) = r1
-                    .process_avid_message(messages.message_for(r1.id).unwrap(), &vcm1)
+                    .process_avid_message(messages.message_for(r1.id).unwrap())
                     .unwrap();
-                let top_root = vote1.top_root;
+                let avid_cert = UnsignedAvidCert {
+                    top_root: vote1.top_root,
+                    pending_recipients: vote1.pending_recipients,
+                };
                 verify_echo.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
                     |b| {
                         b.iter(|| {
-                            r1.verify_avid_echo_message(
-                                echo_for_r1.clone(),
-                                r0.id,
-                                &top_root,
-                                &cert,
-                            )
-                            .unwrap()
+                            r1.verify_avid_echo_message(echo_for_r1.clone(), r0.id, &avid_cert)
+                                .unwrap()
                         })
                     },
                 );
@@ -240,18 +236,20 @@ mod batch_avss_benches {
                 let receivers: Vec<batch_avss::Receiver> = (0..*n)
                     .map(|id| setup_receiver(id, 0, f, t, w, &keys, batch_size_per_weight))
                     .collect();
-                let (common, messages, cert) =
+                let (common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
-                let mut top_root = None;
+                let mut avid_cert = None;
                 let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                     .iter()
                     .map(|r| {
-                        let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                            .process_avid_message(messages.message_for(r.id).unwrap())
                             .unwrap();
                         if r.id == 1 {
-                            top_root = Some(vote.top_root);
+                            avid_cert = Some(UnsignedAvidCert {
+                                top_root: vote.top_root,
+                                pending_recipients: vote.pending_recipients,
+                            });
                         }
                         builder
                             .recipients()
@@ -260,7 +258,7 @@ mod batch_avss_benches {
                             .collect()
                     })
                     .collect();
-                let top_root = top_root.unwrap();
+                let avid_cert = avid_cert.unwrap();
                 let vcm1 = receivers[1].verify_common_message(common).unwrap();
                 let echoes_for_party_1: Vec<batch_avss::VerifiedEcho> = echoes
                     .iter()
@@ -270,8 +268,7 @@ mod batch_avss_benches {
                             .verify_avid_echo_message(
                                 em[&1u16].clone(),
                                 sender as PartyId,
-                                &top_root,
-                                &cert,
+                                &avid_cert,
                             )
                             .unwrap()
                     })
@@ -299,18 +296,20 @@ mod batch_avss_benches {
                 let receivers: Vec<batch_avss::Receiver> = (0..*n)
                     .map(|id| setup_receiver(id, 0, f, t, w, &keys, batch_size_per_weight))
                     .collect();
-                let (common, messages, cert) =
+                let (common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
-                let mut top_root = None;
+                let mut avid_cert = None;
                 let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                     .iter()
                     .map(|r| {
-                        let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                            .process_avid_message(messages.message_for(r.id).unwrap())
                             .unwrap();
                         if r.id == 1 {
-                            top_root = Some(vote.top_root);
+                            avid_cert = Some(UnsignedAvidCert {
+                                top_root: vote.top_root,
+                                pending_recipients: vote.pending_recipients,
+                            });
                         }
                         builder
                             .recipients()
@@ -319,7 +318,7 @@ mod batch_avss_benches {
                             .collect()
                     })
                     .collect();
-                let top_root = top_root.unwrap();
+                let avid_cert = avid_cert.unwrap();
                 let vcm1 = receivers[1].verify_common_message(common).unwrap();
                 let echoes_for_party_1: Vec<batch_avss::VerifiedEcho> = echoes
                     .iter()
@@ -329,8 +328,7 @@ mod batch_avss_benches {
                             .verify_avid_echo_message(
                                 em[&1u16].clone(),
                                 sender as PartyId,
-                                &top_root,
-                                &cert,
+                                &avid_cert,
                             )
                             .unwrap()
                     })
@@ -365,7 +363,7 @@ mod batch_avss_benches {
                     .iter()
                     .enumerate()
                     .map(|(dealer_id, d)| {
-                        let (common, messages, cert) =
+                        let (common, messages, _cert) =
                             pessimistic_with_one_straggler(d, *n, &mut thread_rng());
                         let receivers: Vec<batch_avss::Receiver> = (0..*n)
                             .map(|id| {
@@ -380,16 +378,18 @@ mod batch_avss_benches {
                                 )
                             })
                             .collect();
-                        let mut top_root = None;
+                        let mut avid_cert = None;
                         let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                             .iter()
                             .map(|r| {
-                                let vcm = r.verify_common_message(common.clone()).unwrap();
                                 let (builder, vote) = r
-                                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                                    .process_avid_message(messages.message_for(r.id).unwrap())
                                     .unwrap();
                                 if r.id == 1 {
-                                    top_root = Some(vote.top_root);
+                                    avid_cert = Some(UnsignedAvidCert {
+                                        top_root: vote.top_root,
+                                        pending_recipients: vote.pending_recipients,
+                                    });
                                 }
                                 builder
                                     .recipients()
@@ -398,7 +398,7 @@ mod batch_avss_benches {
                                     .collect()
                             })
                             .collect();
-                        let top_root = top_root.unwrap();
+                        let avid_cert = avid_cert.unwrap();
                         let vcm1 = receivers[1].verify_common_message(common).unwrap();
                         let echoes_for_party_1: Vec<batch_avss::VerifiedEcho> = echoes
                             .iter()
@@ -408,8 +408,7 @@ mod batch_avss_benches {
                                     .verify_avid_echo_message(
                                         em[&1u16].clone(),
                                         sender as PartyId,
-                                        &top_root,
-                                        &cert,
+                                        &avid_cert,
                                     )
                                     .unwrap()
                             })

--- a/fastcrypto-tbls/benches/batch_avss_avid.rs
+++ b/fastcrypto-tbls/benches/batch_avss_avid.rs
@@ -216,12 +216,19 @@ mod batch_avss_benches {
                 let keys = generate_ecies_keys(*n);
                 let d0 = setup_dealer(0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
-                let (_common, messages, _cert) =
+                let (common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 let message = messages.message_for(1).unwrap();
+                let vcm = r1.verify_common_message(common).unwrap();
                 echo.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
-                    |b| b.iter(|| r1.process_avid_message(message.clone()).unwrap()),
+                    |b| {
+                        b.iter(|| {
+                            r1.process_avid_message(Some(&vcm), message.clone())
+                                .unwrap()
+                                .unwrap()
+                        })
+                    },
                 );
             }
         }
@@ -239,14 +246,18 @@ mod batch_avss_benches {
                 let d0 = setup_dealer(0, f, t, w, &keys, batch_size_per_weight);
                 let r0 = setup_receiver(0, 0, f, t, w, &keys, batch_size_per_weight);
                 let r1 = setup_receiver(1, 0, f, t, w, &keys, batch_size_per_weight);
-                let (_common, messages, _cert) =
+                let (common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
+                let vcm0 = r0.verify_common_message(common.clone()).unwrap();
+                let vcm1 = r1.verify_common_message(common).unwrap();
                 let (builder0, _) = r0
-                    .process_avid_message(messages.message_for(0).unwrap())
+                    .process_avid_message(Some(&vcm0), messages.message_for(0).unwrap())
+                    .unwrap()
                     .unwrap();
                 let echo_for_r1 = builder0.create_echo(1).unwrap();
                 let (_, vote1) = r1
-                    .process_avid_message(messages.message_for(r1.id).unwrap())
+                    .process_avid_message(Some(&vcm1), messages.message_for(r1.id).unwrap())
+                    .unwrap()
                     .unwrap();
                 let avid_cert = AvidCert {
                     signers: (0..*n).collect(),
@@ -286,8 +297,10 @@ mod batch_avss_benches {
                 let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                     .iter()
                     .map(|r| {
+                        let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .process_avid_message(messages.message_for(r.id).unwrap())
+                            .process_avid_message(Some(&vcm), messages.message_for(r.id).unwrap())
+                            .unwrap()
                             .unwrap();
                         if r.id == 1 {
                             avid_cert = Some(
@@ -355,8 +368,10 @@ mod batch_avss_benches {
                 let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                     .iter()
                     .map(|r| {
+                        let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .process_avid_message(messages.message_for(r.id).unwrap())
+                            .process_avid_message(Some(&vcm), messages.message_for(r.id).unwrap())
+                            .unwrap()
                             .unwrap();
                         if r.id == 1 {
                             avid_cert = Some(
@@ -447,8 +462,13 @@ mod batch_avss_benches {
                         let echoes: Vec<BTreeMap<PartyId, batch_avss::Echo>> = receivers
                             .iter()
                             .map(|r| {
+                                let vcm = r.verify_common_message(common.clone()).unwrap();
                                 let (builder, vote) = r
-                                    .process_avid_message(messages.message_for(r.id).unwrap())
+                                    .process_avid_message(
+                                        Some(&vcm),
+                                        messages.message_for(r.id).unwrap(),
+                                    )
+                                    .unwrap()
                                     .unwrap();
                                 if r.id == 1 {
                                     avid_cert = Some(

--- a/fastcrypto-tbls/benches/batch_avss_avid.rs
+++ b/fastcrypto-tbls/benches/batch_avss_avid.rs
@@ -84,7 +84,7 @@ mod batch_avss_benches {
     use super::*;
     use fastcrypto::traits::AllowedRng;
     use fastcrypto_tbls::threshold_schnorr::batch_avss_avid::{
-        self as batch_avss, AvidMessage, AvssCommonMessage, Dealer, UnsignedAvssCert,
+        self as batch_avss, AvidMessageBuilder, AvssCommonMessage, Dealer, UnsignedAvssCert,
     };
     use fastcrypto_tbls::threshold_schnorr::presigning::Presignatures;
     use itertools::Itertools;
@@ -95,18 +95,14 @@ mod batch_avss_benches {
     const STRAGGLER: PartyId = 1;
 
     /// Run a "one straggler" pessimistic round: every receiver but [STRAGGLER] is treated as
-    /// having confirmed in the optimistic phase; [STRAGGLER] is the straggler. Returns `v`, the
-    /// per-recipient [AvidMessage]s, and the [UnsignedAvssCert] (all parties except the
-    /// straggler) — the cert is also bundled into each [AvidMessage].
+    /// having confirmed in the optimistic phase; [STRAGGLER] is the straggler. Returns `v`, an
+    /// [AvidMessageBuilder] that mints per-receiver messages on demand, and the
+    /// [UnsignedAvssCert] (all parties except the straggler).
     fn pessimistic_with_one_straggler(
         dealer: &Dealer,
         n: u16,
         rng: &mut impl AllowedRng,
-    ) -> (
-        AvssCommonMessage,
-        BTreeMap<PartyId, AvidMessage>,
-        UnsignedAvssCert,
-    ) {
+    ) -> (AvssCommonMessage, AvidMessageBuilder, UnsignedAvssCert) {
         let (state, _) = dealer.create_avss_messages(rng).unwrap();
         let common = state.common.clone();
         let cert = UnsignedAvssCert {
@@ -180,7 +176,7 @@ mod batch_avss_benches {
                 let (common, messages, _cert) =
                     pessimistic_with_one_straggler(&d0, *n, &mut thread_rng());
                 let vcm = r1.verify_common_message(common).unwrap();
-                let message = &messages[&1];
+                let message = messages.message_for(1).unwrap();
                 echo.bench_function(
                     format!("n={}, total_weight={}, t={}, w={}", n, total_w, t, w).as_str(),
                     |b| b.iter(|| r1.process_avid_message(message.clone(), &vcm).unwrap()),
@@ -206,11 +202,11 @@ mod batch_avss_benches {
                 let vcm0 = r0.verify_common_message(common.clone()).unwrap();
                 let vcm1 = r1.verify_common_message(common).unwrap();
                 let (builder0, _) = r0
-                    .process_avid_message(messages[&0].clone(), &vcm0)
+                    .process_avid_message(messages.message_for(0).unwrap(), &vcm0)
                     .unwrap();
                 let echo_for_r1 = builder0.create_echo(1).unwrap();
                 let (_, vote1) = r1
-                    .process_avid_message(messages[&r1.id].clone(), &vcm1)
+                    .process_avid_message(messages.message_for(r1.id).unwrap(), &vcm1)
                     .unwrap();
                 let top_root = vote1.top_root;
                 verify_echo.bench_function(
@@ -252,7 +248,7 @@ mod batch_avss_benches {
                     .map(|r| {
                         let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .process_avid_message(messages[&r.id].clone(), &vcm)
+                            .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                             .unwrap();
                         if r.id == 1 {
                             top_root = Some(vote.top_root);
@@ -311,7 +307,7 @@ mod batch_avss_benches {
                     .map(|r| {
                         let vcm = r.verify_common_message(common.clone()).unwrap();
                         let (builder, vote) = r
-                            .process_avid_message(messages[&r.id].clone(), &vcm)
+                            .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                             .unwrap();
                         if r.id == 1 {
                             top_root = Some(vote.top_root);
@@ -390,7 +386,7 @@ mod batch_avss_benches {
                             .map(|r| {
                                 let vcm = r.verify_common_message(common.clone()).unwrap();
                                 let (builder, vote) = r
-                                    .process_avid_message(messages[&r.id].clone(), &vcm)
+                                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                                     .unwrap();
                                 if r.id == 1 {
                                     top_root = Some(vote.top_root);

--- a/fastcrypto-tbls/src/nodes.rs
+++ b/fastcrypto-tbls/src/nodes.rs
@@ -8,6 +8,7 @@ use fastcrypto::groups::GroupElement;
 use fastcrypto::hash::{Blake2b256, Digest, HashFunction};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use tracing::debug;
 
 pub type PartyId = u16;
@@ -104,6 +105,13 @@ impl<G: GroupElement + Serialize> Nodes<G> {
     /// Number of nodes.
     pub fn num_nodes(&self) -> usize {
         self.nodes.len()
+    }
+
+    /// The relative complement of `subset` within the node set — every node id not in `subset`.
+    pub fn relative_complement(&self, subset: &BTreeSet<PartyId>) -> BTreeSet<PartyId> {
+        self.node_ids_iter()
+            .filter(|id| !subset.contains(id))
+            .collect()
     }
 
     /// Get an iterator on the share ids.

--- a/fastcrypto-tbls/src/threshold_schnorr/avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avid.rs
@@ -87,16 +87,17 @@ impl Avid {
         Ok(Self { nodes, coder, f })
     }
 
-    /// 1. Disperse one payload per recipient. Returns one per-party [Dispersal]. Runs `mutate`
-    ///    over the per-recipient, per-disperser shards before the Merkle trees are built — for
-    ///    production callers pass `|_| {}`.
-    ///    Fails if any of the payloads are empty.
+    /// 1. RS-encode every payload, build the two-level Merkle commitment, and return a
+    ///    [DispersalBuilder] that can mint per-disperser [Dispersal]s on demand via
+    ///    [DispersalBuilder::dispersal_for]. Runs `mutate` over the per-recipient, per-disperser
+    ///    shards before the Merkle tree is built — production callers pass `|_| {}`. Fails if any
+    ///    of the payloads are empty.
     #[cfg_attr(not(test), allow(unused_variables, unused_mut))]
     pub fn disperse_with_mutation(
         &self,
         payloads_by_recipient: &BTreeMap<PartyId, Vec<u8>>,
         mutate: impl FnOnce(&mut BTreeMap<PartyId, Vec<Vec<Shard>>>),
-    ) -> FastCryptoResult<BTreeMap<PartyId, Dispersal>> {
+    ) -> FastCryptoResult<DispersalBuilder> {
         // RS-encode each recipient's payload and bucket the shards by disperser.
         let mut shards_by_recipient: BTreeMap<PartyId, Vec<Vec<Shard>>> = payloads_by_recipient
             .iter()
@@ -113,28 +114,11 @@ impl Avid {
         // Two-level Merkle commitment: per-recipient row trees + a top tree over the row roots.
         let tree = NestedMerkleTree::new(shards_by_recipient.values().cloned())?;
 
-        Ok(self
-            .nodes
-            .node_ids_iter()
-            .map(|j| {
-                let dispersal: Dispersal = shards_by_recipient
-                    .iter()
-                    .enumerate()
-                    .map(|(recipient_idx, (&i, by_disperser))| {
-                        (
-                            i,
-                            AuthenticatedShards {
-                                shards: by_disperser[j as usize].clone(),
-                                proof: tree
-                                    .get_proof(recipient_idx, j as usize)
-                                    .expect("valid leaf index"),
-                            },
-                        )
-                    })
-                    .collect();
-                (j, dispersal)
-            })
-            .collect())
+        Ok(DispersalBuilder {
+            nodes: Arc::clone(&self.nodes),
+            tree,
+            shards_by_recipient,
+        })
     }
 
     /// 2. Verify a [Dispersal] and return an [EchoBuilder] that can produce individual [Echo]s on demand via
@@ -314,6 +298,45 @@ impl EchoBuilder {
     }
 }
 
+/// Dealer-side cache built by [Avid::disperse_with_mutation]. Holds the per-recipient × per-disperser
+/// shards and the two-level [NestedMerkleTree] commitment, and mints individual [Dispersal]s on
+/// demand via [Self::dispersal_for] — avoiding the cost of materializing all `n` dispersals up
+/// front when the dealer only needs to send them out reactively.
+pub struct DispersalBuilder {
+    nodes: Arc<Nodes<EG>>,
+    tree: NestedMerkleTree,
+    shards_by_recipient: BTreeMap<PartyId, Vec<Vec<Shard>>>,
+}
+
+impl DispersalBuilder {
+    /// The dispersal's `top_root`.
+    #[allow(dead_code)]
+    pub fn top_root(&self) -> merkle::Node {
+        self.tree.top_root()
+    }
+
+    /// Build the [Dispersal] addressed to `disperser`. Returns [InvalidInput] if `disperser` is not
+    /// a valid party id.
+    pub fn dispersal_for(&self, disperser: PartyId) -> FastCryptoResult<Dispersal> {
+        if !self.nodes.is_valid_id(disperser) {
+            return Err(InvalidInput);
+        }
+        self.shards_by_recipient
+            .iter()
+            .enumerate()
+            .map(|(recipient_idx, (&i, by_disperser))| {
+                Ok((
+                    i,
+                    AuthenticatedShards {
+                        shards: by_disperser[disperser as usize].clone(),
+                        proof: self.tree.get_proof(recipient_idx, disperser as usize)?,
+                    },
+                ))
+            })
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -354,16 +377,17 @@ mod tests {
         let payloads: BTreeMap<PartyId, Vec<u8>> =
             std::iter::once((recipient, payload.clone())).collect();
 
-        // 1. Dealer disperses: one message per party.
-        let messages = avid.disperse_with_mutation(&payloads, |_| {}).unwrap();
-        assert_eq!(messages.len(), weights.len());
+        // 1. Dealer disperses: builder mints messages on demand.
+        let dispersal_builder = avid.disperse_with_mutation(&payloads, |_| {}).unwrap();
 
         // 2. Each party verifies its dispersal and emits the echoes it will send to others.
         let mut top_root = None;
         let mut recipients = BTreeSet::new();
-        let party_echoes: Vec<(PartyId, BTreeMap<PartyId, Echo>)> = messages
-            .into_iter()
-            .map(|(j, m)| {
+        let party_echoes: Vec<(PartyId, BTreeMap<PartyId, Echo>)> = avid
+            .nodes
+            .node_ids_iter()
+            .map(|j| {
+                let m = dispersal_builder.dispersal_for(j).unwrap();
                 let (builder, vote) = avid.process_dispersal(j, m).unwrap();
                 if top_root.is_none() {
                     top_root = Some(vote.top_root);
@@ -409,7 +433,7 @@ mod tests {
         let payloads: BTreeMap<PartyId, Vec<u8>> =
             std::iter::once((recipient, payload.clone())).collect();
 
-        let messages = avid
+        let dispersal_builder = avid
             .disperse_with_mutation(&payloads, |shards| {
                 shards.get_mut(&recipient).unwrap()[cheater as usize][0].0[0] ^= 1;
             })
@@ -417,9 +441,11 @@ mod tests {
 
         let mut top_root = None;
         let mut recipients = BTreeSet::new();
-        let party_echoes: Vec<(PartyId, BTreeMap<PartyId, Echo>)> = messages
-            .into_iter()
-            .map(|(j, m)| {
+        let party_echoes: Vec<(PartyId, BTreeMap<PartyId, Echo>)> = avid
+            .nodes
+            .node_ids_iter()
+            .map(|j| {
+                let m = dispersal_builder.dispersal_for(j).unwrap();
                 let (builder, vote) = avid.process_dispersal(j, m).unwrap();
                 if top_root.is_none() {
                     top_root = Some(vote.top_root);

--- a/fastcrypto-tbls/src/threshold_schnorr/avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avid.rs
@@ -29,6 +29,14 @@ pub struct Avid {
     f: u16,
 }
 
+/// Dealer-side cache built by [Avid::disperse_with_mutation] which can create individual [Dispersal]s
+/// on demand via [Self::dispersal_for].
+pub struct DispersalBuilder {
+    nodes: Arc<Nodes<EG>>,
+    tree: NestedMerkleTree,
+    shards_by_recipient: BTreeMap<PartyId, Vec<Vec<Shard>>>,
+}
+
 /// The dealer's per-party dispersal message. One [AuthenticatedShards] per recipient.
 pub type Dispersal = BTreeMap<PartyId, AuthenticatedShards>;
 
@@ -41,10 +49,13 @@ pub struct AuthenticatedShards {
     pub(crate) proof: NestedMerkleProof,
 }
 
-/// An endorsement of a dispersal's `top_root`.
+/// An endorsement of a dispersal's `top_root` and the set of pending recipients it covers.
+/// A quorum of these — once signed and certified — gives the receiver everything it needs to
+/// verify echoes (see [`crate::threshold_schnorr::batch_avss_avid::UnsignedAvidCert`]).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Vote {
     pub top_root: merkle::Node,
+    pub pending_recipients: BTreeSet<PartyId>,
 }
 
 /// A precomputed dispersal-side cache produced by [Avid::process_dispersal] to build [Echo]s.
@@ -87,11 +98,11 @@ impl Avid {
         Ok(Self { nodes, coder, f })
     }
 
-    /// 1. RS-encode every payload, build the two-level Merkle commitment, and return a
-    ///    [DispersalBuilder] that can mint per-disperser [Dispersal]s on demand via
-    ///    [DispersalBuilder::dispersal_for]. Runs `mutate` over the per-recipient, per-disperser
-    ///    shards before the Merkle tree is built — production callers pass `|_| {}`. Fails if any
-    ///    of the payloads are empty.
+    /// 1. RS-encode every payload and return a [DispersalBuilder] that can mint per-disperser
+    ///    [Dispersal]s on demand via [DispersalBuilder::dispersal_for].
+    ///
+    ///    Runs `mutate` over the per-recipient, per-disperser shards before the Merkle tree is
+    ///    built — production callers pass `|_| {}`. Fails if any of the payloads are empty.
     #[cfg_attr(not(test), allow(unused_variables, unused_mut))]
     pub fn disperse_with_mutation(
         &self,
@@ -145,32 +156,32 @@ impl Avid {
             })
             .collect::<FastCryptoResult<Vec<_>>>()?;
         let top_root = get_uniform_value(implied_roots).ok_or(InvalidMessage)?;
+        let pending_recipients: BTreeSet<PartyId> = dispersal.keys().copied().collect();
         Ok((
             EchoBuilder {
                 dispersal,
                 top_root: top_root.clone(),
             },
-            Vote { top_root },
+            Vote {
+                top_root,
+                pending_recipients,
+            },
         ))
     }
 
-    /// 3a. Verify an [Echo] addressed to `receiver`. Use the published `certified_top_root`.
+    /// 3a. Verify an [Echo] addressed to the recipient at `receiver_idx` (its index in the
+    ///     dispersal's sorted pending-recipient set). Use the published `certified_top_root`.
     pub fn verify_echo(
         &self,
         echo: Echo,
         sender: PartyId,
         certified_top_root: &merkle::Node,
-        pending_recipients: &BTreeSet<PartyId>,
-        receiver: PartyId,
+        receiver_idx: usize,
     ) -> FastCryptoResult<VerifiedEcho> {
         let auth = &echo.authenticated_shards;
         if auth.shards.len() != self.nodes.weight_of(sender)? as usize {
             return Err(InvalidMessage);
         }
-        let receiver_idx = pending_recipients
-            .iter()
-            .position(|&id| id == receiver)
-            .ok_or(InvalidInput)?;
         auth.proof.verify(
             certified_top_root,
             &auth.shards,
@@ -298,16 +309,6 @@ impl EchoBuilder {
     }
 }
 
-/// Dealer-side cache built by [Avid::disperse_with_mutation]. Holds the per-recipient × per-disperser
-/// shards and the two-level [NestedMerkleTree] commitment, and mints individual [Dispersal]s on
-/// demand via [Self::dispersal_for] — avoiding the cost of materializing all `n` dispersals up
-/// front when the dealer only needs to send them out reactively.
-pub struct DispersalBuilder {
-    nodes: Arc<Nodes<EG>>,
-    tree: NestedMerkleTree,
-    shards_by_recipient: BTreeMap<PartyId, Vec<Vec<Shard>>>,
-}
-
 impl DispersalBuilder {
     /// The dispersal's `top_root`.
     #[allow(dead_code)]
@@ -408,7 +409,8 @@ mod tests {
             .into_iter()
             .map(|(sender, mut echoes)| {
                 let echo = echoes.remove(&recipient).unwrap();
-                avid.verify_echo(echo, sender, &top_root, &recipients, recipient)
+                let receiver_idx = recipients.iter().position(|&id| id == recipient).unwrap();
+                avid.verify_echo(echo, sender, &top_root, receiver_idx)
                     .unwrap()
             })
             .collect();
@@ -467,7 +469,8 @@ mod tests {
             .into_iter()
             .map(|(sender, mut echoes)| {
                 let echo = echoes.remove(&recipient).unwrap();
-                avid.verify_echo(echo, sender, &top_root, &recipients, recipient)
+                let receiver_idx = recipients.iter().position(|&id| id == recipient).unwrap();
+                avid.verify_echo(echo, sender, &top_root, receiver_idx)
                     .unwrap()
             })
             .collect();

--- a/fastcrypto-tbls/src/threshold_schnorr/avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avid.rs
@@ -50,8 +50,6 @@ pub struct AuthenticatedShards {
 }
 
 /// An endorsement of a dispersal's `top_root` and the set of pending recipients it covers.
-/// A quorum of these — once signed and certified — gives the receiver everything it needs to
-/// verify echoes (see [`crate::threshold_schnorr::batch_avss_avid::UnsignedAvidCert`]).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Vote {
     pub top_root: merkle::Node,
@@ -133,8 +131,7 @@ impl Avid {
     }
 
     /// 2. Verify a [Dispersal] and return an [EchoBuilder] that can produce individual [Echo]s on demand via
-    ///    [EchoBuilder::create_echo] and a [Vote] to return to the disperser. When the disperser
-    ///    has `W-f` weight of signed [Vote]s, he can publish the certified `top_root`.
+    ///    [EchoBuilder::create_echo] and a [Vote] to return to the disperser.
     pub fn process_dispersal(
         &self,
         my_id: PartyId,
@@ -169,25 +166,26 @@ impl Avid {
         ))
     }
 
-    /// 3a. Verify an [Echo] addressed to the recipient at `receiver_idx` (its index in the
-    ///     dispersal's sorted pending-recipient set). Use the published `certified_top_root`.
+    /// 3a. Verify an [Echo] addressed to `receiver`, against the certified [Vote] published
+    ///     by the dealer.
     pub fn verify_echo(
         &self,
         echo: Echo,
         sender: PartyId,
-        certified_top_root: &merkle::Node,
-        receiver_idx: usize,
+        vote: &Vote,
+        receiver: PartyId,
     ) -> FastCryptoResult<VerifiedEcho> {
         let auth = &echo.authenticated_shards;
         if auth.shards.len() != self.nodes.weight_of(sender)? as usize {
             return Err(InvalidMessage);
         }
-        auth.proof.verify(
-            certified_top_root,
-            &auth.shards,
-            receiver_idx,
-            sender as usize,
-        )?;
+        let receiver_idx = vote
+            .pending_recipients
+            .iter()
+            .position(|&id| id == receiver)
+            .ok_or(InvalidInput)?;
+        auth.proof
+            .verify(&vote.top_root, &auth.shards, receiver_idx, sender as usize)?;
         Ok(VerifiedEcho { echo, sender })
     }
 
@@ -316,10 +314,10 @@ impl DispersalBuilder {
         self.tree.top_root()
     }
 
-    /// Build the [Dispersal] addressed to `disperser`. Returns [InvalidInput] if `disperser` is not
-    /// a valid party id.
-    pub fn dispersal_for(&self, disperser: PartyId) -> FastCryptoResult<Dispersal> {
-        if !self.nodes.is_valid_id(disperser) {
+    /// Build the [Dispersal] addressed to `recipient`. Returns [InvalidInput] if `recipient` is
+    /// not a valid party id.
+    pub fn dispersal_for(&self, recipient: PartyId) -> FastCryptoResult<Dispersal> {
+        if !self.nodes.is_valid_id(recipient) {
             return Err(InvalidInput);
         }
         self.shards_by_recipient
@@ -329,8 +327,8 @@ impl DispersalBuilder {
                 Ok((
                     i,
                     AuthenticatedShards {
-                        shards: by_disperser[disperser as usize].clone(),
-                        proof: self.tree.get_proof(recipient_idx, disperser as usize)?,
+                        shards: by_disperser[recipient as usize].clone(),
+                        proof: self.tree.get_proof(recipient_idx, recipient as usize)?,
                     },
                 ))
             })
@@ -382,17 +380,15 @@ mod tests {
         let dispersal_builder = avid.disperse_with_mutation(&payloads, |_| {}).unwrap();
 
         // 2. Each party verifies its dispersal and emits the echoes it will send to others.
-        let mut top_root = None;
-        let mut recipients = BTreeSet::new();
+        let mut certified_vote = None;
         let party_echoes: Vec<(PartyId, BTreeMap<PartyId, Echo>)> = avid
             .nodes
             .node_ids_iter()
             .map(|j| {
                 let m = dispersal_builder.dispersal_for(j).unwrap();
                 let (builder, vote) = avid.process_dispersal(j, m).unwrap();
-                if top_root.is_none() {
-                    top_root = Some(vote.top_root);
-                    recipients = builder.recipients();
+                if certified_vote.is_none() {
+                    certified_vote = Some(vote);
                 }
                 let echoes = builder
                     .recipients()
@@ -402,15 +398,14 @@ mod tests {
                 (j, echoes)
             })
             .collect();
-        let top_root = top_root.unwrap();
+        let certified_vote = certified_vote.unwrap();
 
         // The recipient verifies the echoes addressed to it.
         let echoes: Vec<VerifiedEcho> = party_echoes
             .into_iter()
             .map(|(sender, mut echoes)| {
                 let echo = echoes.remove(&recipient).unwrap();
-                let receiver_idx = recipients.iter().position(|&id| id == recipient).unwrap();
-                avid.verify_echo(echo, sender, &top_root, receiver_idx)
+                avid.verify_echo(echo, sender, &certified_vote, recipient)
                     .unwrap()
             })
             .collect();
@@ -441,17 +436,15 @@ mod tests {
             })
             .unwrap();
 
-        let mut top_root = None;
-        let mut recipients = BTreeSet::new();
+        let mut certified_vote = None;
         let party_echoes: Vec<(PartyId, BTreeMap<PartyId, Echo>)> = avid
             .nodes
             .node_ids_iter()
             .map(|j| {
                 let m = dispersal_builder.dispersal_for(j).unwrap();
                 let (builder, vote) = avid.process_dispersal(j, m).unwrap();
-                if top_root.is_none() {
-                    top_root = Some(vote.top_root);
-                    recipients = builder.recipients();
+                if certified_vote.is_none() {
+                    certified_vote = Some(vote);
                 }
                 let echoes = builder
                     .recipients()
@@ -461,7 +454,7 @@ mod tests {
                 (j, echoes)
             })
             .collect();
-        let top_root = top_root.unwrap();
+        let certified_vote = certified_vote.unwrap();
 
         // The recipient gathers a quorum of echoes including the cheater's ...
         let _ = cheater;
@@ -469,8 +462,7 @@ mod tests {
             .into_iter()
             .map(|(sender, mut echoes)| {
                 let echo = echoes.remove(&recipient).unwrap();
-                let receiver_idx = recipients.iter().position(|&id| id == recipient).unwrap();
-                avid.verify_echo(echo, sender, &top_root, receiver_idx)
+                avid.verify_echo(echo, sender, &certified_vote, recipient)
                     .unwrap()
             })
             .collect();
@@ -484,7 +476,13 @@ mod tests {
 
         // Another party validates the complaint.
         assert!(avid
-            .complaint_is_valid(&complaint, recipient, &top_root, &recipients, |_| true)
+            .complaint_is_valid(
+                &complaint,
+                recipient,
+                &certified_vote.top_root,
+                &certified_vote.pending_recipients,
+                |_| true
+            )
             .unwrap());
     }
 }

--- a/fastcrypto-tbls/src/threshold_schnorr/avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avid.rs
@@ -49,11 +49,11 @@ pub struct AuthenticatedShards {
     pub(crate) proof: NestedMerkleProof,
 }
 
-/// An endorsement of a dispersal's `top_root` and the set of pending recipients it covers.
+/// An endorsement of a dispersal's `top_root` and the set of recipients it covers.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Vote {
     pub top_root: merkle::Node,
-    pub pending_recipients: BTreeSet<PartyId>,
+    pub recipients: BTreeSet<PartyId>,
 }
 
 /// A precomputed dispersal-side cache produced by [Avid::process_dispersal] to build [Echo]s.
@@ -153,7 +153,7 @@ impl Avid {
             })
             .collect::<FastCryptoResult<Vec<_>>>()?;
         let top_root = get_uniform_value(implied_roots).ok_or(InvalidMessage)?;
-        let pending_recipients: BTreeSet<PartyId> = dispersal.keys().copied().collect();
+        let recipients: BTreeSet<PartyId> = dispersal.keys().copied().collect();
         Ok((
             EchoBuilder {
                 dispersal,
@@ -161,7 +161,7 @@ impl Avid {
             },
             Vote {
                 top_root,
-                pending_recipients,
+                recipients,
             },
         ))
     }
@@ -180,7 +180,7 @@ impl Avid {
             return Err(InvalidMessage);
         }
         let receiver_idx = vote
-            .pending_recipients
+            .recipients
             .iter()
             .position(|&id| id == receiver)
             .ok_or(InvalidInput)?;
@@ -480,7 +480,7 @@ mod tests {
                 &complaint,
                 recipient,
                 &certified_vote.top_root,
-                &certified_vote.pending_recipients,
+                &certified_vote.recipients,
                 |_| true
             )
             .unwrap());

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -103,8 +103,9 @@ pub struct AvssVote {
 /// attested to.
 ///
 /// This type is verified by the caller. By constructing it, the caller promises it has verified
-/// each voter's signed [AvssVote] over `common_message_hash`.
-#[derive(Clone, Debug)]
+/// each voter's signed [AvssVote] over `common_message_hash`. The cert travels alongside the
+/// AVID dispersal inside an [AvidMessage].
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UnsignedAvssCert {
     pub voters: BTreeSet<PartyId>,
     pub common_message_hash: Digest,
@@ -117,8 +118,12 @@ pub struct DealerState {
     ciphertexts: Vec<Ciphertext>,
 }
 
-/// The dealer's per-receiver message for the pessimistic phase.
-pub type AvidDispersal = avid::Dispersal;
+/// The dealer's per-receiver pessimistic-phase message: an [avid::Dispersal] of the receiver's ciphertext bundled with the [UnsignedAvssCert] that justifies the pessimistic phase.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AvidMessage {
+    pub dispersal: avid::Dispersal,
+    pub cert: UnsignedAvssCert,
+}
 
 /// An endorsement of the dealer's pessimistic dispersal.
 pub type AvidVote = avid::Vote;
@@ -388,36 +393,54 @@ impl Dealer {
         })
     }
 
-    /// 3. Build a [AvidDispersal] per receiver dispersing the existing ciphertexts for
-    ///    the `pending_recipients` (those that didn't confirm) via AVID, keyed by recipient id.
+    /// 3. Build an [AvidMessage] per pending recipient: an AVID dispersal of that recipient's
+    ///    ciphertext, bundled with the [UnsignedAvssCert] that justifies the pessimistic phase.
+    ///    The pending recipients are derived as the complement of `cert.voters`.
     ///
-    ///    Only needed for the `pending_recipients`, and if every receiver confirmed in the optimistic
-    ///    phase, the pessimistic phase can be skipped entirely.
+    ///    Only needed if any receiver failed to confirm in the optimistic phase; if every
+    ///    receiver confirmed, the pessimistic phase can be skipped entirely.
     pub fn create_avid_dispersals(
         &self,
         state: &DealerState,
-        pending_recipients: BTreeSet<PartyId>,
-    ) -> FastCryptoResult<BTreeMap<PartyId, AvidDispersal>> {
-        self.create_avid_dispersals_with_mutation(state, pending_recipients, |_| {})
+        cert: UnsignedAvssCert,
+    ) -> FastCryptoResult<BTreeMap<PartyId, AvidMessage>> {
+        self.create_avid_dispersals_with_mutation(state, cert, |_| {})
     }
 
     fn create_avid_dispersals_with_mutation(
         &self,
         state: &DealerState,
-        pending_recipients: BTreeSet<PartyId>,
+        cert: UnsignedAvssCert,
         mutate_shards: impl FnOnce(&mut BTreeMap<PartyId, Vec<Vec<Shard>>>),
-    ) -> FastCryptoResult<BTreeMap<PartyId, AvidDispersal>> {
-        // Validate pending_recipients ⊆ all_ids.
-        let all_ids: BTreeSet<PartyId> = self.nodes.node_ids_iter().collect();
-        if !pending_recipients.is_subset(&all_ids) {
-            return Err(InvalidInput);
-        }
+    ) -> FastCryptoResult<BTreeMap<PartyId, AvidMessage>> {
+        // Pending recipients are the complement of the cert's voters. (They must be a subset of
+        // the known nodes — guaranteed since `voters ⊆ nodes` is the cert's invariant.)
+        let pending_recipients: BTreeSet<PartyId> = self
+            .nodes
+            .node_ids_iter()
+            .filter(|id| !cert.voters.contains(id))
+            .collect();
         // AVID-disperse each pending recipient's existing ciphertext `E_i`, bound to `H(v)`.
         let payloads: BTreeMap<PartyId, Vec<u8>> = pending_recipients
             .iter()
             .map(|&i| (i, state.ciphertexts[i as usize].0.clone()))
             .collect();
-        self.avid.disperse_with_mutation(&payloads, mutate_shards)
+        self.avid
+            .disperse_with_mutation(&payloads, mutate_shards)
+            .map(|dispersals| {
+                dispersals
+                    .into_iter()
+                    .map(|(j, dispersal)| {
+                        (
+                            j,
+                            AvidMessage {
+                                dispersal,
+                                cert: cert.clone(),
+                            },
+                        )
+                    })
+                    .collect()
+            })
     }
 
     fn random_oracle(&self) -> RandomOracle {
@@ -511,37 +534,33 @@ impl Receiver {
         )
     }
 
-    /// 4. Verify the pessimistic phase [AvidDispersal] against a [VerifiedAvssCommonMessage] and
-    ///    emit an [EchoBuilder] which can build [Echo]es on demand. The
-    ///    receiver is expected to already hold the [VerifiedAvssCommonMessage] from the optimistic
-    ///    phase or to have fetched it from a confirming party and to have verified and created an
-    ///    [UnsignedAvssCert] from the published certificate from the optimistic phase.
-    ///    Returns also an [AvidVote] to be signed and returned to the dealer.
-    pub fn prepare_avid_echo_messages_and_vote(
+    /// 4. Verify a pessimistic-phase [AvidMessage] against a [VerifiedAvssCommonMessage] and emit
+    ///    an [EchoBuilder] which can build [Echo]es on demand. The receiver is expected to already
+    ///    hold the [VerifiedAvssCommonMessage] from the optimistic phase or to have fetched it
+    ///    from a voter. The caller must have verified the cert's signed [AvssVote]s before
+    ///    constructing the [AvidMessage] (the cert is unsigned at this layer). Returns also an
+    ///    [AvidVote] to be signed and returned to the dealer.
+    pub fn process_avid_message(
         &self,
-        message: AvidDispersal,
+        message: AvidMessage,
         verified_common: &VerifiedAvssCommonMessage,
-        verified_cert: &UnsignedAvssCert,
     ) -> FastCryptoResult<(EchoBuilder, AvidVote)> {
+        let AvidMessage { dispersal, cert } = message;
         let required_weight_of_voters = self.params.t + self.params.f;
-        if self.nodes.total_weight_of(verified_cert.voters.iter())? < required_weight_of_voters {
+        if self.nodes.total_weight_of(cert.voters.iter())? < required_weight_of_voters {
             warn!("batch_avss echo: not enough voters");
             return Err(NotEnoughWeight(required_weight_of_voters as usize));
         }
-        let expected_common_message_hash = verified_common.0.hash();
-        if verified_cert.common_message_hash != expected_common_message_hash {
+        if cert.common_message_hash != verified_common.0.hash() {
             warn!("batch_avss echo: voters attested to a different common message");
             return Err(InvalidMessage);
         }
         // Dispersal recipients and voters must partition the node set (AVSS policy).
-        if !message
-            .keys()
-            .eq(self.pending_recipients(verified_cert).iter())
-        {
+        if !dispersal.keys().eq(self.pending_recipients(&cert).iter()) {
             warn!("batch_avss echo: dispersal recipients and voters do not partition the node set");
             return Err(InvalidMessage);
         }
-        self.avid.process_dispersal(self.id, message)
+        self.avid.process_dispersal(self.id, dispersal)
     }
 
     /// Verify an [Echo] addressed to this receiver. Returns a [VerifiedEcho] suitable for
@@ -552,7 +571,7 @@ impl Receiver {
     /// [InvalidInput].
     ///
     /// `certified_top_root` can be taken from the [EchoBuilder] returned from
-    /// [Self::prepare_avid_echo_messages_and_vote] if this receiver got a valid [AvidDispersal],
+    /// [Self::process_avid_message] if this receiver got a valid [avid::Dispersal],
     /// or the published certificate over [AvidVote]s from the pessimistic phase otherwise.
     pub fn verify_avid_echo_message(
         &self,
@@ -1158,7 +1177,7 @@ fn compute_challenge_from_common_message(
 #[cfg(test)]
 mod tests {
     use super::{
-        merkle, AvidDispersal, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
+        merkle, AvidMessage, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
         DecryptionOutcome, Parameters, Receiver, ReceiverOutput, UnsignedAvssCert, VerifiedEcho,
     };
     use crate::ecies_v1;
@@ -1244,10 +1263,6 @@ mod tests {
             .collect();
         assert!(votes.len() as u16 >= t + f);
 
-        // Pessimistic phase: dispersal for parties in I = {5, 6}.
-        let messages = dealer
-            .create_avid_dispersals(&state, pending.clone())
-            .unwrap();
         // The voters are the parties we collected AvssVotes from (the complement of the
         // dispersal recipients). The caller verifies their signed AvssVotes; here we just wrap the
         // collected ids and the common message they attested to.
@@ -1255,6 +1270,9 @@ mod tests {
             voters: votes.keys().copied().collect(),
             common_message_hash: state.common.hash(),
         };
+        // Pessimistic phase: dispersal for the complement of voters (I = {5, 6}). The dealer
+        // bundles each dispersal with the cert into an [AvidMessage].
+        let messages = dealer.create_avid_dispersals(&state, cert.clone()).unwrap();
 
         // All receivers verify v (which they already have from the optimistic phase) and echo
         // for I. Every receiver also emits an `AvidVote` over `top_root` at this point —
@@ -1267,7 +1285,7 @@ mod tests {
         for r in &receivers {
             let vcm = r.verify_common_message(state.common.clone()).unwrap();
             let (builder, vote) = r
-                .prepare_avid_echo_messages_and_vote(messages[&r.id].clone(), &vcm, &cert)
+                .process_avid_message(messages[&r.id].clone(), &vcm)
                 .unwrap();
             let echoes: BTreeMap<PartyId, avid::Echo> = builder
                 .recipients()
@@ -1344,8 +1362,6 @@ mod tests {
             .process_avss_message(&opt_messages[victim_id as usize])
             .is_err());
 
-        let pending: BTreeSet<PartyId> = std::iter::once(victim_id).collect();
-        let messages = dealer.create_avid_dispersals(&state, pending).unwrap();
         // The voters are the parties we collected AvssVotes from (the complement of the
         // dispersal recipients). The caller verifies their signed AvssVotes; we wrap the ids and
         // the common message they attested to.
@@ -1353,14 +1369,15 @@ mod tests {
             voters: votes.keys().copied().collect(),
             common_message_hash: common.hash(),
         };
+        let messages = dealer.create_avid_dispersals(&state, cert.clone()).unwrap();
 
-        // Receiver 0 verifies their AvidDispersal and produces their own echo (the only
+        // Receiver 0 verifies their AvidMessage and produces their own echo (the only
         // entry, for themselves). Other receivers each emit one echo addressed to receiver 0.
         let vcm0 = receivers[victim_id as usize]
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .prepare_avid_echo_messages_and_vote(messages[&victim_id].clone(), &vcm0, &cert)
+            .process_avid_message(messages[&victim_id].clone(), &vcm0)
             .unwrap();
         let cert0_top_root = vote0.top_root;
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
@@ -1368,7 +1385,7 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .prepare_avid_echo_messages_and_vote(messages[&r.id].clone(), &vcm, &cert)
+                    .process_avid_message(messages[&r.id].clone(), &vcm)
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
@@ -1460,10 +1477,6 @@ mod tests {
             votes.insert(r.id, c);
         }
 
-        let pending: BTreeSet<PartyId> = std::iter::once(victim_id).collect();
-        let messages = dealer
-            .pessimistic_with_corrupted_dispersal(&state, pending)
-            .unwrap();
         // The voters are the parties we collected AvssVotes from (the complement of the
         // dispersal recipients). The caller verifies their signed AvssVotes; we wrap the ids and
         // the common message they attested to.
@@ -1471,6 +1484,9 @@ mod tests {
             voters: votes.keys().copied().collect(),
             common_message_hash: common.hash(),
         };
+        let messages = dealer
+            .pessimistic_with_corrupted_dispersal(&state, cert.clone())
+            .unwrap();
 
         // Receiver 0 collects echoes for their own ciphertext from the first W − f honest
         // dispersers. The last `f` dispersers (whose shards the dealer corrupted) are simulated
@@ -1484,7 +1500,7 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .prepare_avid_echo_messages_and_vote(messages[&victim_id].clone(), &vcm0, &cert)
+            .process_avid_message(messages[&victim_id].clone(), &vcm0)
             .unwrap();
         let cert0_top_root = vote0.top_root;
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
@@ -1492,7 +1508,7 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .prepare_avid_echo_messages_and_vote(messages[&r.id].clone(), &vcm, &cert)
+                    .process_avid_message(messages[&r.id].clone(), &vcm)
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
@@ -1516,7 +1532,7 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (_, vote) = r
-                    .prepare_avid_echo_messages_and_vote(messages[&r.id].clone(), &vcm, &cert)
+                    .process_avid_message(messages[&r.id].clone(), &vcm)
                     .unwrap();
                 let top_root = vote.top_root;
                 let resp = r
@@ -1651,11 +1667,11 @@ mod tests {
         fn pessimistic_with_corrupted_dispersal(
             &self,
             state: &DealerState,
-            pending: BTreeSet<PartyId>,
-        ) -> FastCryptoResult<BTreeMap<PartyId, AvidDispersal>> {
+            cert: UnsignedAvssCert,
+        ) -> FastCryptoResult<BTreeMap<PartyId, AvidMessage>> {
             let f = self.params.f as usize;
             let n = self.nodes.total_weight() as usize;
-            self.create_avid_dispersals_with_mutation(state, pending, |shards_by_recipient| {
+            self.create_avid_dispersals_with_mutation(state, cert, |shards_by_recipient| {
                 // Flip a byte in the shards held by the last `f` dispersers for receiver 0's
                 // ciphertext.
                 if let Some(shards) = shards_by_recipient.get_mut(&0) {

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -13,12 +13,12 @@ use crate::ecies_v1::{
 use crate::nodes::{Nodes, PartyId};
 use crate::polynomial::{create_secret_sharing, Eval, Poly};
 use crate::random_oracle::RandomOracle;
-use crate::threshold_schnorr::avid;
 pub use crate::threshold_schnorr::avid::{Echo, EchoBuilder, VerifiedEcho};
 use crate::threshold_schnorr::bcs::BCSSerialized;
 use crate::threshold_schnorr::recovery_proof;
 use crate::threshold_schnorr::reed_solomon::{ErasureCoder, Shard};
 use crate::threshold_schnorr::Extensions::{Challenge, Encryption, Recovery};
+use crate::threshold_schnorr::{avid, Certificate, VerifiedCertificate};
 use crate::threshold_schnorr::{random_oracle_from_sid, EG, G, S};
 use crate::types::{get_uniform_value, ShareIndex};
 use fastcrypto::error::FastCryptoError::{
@@ -99,18 +99,6 @@ pub struct AvssVote {
     pub common_message_hash: Digest,
 }
 
-/// The set of voters from the optimistic phase together with a hash of the common message they
-/// attested to.
-///
-/// This type is verified by the caller. By constructing it, the caller promises it has verified
-/// each voter's signed [AvssVote] over `common_message_hash`. The cert travels alongside the
-/// AVID dispersal inside an [AvidMessage].
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct UnsignedAvssCert {
-    pub voters: BTreeSet<PartyId>,
-    pub common_message_hash: Digest,
-}
-
 /// Dealer state carried from the optimistic to the pessimistic phase.
 #[derive(Clone, Debug)]
 pub struct DealerState {
@@ -119,28 +107,25 @@ pub struct DealerState {
 }
 
 /// Dealer-side cache that can create individual [AvidMessage]s on demand.
-pub struct AvidMessageBuilder {
+pub struct AvidMessageBuilder<C: Certificate<Payload = AvssVote>> {
     inner: avid::DispersalBuilder,
-    cert: UnsignedAvssCert,
+    avss_cert: C,
 }
 
-/// The dealer's per-receiver pessimistic-phase message.
+/// The dealer's per-receiver pessimistic-phase message. Generic over the concrete cert type
+/// `C: Certificate<Payload = AvssVote>` so different deployments can plug in their own cert.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AvidMessage {
+pub struct AvidMessage<C: Certificate<Payload = AvssVote>> {
     pub dispersal: avid::Dispersal,
-    pub cert: UnsignedAvssCert,
+    pub avss_cert: C,
 }
 
-/// An endorsement of the dealer's pessimistic message.
-pub type AvidVote = avid::Vote;
-
-/// A certified `top_root` + `pending_recipients` pair drawn from a certificate of at least W - f signed [AvidVote]s.
-///
-/// This type is verified by the caller. By constructing it, the caller promises it has verified the certificate.
-#[derive(Clone, Debug)]
-pub struct UnsignedAvidCert {
+/// An endorsement of the dealer's pessimistic dispersal.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AvidVote {
     pub top_root: merkle::Node,
     pub pending_recipients: BTreeSet<PartyId>,
+    pub common_message_hash: Digest,
 }
 
 /// The result of [Receiver::decode_ciphertext] so either a successfully reconstructed ciphertext
@@ -167,8 +152,7 @@ pub struct AvssComplaint {
 }
 
 /// A complaint by a receiver who found the AVID dispersal inconsistent — a generic AVID
-/// [avid::Complaint]. The accuser's identity and the dispersal's `top_root` are tracked
-/// out-of-band by the caller.
+/// [avid::Complaint].
 pub use avid::Complaint as AvidComplaint;
 
 /// A responder's reply to a [AvssComplaint] / [AvidComplaint]: their ciphertext and a recovery
@@ -414,31 +398,31 @@ impl Dealer {
     ///    of `cert.voters`.
     ///
     ///    All receivers that sends an [AvssVote] after the optimistic phase (even the ones who are
-    ///    late and are not in the [UnsignedAvssCert]) should get an [AvidMessage].
+    ///    late and are not in the [AvssCert]) should get an [AvidMessage].
     ///
     ///    When at least W-f votes counted by weight are returned from the receivers, the dealer can
     ///    form and publish a certificate over the [AvssVote]s.
     ///
     ///    This phase is only needed if any receiver failed to confirm in the optimistic phase. If
     ///    every receiver confirmed, the pessimistic phase can be skipped entirely.
-    pub fn create_avid_messages(
+    pub fn create_avid_messages<C: Certificate<Payload = AvssVote>>(
         &self,
         state: &DealerState,
-        cert: UnsignedAvssCert,
-    ) -> FastCryptoResult<AvidMessageBuilder> {
-        self.create_avid_messages_with_mutation(state, cert, |_| {})
+        avss_cert: C,
+    ) -> FastCryptoResult<AvidMessageBuilder<C>> {
+        self.create_avid_messages_with_mutation(state, avss_cert, |_| {})
     }
 
-    fn create_avid_messages_with_mutation(
+    fn create_avid_messages_with_mutation<C: Certificate<Payload = AvssVote>>(
         &self,
         state: &DealerState,
-        cert: UnsignedAvssCert,
+        avss_cert: C,
         mutate_shards: impl FnOnce(&mut BTreeMap<PartyId, Vec<Vec<Shard>>>),
-    ) -> FastCryptoResult<AvidMessageBuilder> {
+    ) -> FastCryptoResult<AvidMessageBuilder<C>> {
         let pending_recipients: BTreeSet<PartyId> = self
             .nodes
             .node_ids_iter()
-            .filter(|id| !cert.voters.contains(id))
+            .filter(|id| !avss_cert.signers().contains(id))
             .collect();
         let payloads: BTreeMap<PartyId, Vec<u8>> = pending_recipients
             .iter()
@@ -446,7 +430,7 @@ impl Dealer {
             .collect();
         self.avid
             .disperse_with_mutation(&payloads, mutate_shards)
-            .map(|inner| AvidMessageBuilder { inner, cert })
+            .map(|inner| AvidMessageBuilder { inner, avss_cert })
     }
 
     fn random_oracle(&self) -> RandomOracle {
@@ -541,25 +525,36 @@ impl Receiver {
     }
 
     /// 4. Verify a pessimistic-phase [AvidMessage] and emit an [EchoBuilder] which can build
-    ///    [Echo]es on demand. The caller must have verified the cert's signed [AvssVote]s before
-    ///    constructing the [AvidMessage] (the cert is unsigned at this layer). Returns also an
-    ///    [AvidVote] to be signed and returned to the dealer.
-    pub fn process_avid_message(
+    ///    [Echo]es on demand. Returns also an [AvidVote] to be signed and returned to the dealer.
+    pub fn process_avid_message<C: Certificate<Payload = AvssVote>>(
         &self,
-        message: AvidMessage,
+        message: AvidMessage<C>,
     ) -> FastCryptoResult<(EchoBuilder, AvidVote)> {
-        let AvidMessage { dispersal, cert } = message;
+        let AvidMessage {
+            dispersal,
+            avss_cert,
+        } = message;
         let required_weight_of_voters = self.params.t + self.params.f;
-        if self.nodes.total_weight_of(cert.voters.iter())? < required_weight_of_voters {
+        if self.nodes.total_weight_of(avss_cert.signers().iter())? < required_weight_of_voters {
             warn!("batch_avss echo: not enough voters");
             return Err(NotEnoughWeight(required_weight_of_voters as usize));
         }
+        avss_cert.verify()?;
         // Dispersal recipients and voters must partition the node set (AVSS policy).
-        if !dispersal.keys().eq(self.pending_recipients(&cert).iter()) {
+        if !dispersal
+            .keys()
+            .eq(self.nodes.relative_complement(avss_cert.signers()).iter())
+        {
             warn!("batch_avss echo: dispersal recipients and voters do not partition the node set");
             return Err(InvalidMessage);
         }
-        self.avid.process_dispersal(self.id, dispersal)
+        let (builder, vote) = self.avid.process_dispersal(self.id, dispersal)?;
+        let avid_vote = AvidVote {
+            top_root: vote.top_root,
+            pending_recipients: vote.pending_recipients,
+            common_message_hash: avss_cert.payload().common_message_hash,
+        };
+        Ok((builder, avid_vote))
     }
 
     /// Verify an [Echo] addressed to this receiver. Returns a [VerifiedEcho] suitable for
@@ -567,19 +562,20 @@ impl Receiver {
     ///
     /// Precondition: `self.id` is one of `cert.pending_recipients`. Echoes are only meaningful
     /// for pending recipients, so voters calling this for themselves get [InvalidInput].
-    pub fn verify_avid_echo_message(
+    pub fn verify_avid_echo_message<C: Certificate<Payload = AvidVote>>(
         &self,
         echo: Echo,
         sender: PartyId,
-        cert: &UnsignedAvidCert,
+        avid_cert: &VerifiedCertificate<C>,
     ) -> FastCryptoResult<VerifiedEcho> {
-        let receiver_idx = cert
+        let vote = avid_cert.payload();
+        let receiver_idx = vote
             .pending_recipients
             .iter()
             .position(|&id| id == self.id)
             .ok_or(InvalidInput)?;
         self.avid
-            .verify_echo(echo, sender, &cert.top_root, receiver_idx)
+            .verify_echo(echo, sender, &vote.top_root, receiver_idx)
     }
 
     /// 5. Reconstruct this receiver's ciphertext from `W − 2f` weight of [VerifiedEcho]s — the
@@ -593,11 +589,16 @@ impl Receiver {
     ///    certified on the TOB, or discard it if a different one wins.
     ///
     ///    A pending recipient should retain its decoded ciphertext for the session to answer complaints.
-    pub fn decode_ciphertext(
+    pub fn decode_ciphertext<C: Certificate<Payload = AvidVote>>(
         &self,
         echoes: &[VerifiedEcho],
         verified_common: &VerifiedAvssCommonMessage,
+        cert: &VerifiedCertificate<C>,
     ) -> FastCryptoResult<DecodeOutcome> {
+        if cert.payload().common_message_hash != verified_common.0.hash() {
+            warn!("batch_avss decode_ciphertext: AvidCert binds a different common message");
+            return Err(InvalidProof);
+        }
         let expected_hash = verified_common
             .0
             .ciphertext_hashes
@@ -627,11 +628,16 @@ impl Receiver {
     ///    The [AvssComplaint] is an encryption-layer fault carrying the accuser's ciphertext
     ///    and an ECIES recovery package. Broadcast it only after seeing a TOB certificate for
     ///    the corresponding `common_message_hash`.
-    pub fn decrypt_and_verify(
+    pub fn decrypt_and_verify<C: Certificate<Payload = AvidVote>>(
         &self,
         ciphertext: &Ciphertext,
         verified_common: &VerifiedAvssCommonMessage,
+        cert: &VerifiedCertificate<C>,
     ) -> FastCryptoResult<DecryptionOutcome> {
+        if cert.payload().common_message_hash != verified_common.0.hash() {
+            warn!("batch_avss decrypt_and_verify: AvidCert binds a different common message");
+            return Err(InvalidProof);
+        }
         self.check_ciphertext_hash(ciphertext, verified_common)?;
         match self.decrypt_and_verify_shares(ciphertext, verified_common) {
             Ok(output) => Ok(DecryptionOutcome::Valid(output)),
@@ -760,12 +766,12 @@ impl Receiver {
     }
 
     /// 7b. Validate a [AvidComplaint] and respond with this party's shares.
-    pub fn handle_avid_complaint(
+    pub fn handle_avid_complaint<C: Certificate<Payload = AvidVote>>(
         &self,
         blame: &AvidComplaint,
         accuser_id: PartyId,
         verified_common: &VerifiedAvssCommonMessage,
-        cert: &UnsignedAvidCert,
+        avid_cert: &VerifiedCertificate<C>,
         own_ciphertext: Ciphertext,
     ) -> FastCryptoResult<ComplaintResponse> {
         let expected_hash = verified_common
@@ -774,11 +780,12 @@ impl Receiver {
             .get(accuser_id as usize)
             .ok_or(InvalidProof)?;
 
+        let vote = avid_cert.payload();
         if !self.avid.complaint_is_valid(
             blame,
             accuser_id,
-            &cert.top_root,
-            &cert.pending_recipients,
+            &vote.top_root,
+            &vote.pending_recipients,
             |payload| Blake2b256::digest(payload) == *expected_hash,
         )? {
             return Err(InvalidProof);
@@ -909,14 +916,6 @@ impl Receiver {
     fn random_oracle(&self) -> RandomOracle {
         random_oracle_from_sid(&self.sid)
     }
-
-    /// Pending recipients = all parties minus those that voted in the optimistic phase.
-    fn pending_recipients(&self, cert: &UnsignedAvssCert) -> BTreeSet<PartyId> {
-        self.nodes
-            .node_ids_iter()
-            .filter(|id| !cert.voters.contains(id))
-            .collect()
-    }
 }
 
 impl Parameters {
@@ -987,12 +986,12 @@ impl AvssCommonMessage {
     }
 }
 
-impl AvidMessageBuilder {
+impl<C: Certificate<Payload = AvssVote> + Clone> AvidMessageBuilder<C> {
     /// Build the [AvidMessage] addressed to `receiver`.
-    pub fn message_for(&self, receiver: PartyId) -> FastCryptoResult<AvidMessage> {
+    pub fn message_for(&self, receiver: PartyId) -> FastCryptoResult<AvidMessage<C>> {
         Ok(AvidMessage {
             dispersal: self.inner.dispersal_for(receiver)?,
-            cert: self.cert.clone(),
+            avss_cert: self.avss_cert.clone(),
         })
     }
 }
@@ -1178,20 +1177,61 @@ fn compute_challenge_from_common_message(
 #[cfg(test)]
 mod tests {
     use super::{
-        merkle, AvidMessageBuilder, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
-        DecryptionOutcome, Parameters, Receiver, ReceiverOutput, UnsignedAvidCert,
-        UnsignedAvssCert, VerifiedEcho,
+        AvidMessageBuilder, AvidVote, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
+        DecryptionOutcome, Parameters, Receiver, ReceiverOutput, VerifiedEcho,
     };
     use crate::ecies_v1;
     use crate::ecies_v1::{Ciphertext, PublicKey};
     use crate::nodes::{Node, Nodes, PartyId};
     use crate::polynomial::{Eval, Poly};
-    use crate::threshold_schnorr::{avid, batch_avss_avid as batch_avss, EG};
+    use crate::threshold_schnorr::{avid, batch_avss_avid as batch_avss, Certificate, EG};
     use crate::types::ShareIndex;
     use fastcrypto::error::FastCryptoResult;
+    use fastcrypto::merkle;
     use fastcrypto::traits::AllowedRng;
     use itertools::Itertools;
+    use serde::{Deserialize, Serialize};
     use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+    /// Concrete [AvssCert](super::AvssCert) implementation used by these tests.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct AvssCert {
+        voters: BTreeSet<PartyId>,
+        vote: AvssVote,
+    }
+
+    impl Certificate for AvssCert {
+        type Payload = AvssVote;
+        fn signers(&self) -> &BTreeSet<PartyId> {
+            &self.voters
+        }
+        fn payload(&self) -> &AvssVote {
+            &self.vote
+        }
+        fn verify(&self) -> FastCryptoResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Concrete [AvidCert](super::AvidCert) implementation used by these tests.
+    #[derive(Clone, Debug)]
+    struct AvidCert {
+        signers: BTreeSet<PartyId>,
+        vote: AvidVote,
+    }
+
+    impl Certificate for AvidCert {
+        type Payload = AvidVote;
+        fn signers(&self) -> &BTreeSet<PartyId> {
+            &self.signers
+        }
+        fn payload(&self) -> &AvidVote {
+            &self.vote
+        }
+        fn verify(&self) -> FastCryptoResult<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn test_optimistic_then_pessimistic() {
@@ -1268,9 +1308,11 @@ mod tests {
         // The voters are the parties we collected AvssVotes from (the complement of the
         // dispersal recipients). The caller verifies their signed AvssVotes; here we just wrap the
         // collected ids and the common message they attested to.
-        let cert = UnsignedAvssCert {
+        let cert = AvssCert {
             voters: votes.keys().copied().collect(),
-            common_message_hash: state.common.hash(),
+            vote: AvssVote {
+                common_message_hash: state.common.hash(),
+            },
         };
         // Pessimistic phase: dispersal for the complement of voters (I = {5, 6}). The dealer
         // bundles each dispersal with the cert into an [AvidMessage].
@@ -1312,18 +1354,26 @@ mod tests {
                 .map(|(sender, em)| (sender as PartyId, em[&i].clone()))
                 .collect();
             let r = &receivers[i as usize];
-            let avid_cert = UnsignedAvidCert {
-                top_root: top_roots[i as usize].clone(),
-                pending_recipients: pending.clone(),
-            };
+            let avid_cert = AvidCert {
+                signers: receivers.iter().map(|r| r.id).collect(),
+                vote: AvidVote {
+                    top_root: top_roots[i as usize].clone(),
+                    pending_recipients: pending.clone(),
+                    common_message_hash: state.common.hash(),
+                },
+            }
+            .into_verified()
+            .unwrap();
             let vcm = &verified_commons[i as usize];
             let verified_echoes = echoes_for_i
                 .into_iter()
                 .map(|(sender, e)| r.verify_avid_echo_message(e, sender, &avid_cert).unwrap())
                 .collect_vec();
-            let outcome = r.decode_ciphertext(&verified_echoes, vcm).unwrap();
+            let outcome = r
+                .decode_ciphertext(&verified_echoes, vcm, &avid_cert)
+                .unwrap();
             let decoded = assert_decoded(outcome);
-            assert_valid(r.decrypt_and_verify(&decoded, vcm).unwrap());
+            assert_valid(r.decrypt_and_verify(&decoded, vcm, &avid_cert).unwrap());
         }
     }
 
@@ -1367,9 +1417,11 @@ mod tests {
         // The voters are the parties we collected AvssVotes from (the complement of the
         // dispersal recipients). The caller verifies their signed AvssVotes; we wrap the ids and
         // the common message they attested to.
-        let cert = UnsignedAvssCert {
+        let cert = AvssCert {
             voters: votes.keys().copied().collect(),
-            common_message_hash: common.hash(),
+            vote: AvssVote {
+                common_message_hash: common.hash(),
+            },
         };
         let messages = dealer.create_avid_messages(&state, cert.clone()).unwrap();
 
@@ -1381,10 +1433,12 @@ mod tests {
         let (_, vote0) = receivers[victim_id as usize]
             .process_avid_message(messages.message_for(victim_id).unwrap())
             .unwrap();
-        let avid_cert0 = UnsignedAvidCert {
-            top_root: vote0.top_root,
-            pending_recipients: vote0.pending_recipients,
-        };
+        let avid_cert0 = AvidCert {
+            signers: receivers.iter().map(|r| r.id).collect(),
+            vote: vote0,
+        }
+        .into_verified()
+        .unwrap();
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
             .iter()
             .map(|r| {
@@ -1398,11 +1452,11 @@ mod tests {
             })
             .collect();
         let outcome = receivers[victim_id as usize]
-            .decode_ciphertext(&echoes_for_victim, &vcm0)
+            .decode_ciphertext(&echoes_for_victim, &vcm0, &avid_cert0)
             .unwrap();
         let decoded = assert_decoded(outcome);
         let reveal = match receivers[victim_id as usize]
-            .decrypt_and_verify(&decoded, &vcm0)
+            .decrypt_and_verify(&decoded, &vcm0, &avid_cert0)
             .unwrap()
         {
             DecryptionOutcome::Invalid(r) => r,
@@ -1484,9 +1538,11 @@ mod tests {
         // The voters are the parties we collected AvssVotes from (the complement of the
         // dispersal recipients). The caller verifies their signed AvssVotes; we wrap the ids and
         // the common message they attested to.
-        let cert = UnsignedAvssCert {
+        let cert = AvssCert {
             voters: votes.keys().copied().collect(),
-            common_message_hash: common.hash(),
+            vote: AvssVote {
+                common_message_hash: common.hash(),
+            },
         };
         let messages = dealer
             .pessimistic_with_corrupted_dispersal(&state, cert.clone())
@@ -1506,10 +1562,12 @@ mod tests {
         let (_, vote0) = receivers[victim_id as usize]
             .process_avid_message(messages.message_for(victim_id).unwrap())
             .unwrap();
-        let avid_cert0 = UnsignedAvidCert {
-            top_root: vote0.top_root,
-            pending_recipients: vote0.pending_recipients,
-        };
+        let avid_cert0 = AvidCert {
+            signers: receivers.iter().map(|r| r.id).collect(),
+            vote: vote0,
+        }
+        .into_verified()
+        .unwrap();
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
             .iter()
             .map(|r| {
@@ -1524,7 +1582,7 @@ mod tests {
             .collect();
 
         let outcome = receivers[victim_id as usize]
-            .decode_ciphertext(&echoes_for_victim, &vcm0)
+            .decode_ciphertext(&echoes_for_victim, &vcm0, &avid_cert0)
             .unwrap();
         let blame = match outcome {
             DecodeOutcome::InvalidDispersal(blame) => blame,
@@ -1540,10 +1598,12 @@ mod tests {
                 let (_, vote) = r
                     .process_avid_message(messages.message_for(r.id).unwrap())
                     .unwrap();
-                let avid_cert = UnsignedAvidCert {
-                    top_root: vote.top_root,
-                    pending_recipients: vote.pending_recipients,
-                };
+                let avid_cert = AvidCert {
+                    signers: receivers.iter().map(|r| r.id).collect(),
+                    vote,
+                }
+                .into_verified()
+                .unwrap();
                 let resp = r
                     .handle_avid_complaint(
                         &blame,
@@ -1675,8 +1735,8 @@ mod tests {
         fn pessimistic_with_corrupted_dispersal(
             &self,
             state: &DealerState,
-            cert: UnsignedAvssCert,
-        ) -> FastCryptoResult<AvidMessageBuilder> {
+            cert: AvssCert,
+        ) -> FastCryptoResult<AvidMessageBuilder<AvssCert>> {
             let f = self.params.f as usize;
             let n = self.nodes.total_weight() as usize;
             self.create_avid_messages_with_mutation(state, cert, |shards_by_recipient| {

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -425,6 +425,10 @@ impl Dealer {
             .node_ids_iter()
             .filter(|id| !avss_cert.signers().contains(id))
             .collect();
+        if self.nodes.total_weight_of(pending_recipients.iter())? >= self.params.f {
+            warn!("batch_avss create_avid_messages_with_mutation: too many pending recipients");
+            return Err(InvalidInput);
+        }
         let payloads: BTreeMap<PartyId, Vec<u8>> = pending_recipients
             .iter()
             .map(|&i| (i, state.ciphertexts[i as usize].0.clone()))
@@ -486,6 +490,9 @@ impl Receiver {
 
     /// 2. Process an [AvssMessage] sent by the dealer in the optimistic phase.
     ///
+    ///    The receiver should provide a `verified_avss_common_message` if it has already received
+    ///    and verified the [AvssCommonMessage] from a prior delivery of this AVSS round.
+    ///
     ///    On success, returns
     ///     * a [ReceiverOutput],
     ///     * an [AvssVote] to be returned to the dealer,
@@ -499,7 +506,14 @@ impl Receiver {
     pub fn process_avss_message(
         &self,
         message: &AvssMessage,
+        verified_avss_common_message: Option<&VerifiedAvssCommonMessage>,
     ) -> FastCryptoResult<(ReceiverOutput, AvssVote, VerifiedAvssCommonMessage)> {
+        if verified_avss_common_message
+            .is_some_and(|verified| verified.0.hash() != message.common.hash())
+        {
+            warn!("batch_avss process_avss_message: provided verified common message does not match the message's common message");
+            return Err(InvalidInput);
+        }
         let verified_common = self.verify_common_message(message.common.clone())?;
         self.check_ciphertext_hash(&message.ciphertext, &verified_common)?;
         let output = self.decrypt_and_verify_shares(&message.ciphertext, &verified_common)?;
@@ -529,17 +543,35 @@ impl Receiver {
     /// 4. Verify a pessimistic-phase [AvidMessage] and emit an [EchoBuilder] which can build
     ///    [Echo]es on demand. Returns also an [AvidVote] to be signed and returned to the dealer.
     ///
+    ///    The receiver should provide a `verified_avss_common_message` if it received and verified
+    ///    an [AvssMessage] in the first AVSS round. If the receiver has no verified common (or it
+    ///    doesn't match), the AVID message should be ignored and this function returns `Ok(None)`.
+    ///
     ///    Receivers who did not receive their shares through an [AvssMessage] should wait for a
     ///    published [Certificate] over [AvidVote]s that confirms they are a pending recipient and
-    ///    then get [Echo]es from the signers and verify them with [Self::verify_avid_echo_message].
+    ///    then get the [AvssCommonMessage] and [Echo]es from the signers.
     pub fn process_avid_message<C: Certificate<Payload = AvssVote>>(
         &self,
+        verified_avss_common_message: Option<&VerifiedAvssCommonMessage>,
         message: AvidMessage<C>,
-    ) -> FastCryptoResult<(EchoBuilder, AvidVote)> {
+    ) -> FastCryptoResult<Option<(EchoBuilder, AvidVote)>> {
         let AvidMessage {
             dispersal,
             avss_cert,
         } = message;
+
+        if let Some(verified_common) = verified_avss_common_message {
+            if avss_cert.payload().common_message_hash != verified_common.0.hash() {
+                warn!(
+                    "batch_avss process_avid_message: AVSS Cert binds a different common message"
+                );
+                return Ok(None);
+            }
+        } else {
+            warn!("batch_avss process_avid_message: no verified common message available");
+            return Ok(None);
+        }
+
         let required_weight_of_voters = self.params.t + self.params.f;
         if self.nodes.total_weight_of(avss_cert.signers().iter())? < required_weight_of_voters {
             warn!("batch_avss echo: not enough voters");
@@ -559,14 +591,14 @@ impl Receiver {
             vote,
             common_message_hash: avss_cert.payload().common_message_hash,
         };
-        Ok((builder, avid_vote))
+        Ok(Some((builder, avid_vote)))
     }
 
     /// Verify an [Echo] addressed to this receiver. Returns a [VerifiedEcho] suitable for
     /// [Self::decode_ciphertext].
     ///
-    /// Precondition: `self.id` is one of `avid_cert.payload().vote.pending_recipients`. Echoes
-    /// are only meaningful for pending recipients, so voters calling this for themselves get
+    /// Precondition: `self.id` is one of the pending recipients. Echoes are only
+    /// meaningful for pending recipients, so voters calling this for themselves get
     /// [InvalidInput].
     pub fn verify_avid_echo_message<C: Certificate<Payload = AvidVote>>(
         &self,
@@ -786,7 +818,7 @@ impl Receiver {
             blame,
             accuser_id,
             &vote.top_root,
-            &vote.pending_recipients,
+            &vote.recipients,
             |payload| Blake2b256::digest(payload) == *expected_hash,
         )? {
             return Err(InvalidProof);
@@ -1235,11 +1267,13 @@ mod tests {
 
     #[test]
     fn test_optimistic_then_pessimistic() {
-        // 5 of 7 parties confirm in the optimistic phase; the remaining 2 receive their shares
-        // via the pessimistic AVID phase, gated on the optimistic certificate.
+        // 8 of 10 parties confirm in the optimistic phase; the remaining 2 receive their shares
+        // via the pessimistic AVID phase, gated on the optimistic certificate. Pending weight
+        // (= 2) must be strictly less than `f` so the dealer-side precheck in
+        // `create_avid_messages_with_mutation` accepts the cert.
         let t = 3;
-        let f = 2;
-        let n = 7u16;
+        let f = 3;
+        let n = 10u16;
         let batch_size_per_weight = 3;
 
         let mut rng = rand::thread_rng();
@@ -1287,17 +1321,17 @@ mod tests {
             })
             .collect_vec();
 
-        // Optimistic phase: only parties 0..=4 confirm; 5 and 6 are stragglers.
+        // Optimistic phase: only parties 0..=7 confirm; 8 and 9 are stragglers.
         let (state, optimistic_messages) = dealer.create_avss_messages(&mut rng).unwrap();
-        let voters: Vec<PartyId> = (0u16..=4).collect();
-        let pending: BTreeSet<PartyId> = [5u16, 6].into_iter().collect();
+        let voters: Vec<PartyId> = (0u16..=7).collect();
+        let pending: BTreeSet<PartyId> = [8u16, 9].into_iter().collect();
         let votes: BTreeMap<PartyId, AvssVote> = voters
             .iter()
             .map(|id| {
                 (
                     *id,
                     receivers[*id as usize]
-                        .process_avss_message(&optimistic_messages[id])
+                        .process_avss_message(&optimistic_messages[id], None)
                         .unwrap()
                         .1,
                 )
@@ -1329,7 +1363,8 @@ mod tests {
         for r in &receivers {
             let vcm = r.verify_common_message(state.common.clone()).unwrap();
             let (builder, avid_vote) = r
-                .process_avid_message(messages.message_for(r.id).unwrap())
+                .process_avid_message(Some(&vcm), messages.message_for(r.id).unwrap())
+                .unwrap()
                 .unwrap();
             let echoes: BTreeMap<PartyId, avid::Echo> = builder
                 .recipients()
@@ -1401,13 +1436,13 @@ mod tests {
         let mut votes: BTreeMap<PartyId, AvssVote> = BTreeMap::new();
         for r in receivers.iter().filter(|r| r.id != victim_id) {
             let (out, c, _) = r
-                .process_avss_message(&opt_messages[r.id as usize])
+                .process_avss_message(&opt_messages[r.id as usize], None)
                 .unwrap();
             outputs.insert(r.id, out);
             votes.insert(r.id, c);
         }
         assert!(receivers[victim_id as usize]
-            .process_avss_message(&opt_messages[victim_id as usize])
+            .process_avss_message(&opt_messages[victim_id as usize], None)
             .is_err());
 
         // The voters are the parties we collected AvssVotes from (the complement of the
@@ -1427,7 +1462,8 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .process_avid_message(messages.message_for(victim_id).unwrap())
+            .process_avid_message(Some(&vcm0), messages.message_for(victim_id).unwrap())
+            .unwrap()
             .unwrap();
         let avid_cert0 = AvidCert {
             signers: receivers.iter().map(|r| r.id).collect(),
@@ -1438,8 +1474,10 @@ mod tests {
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
             .iter()
             .map(|r| {
+                let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .process_avid_message(messages.message_for(r.id).unwrap())
+                    .process_avid_message(Some(&vcm), messages.message_for(r.id).unwrap())
+                    .unwrap()
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
@@ -1526,7 +1564,7 @@ mod tests {
         let mut outputs: HashMap<u16, ReceiverOutput> = HashMap::new();
         let mut votes: BTreeMap<PartyId, AvssVote> = BTreeMap::new();
         for r in receivers.iter().filter(|r| r.id != victim_id) {
-            let (out, c, _) = r.process_avss_message(&opt_messages[&r.id]).unwrap();
+            let (out, c, _) = r.process_avss_message(&opt_messages[&r.id], None).unwrap();
             outputs.insert(r.id, out);
             votes.insert(r.id, c);
         }
@@ -1556,7 +1594,8 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .process_avid_message(messages.message_for(victim_id).unwrap())
+            .process_avid_message(Some(&vcm0), messages.message_for(victim_id).unwrap())
+            .unwrap()
             .unwrap();
         let avid_cert0 = AvidCert {
             signers: receivers.iter().map(|r| r.id).collect(),
@@ -1567,8 +1606,10 @@ mod tests {
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
             .iter()
             .map(|r| {
+                let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .process_avid_message(messages.message_for(r.id).unwrap())
+                    .process_avid_message(Some(&vcm), messages.message_for(r.id).unwrap())
+                    .unwrap()
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
@@ -1592,7 +1633,8 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (_, vote) = r
-                    .process_avid_message(messages.message_for(r.id).unwrap())
+                    .process_avid_message(Some(&vcm), messages.message_for(r.id).unwrap())
+                    .unwrap()
                     .unwrap();
                 let avid_cert = AvidCert {
                     signers: receivers.iter().map(|r| r.id).collect(),

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -125,6 +125,26 @@ pub struct AvidMessage {
     pub cert: UnsignedAvssCert,
 }
 
+/// Dealer-side cache produced by [Dealer::create_avid_dispersals] that mints individual
+/// [AvidMessage]s on demand via [Self::message_for]. The eager work (RS-encoding and building the
+/// two-level Merkle commitment) happens once; per-receiver shards and proofs are materialized as
+/// each [AvidMessage] is requested — letting the dealer send out messages reactively without
+/// holding `n` copies of the dispersal in memory.
+pub struct AvidMessageBuilder {
+    inner: avid::DispersalBuilder,
+    cert: UnsignedAvssCert,
+}
+
+impl AvidMessageBuilder {
+    /// Build the [AvidMessage] addressed to `receiver`.
+    pub fn message_for(&self, receiver: PartyId) -> FastCryptoResult<AvidMessage> {
+        Ok(AvidMessage {
+            dispersal: self.inner.dispersal_for(receiver)?,
+            cert: self.cert.clone(),
+        })
+    }
+}
+
 /// An endorsement of the dealer's pessimistic dispersal.
 pub type AvidVote = avid::Vote;
 
@@ -393,9 +413,10 @@ impl Dealer {
         })
     }
 
-    /// 3. Build an [AvidMessage] per pending recipient: an AVID dispersal of that recipient's
-    ///    ciphertext, bundled with the [UnsignedAvssCert] that justifies the pessimistic phase.
-    ///    The pending recipients are derived as the complement of `cert.voters`.
+    /// 3. RS-encode and commit the pending recipients' ciphertexts via AVID, returning an
+    ///    [AvidMessageBuilder] that can mint per-receiver [AvidMessage]s on demand via
+    ///    [AvidMessageBuilder::message_for]. The pending recipients are derived as the complement
+    ///    of `cert.voters`.
     ///
     ///    Only needed if any receiver failed to confirm in the optimistic phase; if every
     ///    receiver confirmed, the pessimistic phase can be skipped entirely.
@@ -403,7 +424,7 @@ impl Dealer {
         &self,
         state: &DealerState,
         cert: UnsignedAvssCert,
-    ) -> FastCryptoResult<BTreeMap<PartyId, AvidMessage>> {
+    ) -> FastCryptoResult<AvidMessageBuilder> {
         self.create_avid_dispersals_with_mutation(state, cert, |_| {})
     }
 
@@ -412,35 +433,19 @@ impl Dealer {
         state: &DealerState,
         cert: UnsignedAvssCert,
         mutate_shards: impl FnOnce(&mut BTreeMap<PartyId, Vec<Vec<Shard>>>),
-    ) -> FastCryptoResult<BTreeMap<PartyId, AvidMessage>> {
-        // Pending recipients are the complement of the cert's voters. (They must be a subset of
-        // the known nodes — guaranteed since `voters ⊆ nodes` is the cert's invariant.)
+    ) -> FastCryptoResult<AvidMessageBuilder> {
         let pending_recipients: BTreeSet<PartyId> = self
             .nodes
             .node_ids_iter()
             .filter(|id| !cert.voters.contains(id))
             .collect();
-        // AVID-disperse each pending recipient's existing ciphertext `E_i`, bound to `H(v)`.
         let payloads: BTreeMap<PartyId, Vec<u8>> = pending_recipients
             .iter()
             .map(|&i| (i, state.ciphertexts[i as usize].0.clone()))
             .collect();
         self.avid
             .disperse_with_mutation(&payloads, mutate_shards)
-            .map(|dispersals| {
-                dispersals
-                    .into_iter()
-                    .map(|(j, dispersal)| {
-                        (
-                            j,
-                            AvidMessage {
-                                dispersal,
-                                cert: cert.clone(),
-                            },
-                        )
-                    })
-                    .collect()
-            })
+            .map(|inner| AvidMessageBuilder { inner, cert })
     }
 
     fn random_oracle(&self) -> RandomOracle {
@@ -1177,7 +1182,7 @@ fn compute_challenge_from_common_message(
 #[cfg(test)]
 mod tests {
     use super::{
-        merkle, AvidMessage, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
+        merkle, AvidMessageBuilder, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
         DecryptionOutcome, Parameters, Receiver, ReceiverOutput, UnsignedAvssCert, VerifiedEcho,
     };
     use crate::ecies_v1;
@@ -1285,7 +1290,7 @@ mod tests {
         for r in &receivers {
             let vcm = r.verify_common_message(state.common.clone()).unwrap();
             let (builder, vote) = r
-                .process_avid_message(messages[&r.id].clone(), &vcm)
+                .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                 .unwrap();
             let echoes: BTreeMap<PartyId, avid::Echo> = builder
                 .recipients()
@@ -1377,7 +1382,7 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .process_avid_message(messages[&victim_id].clone(), &vcm0)
+            .process_avid_message(messages.message_for(victim_id).unwrap(), &vcm0)
             .unwrap();
         let cert0_top_root = vote0.top_root;
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
@@ -1385,7 +1390,7 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .process_avid_message(messages[&r.id].clone(), &vcm)
+                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
@@ -1500,7 +1505,7 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .process_avid_message(messages[&victim_id].clone(), &vcm0)
+            .process_avid_message(messages.message_for(victim_id).unwrap(), &vcm0)
             .unwrap();
         let cert0_top_root = vote0.top_root;
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
@@ -1508,7 +1513,7 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .process_avid_message(messages[&r.id].clone(), &vcm)
+                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
@@ -1532,7 +1537,7 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (_, vote) = r
-                    .process_avid_message(messages[&r.id].clone(), &vcm)
+                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
                     .unwrap();
                 let top_root = vote.top_root;
                 let resp = r
@@ -1668,7 +1673,7 @@ mod tests {
             &self,
             state: &DealerState,
             cert: UnsignedAvssCert,
-        ) -> FastCryptoResult<BTreeMap<PartyId, AvidMessage>> {
+        ) -> FastCryptoResult<AvidMessageBuilder> {
             let f = self.params.f as usize;
             let n = self.nodes.total_weight() as usize;
             self.create_avid_dispersals_with_mutation(state, cert, |shards_by_recipient| {

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -88,6 +88,10 @@ pub struct AvssCommonMessage {
 }
 
 /// A [AvssCommonMessage] that has been validated against the dealer's commitments by a receiver.
+///
+/// This is purely a statement about the dealer's *common* broadcast (public keys, commitments,
+/// ciphertext hashes). It carries no claim about whether this receiver's own shares were
+/// decrypted or verified.
 #[derive(Clone, Debug)]
 pub struct VerifiedAvssCommonMessage(AvssCommonMessage);
 
@@ -543,9 +547,12 @@ impl Receiver {
     /// 4. Verify a pessimistic-phase [AvidMessage] and emit an [EchoBuilder] which can build
     ///    [Echo]es on demand. Returns also an [AvidVote] to be signed and returned to the dealer.
     ///
-    ///    The receiver should provide a `verified_avss_common_message` if it received and verified
-    ///    an [AvssMessage] in the first AVSS round. If the receiver has no verified common (or it
-    ///    doesn't match), the AVID message should be ignored and this function returns `Ok(None)`.
+    ///    The receiver should provide a `verified_avss_common_message` whenever it holds one for
+    ///    this AVSS round — whether it obtained it by verifying its shares in the optimistic phase
+    ///    ([Self::process_avss_message]) or by verifying just the common on its own
+    ///    ([Self::verify_common_message]). Only the common-level guarantee is needed here; the
+    ///    receiver's shares need not have been verified. If the receiver has no verified common (or
+    ///    it doesn't match), the AVID message should be ignored and this function returns `Ok(None)`.
     ///
     ///    Receivers who did not receive their shares through an [AvssMessage] should wait for a
     ///    published [Certificate] over [AvidVote]s that confirms they are a pending recipient and

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -118,29 +118,25 @@ pub struct DealerState {
     ciphertexts: Vec<Ciphertext>,
 }
 
-/// The dealer's per-receiver pessimistic-phase message: an [avid::Dispersal] of the receiver's ciphertext bundled with the [UnsignedAvssCert] that justifies the pessimistic phase.
+/// Dealer-side cache that can create individual [AvidMessage]s on demand.
+pub struct AvidMessageBuilder {
+    inner: avid::DispersalBuilder,
+    cert: UnsignedAvssCert,
+}
+
+/// The dealer's per-receiver pessimistic-phase message.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AvidMessage {
     pub dispersal: avid::Dispersal,
     pub cert: UnsignedAvssCert,
 }
 
-/// Dealer-side cache produced by [Dealer::create_avid_messages] that can create individual
-/// [AvidMessage]s on demand via [Self::message_for].
-pub struct AvidMessageBuilder {
-    inner: avid::DispersalBuilder,
-    cert: UnsignedAvssCert,
-}
-
-/// An endorsement of the dealer's pessimistic dispersal — a [top_root, pending_recipients] pair
-/// signed by a receiver after it verified the AVID dispersal.
+/// An endorsement of the dealer's pessimistic message.
 pub type AvidVote = avid::Vote;
 
-/// A certified `top_root` + `pending_recipients` pair drawn from a quorum of signed [AvidVote]s,
-/// giving a receiver everything it needs to verify echoes against the AVID layer.
+/// A certified `top_root` + `pending_recipients` pair drawn from a certificate of at least W - f signed [AvidVote]s.
 ///
-/// This type is verified by the caller. By constructing it, the caller promises it has verified a
-/// quorum of signed [AvidVote]s over `(top_root, pending_recipients)`.
+/// This type is verified by the caller. By constructing it, the caller promises it has verified the certificate.
 #[derive(Clone, Debug)]
 pub struct UnsignedAvidCert {
     pub top_root: merkle::Node,
@@ -417,11 +413,14 @@ impl Dealer {
     ///    [AvidMessageBuilder::message_for]. The pending recipients are derived as the complement
     ///    of `cert.voters`.
     ///
-    ///    All receivers that responds with an [AvssVote] (even the ones not in the [UnsignedAvssCert]
-    ///    that responded late) should get an [AvidMessage].
+    ///    All receivers that sends an [AvssVote] after the optimistic phase (even the ones who are
+    ///    late and are not in the [UnsignedAvssCert]) should get an [AvidMessage].
     ///
-    ///    This is only needed if any receiver failed to confirm in the optimistic phase. If every
-    ///    receiver confirmed, the pessimistic phase can be skipped entirely.
+    ///    When at least W-f votes counted by weight are returned from the receivers, the dealer can
+    ///    form and publish a certificate over the [AvssVote]s.
+    ///
+    ///    This phase is only needed if any receiver failed to confirm in the optimistic phase. If
+    ///    every receiver confirmed, the pessimistic phase can be skipped entirely.
     pub fn create_avid_messages(
         &self,
         state: &DealerState,
@@ -593,8 +592,7 @@ impl Receiver {
     ///    The [AvidComplaint] is a dispersal-layer fault. Hold it until the matching `common_message_hash` is
     ///    certified on the TOB, or discard it if a different one wins.
     ///
-    ///    A pending recipient should retain its [VerifiedEcho]es and its decoded ciphertext for the session,
-    ///    to decode and to answer complaints.
+    ///    A pending recipient should retain its decoded ciphertext for the session to answer complaints.
     pub fn decode_ciphertext(
         &self,
         echoes: &[VerifiedEcho],

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -125,28 +125,27 @@ pub struct AvidMessage {
     pub cert: UnsignedAvssCert,
 }
 
-/// Dealer-side cache produced by [Dealer::create_avid_dispersals] that mints individual
-/// [AvidMessage]s on demand via [Self::message_for]. The eager work (RS-encoding and building the
-/// two-level Merkle commitment) happens once; per-receiver shards and proofs are materialized as
-/// each [AvidMessage] is requested — letting the dealer send out messages reactively without
-/// holding `n` copies of the dispersal in memory.
+/// Dealer-side cache produced by [Dealer::create_avid_messages] that can create individual
+/// [AvidMessage]s on demand via [Self::message_for].
 pub struct AvidMessageBuilder {
     inner: avid::DispersalBuilder,
     cert: UnsignedAvssCert,
 }
 
-impl AvidMessageBuilder {
-    /// Build the [AvidMessage] addressed to `receiver`.
-    pub fn message_for(&self, receiver: PartyId) -> FastCryptoResult<AvidMessage> {
-        Ok(AvidMessage {
-            dispersal: self.inner.dispersal_for(receiver)?,
-            cert: self.cert.clone(),
-        })
-    }
-}
-
-/// An endorsement of the dealer's pessimistic dispersal.
+/// An endorsement of the dealer's pessimistic dispersal — a [top_root, pending_recipients] pair
+/// signed by a receiver after it verified the AVID dispersal.
 pub type AvidVote = avid::Vote;
+
+/// A certified `top_root` + `pending_recipients` pair drawn from a quorum of signed [AvidVote]s,
+/// giving a receiver everything it needs to verify echoes against the AVID layer.
+///
+/// This type is verified by the caller. By constructing it, the caller promises it has verified a
+/// quorum of signed [AvidVote]s over `(top_root, pending_recipients)`.
+#[derive(Clone, Debug)]
+pub struct UnsignedAvidCert {
+    pub top_root: merkle::Node,
+    pub pending_recipients: BTreeSet<PartyId>,
+}
 
 /// The result of [Receiver::decode_ciphertext] so either a successfully reconstructed ciphertext
 /// whose AVID dispersal is consistent, or a [AvidComplaint] when the collected shards either fail
@@ -414,21 +413,24 @@ impl Dealer {
     }
 
     /// 3. RS-encode and commit the pending recipients' ciphertexts via AVID, returning an
-    ///    [AvidMessageBuilder] that can mint per-receiver [AvidMessage]s on demand via
+    ///    [AvidMessageBuilder] that can create per-receiver [AvidMessage]s on demand via
     ///    [AvidMessageBuilder::message_for]. The pending recipients are derived as the complement
     ///    of `cert.voters`.
     ///
-    ///    Only needed if any receiver failed to confirm in the optimistic phase; if every
+    ///    All receivers that responds with an [AvssVote] (even the ones not in the [UnsignedAvssCert]
+    ///    that responded late) should get an [AvidMessage].
+    ///
+    ///    This is only needed if any receiver failed to confirm in the optimistic phase. If every
     ///    receiver confirmed, the pessimistic phase can be skipped entirely.
-    pub fn create_avid_dispersals(
+    pub fn create_avid_messages(
         &self,
         state: &DealerState,
         cert: UnsignedAvssCert,
     ) -> FastCryptoResult<AvidMessageBuilder> {
-        self.create_avid_dispersals_with_mutation(state, cert, |_| {})
+        self.create_avid_messages_with_mutation(state, cert, |_| {})
     }
 
-    fn create_avid_dispersals_with_mutation(
+    fn create_avid_messages_with_mutation(
         &self,
         state: &DealerState,
         cert: UnsignedAvssCert,
@@ -539,26 +541,19 @@ impl Receiver {
         )
     }
 
-    /// 4. Verify a pessimistic-phase [AvidMessage] against a [VerifiedAvssCommonMessage] and emit
-    ///    an [EchoBuilder] which can build [Echo]es on demand. The receiver is expected to already
-    ///    hold the [VerifiedAvssCommonMessage] from the optimistic phase or to have fetched it
-    ///    from a voter. The caller must have verified the cert's signed [AvssVote]s before
+    /// 4. Verify a pessimistic-phase [AvidMessage] and emit an [EchoBuilder] which can build
+    ///    [Echo]es on demand. The caller must have verified the cert's signed [AvssVote]s before
     ///    constructing the [AvidMessage] (the cert is unsigned at this layer). Returns also an
     ///    [AvidVote] to be signed and returned to the dealer.
     pub fn process_avid_message(
         &self,
         message: AvidMessage,
-        verified_common: &VerifiedAvssCommonMessage,
     ) -> FastCryptoResult<(EchoBuilder, AvidVote)> {
         let AvidMessage { dispersal, cert } = message;
         let required_weight_of_voters = self.params.t + self.params.f;
         if self.nodes.total_weight_of(cert.voters.iter())? < required_weight_of_voters {
             warn!("batch_avss echo: not enough voters");
             return Err(NotEnoughWeight(required_weight_of_voters as usize));
-        }
-        if cert.common_message_hash != verified_common.0.hash() {
-            warn!("batch_avss echo: voters attested to a different common message");
-            return Err(InvalidMessage);
         }
         // Dispersal recipients and voters must partition the node set (AVSS policy).
         if !dispersal.keys().eq(self.pending_recipients(&cert).iter()) {
@@ -571,27 +566,21 @@ impl Receiver {
     /// Verify an [Echo] addressed to this receiver. Returns a [VerifiedEcho] suitable for
     /// [Self::decode_ciphertext].
     ///
-    /// Precondition: `self.id` is one of the message's dispersal recipients. Echoes are only
-    /// meaningful for pending recipients, so voters calling this for themselves get
-    /// [InvalidInput].
-    ///
-    /// `certified_top_root` can be taken from the [EchoBuilder] returned from
-    /// [Self::process_avid_message] if this receiver got a valid [avid::Dispersal],
-    /// or the published certificate over [AvidVote]s from the pessimistic phase otherwise.
+    /// Precondition: `self.id` is one of `cert.pending_recipients`. Echoes are only meaningful
+    /// for pending recipients, so voters calling this for themselves get [InvalidInput].
     pub fn verify_avid_echo_message(
         &self,
         echo: Echo,
         sender: PartyId,
-        certified_top_root: &merkle::Node,
-        cert: &UnsignedAvssCert,
+        cert: &UnsignedAvidCert,
     ) -> FastCryptoResult<VerifiedEcho> {
-        self.avid.verify_echo(
-            echo,
-            sender,
-            certified_top_root,
-            &self.pending_recipients(cert),
-            self.id,
-        )
+        let receiver_idx = cert
+            .pending_recipients
+            .iter()
+            .position(|&id| id == self.id)
+            .ok_or(InvalidInput)?;
+        self.avid
+            .verify_echo(echo, sender, &cert.top_root, receiver_idx)
     }
 
     /// 5. Reconstruct this receiver's ciphertext from `W − 2f` weight of [VerifiedEcho]s — the
@@ -778,8 +767,7 @@ impl Receiver {
         blame: &AvidComplaint,
         accuser_id: PartyId,
         verified_common: &VerifiedAvssCommonMessage,
-        certified_top_root: &merkle::Node,
-        cert: &UnsignedAvssCert,
+        cert: &UnsignedAvidCert,
         own_ciphertext: Ciphertext,
     ) -> FastCryptoResult<ComplaintResponse> {
         let expected_hash = verified_common
@@ -791,8 +779,8 @@ impl Receiver {
         if !self.avid.complaint_is_valid(
             blame,
             accuser_id,
-            certified_top_root,
-            &self.pending_recipients(cert),
+            &cert.top_root,
+            &cert.pending_recipients,
             |payload| Blake2b256::digest(payload) == *expected_hash,
         )? {
             return Err(InvalidProof);
@@ -1001,6 +989,16 @@ impl AvssCommonMessage {
     }
 }
 
+impl AvidMessageBuilder {
+    /// Build the [AvidMessage] addressed to `receiver`.
+    pub fn message_for(&self, receiver: PartyId) -> FastCryptoResult<AvidMessage> {
+        Ok(AvidMessage {
+            dispersal: self.inner.dispersal_for(receiver)?,
+            cert: self.cert.clone(),
+        })
+    }
+}
+
 impl ShareBatch {
     /// Verify a batch of shares at share index `index` using the given challenge.
     fn verify(
@@ -1183,7 +1181,8 @@ fn compute_challenge_from_common_message(
 mod tests {
     use super::{
         merkle, AvidMessageBuilder, AvssMessage, AvssVote, Dealer, DealerState, DecodeOutcome,
-        DecryptionOutcome, Parameters, Receiver, ReceiverOutput, UnsignedAvssCert, VerifiedEcho,
+        DecryptionOutcome, Parameters, Receiver, ReceiverOutput, UnsignedAvidCert,
+        UnsignedAvssCert, VerifiedEcho,
     };
     use crate::ecies_v1;
     use crate::ecies_v1::{Ciphertext, PublicKey};
@@ -1277,7 +1276,7 @@ mod tests {
         };
         // Pessimistic phase: dispersal for the complement of voters (I = {5, 6}). The dealer
         // bundles each dispersal with the cert into an [AvidMessage].
-        let messages = dealer.create_avid_dispersals(&state, cert.clone()).unwrap();
+        let messages = dealer.create_avid_messages(&state, cert.clone()).unwrap();
 
         // All receivers verify v (which they already have from the optimistic phase) and echo
         // for I. Every receiver also emits an `AvidVote` over `top_root` at this point —
@@ -1290,7 +1289,7 @@ mod tests {
         for r in &receivers {
             let vcm = r.verify_common_message(state.common.clone()).unwrap();
             let (builder, vote) = r
-                .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                .process_avid_message(messages.message_for(r.id).unwrap())
                 .unwrap();
             let echoes: BTreeMap<PartyId, avid::Echo> = builder
                 .recipients()
@@ -1315,14 +1314,14 @@ mod tests {
                 .map(|(sender, em)| (sender as PartyId, em[&i].clone()))
                 .collect();
             let r = &receivers[i as usize];
-            let top_root = &top_roots[i as usize];
+            let avid_cert = UnsignedAvidCert {
+                top_root: top_roots[i as usize].clone(),
+                pending_recipients: pending.clone(),
+            };
             let vcm = &verified_commons[i as usize];
             let verified_echoes = echoes_for_i
                 .into_iter()
-                .map(|(sender, e)| {
-                    r.verify_avid_echo_message(e, sender, top_root, &cert)
-                        .unwrap()
-                })
+                .map(|(sender, e)| r.verify_avid_echo_message(e, sender, &avid_cert).unwrap())
                 .collect_vec();
             let outcome = r.decode_ciphertext(&verified_echoes, vcm).unwrap();
             let decoded = assert_decoded(outcome);
@@ -1374,7 +1373,7 @@ mod tests {
             voters: votes.keys().copied().collect(),
             common_message_hash: common.hash(),
         };
-        let messages = dealer.create_avid_dispersals(&state, cert.clone()).unwrap();
+        let messages = dealer.create_avid_messages(&state, cert.clone()).unwrap();
 
         // Receiver 0 verifies their AvidMessage and produces their own echo (the only
         // entry, for themselves). Other receivers each emit one echo addressed to receiver 0.
@@ -1382,19 +1381,21 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .process_avid_message(messages.message_for(victim_id).unwrap(), &vcm0)
+            .process_avid_message(messages.message_for(victim_id).unwrap())
             .unwrap();
-        let cert0_top_root = vote0.top_root;
+        let avid_cert0 = UnsignedAvidCert {
+            top_root: vote0.top_root,
+            pending_recipients: vote0.pending_recipients,
+        };
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
             .iter()
             .map(|r| {
-                let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                    .process_avid_message(messages.message_for(r.id).unwrap())
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
-                    .verify_avid_echo_message(echo, r.id, &cert0_top_root, &cert)
+                    .verify_avid_echo_message(echo, r.id, &avid_cert0)
                     .unwrap()
             })
             .collect();
@@ -1505,19 +1506,21 @@ mod tests {
             .verify_common_message(common.clone())
             .unwrap();
         let (_, vote0) = receivers[victim_id as usize]
-            .process_avid_message(messages.message_for(victim_id).unwrap(), &vcm0)
+            .process_avid_message(messages.message_for(victim_id).unwrap())
             .unwrap();
-        let cert0_top_root = vote0.top_root;
+        let avid_cert0 = UnsignedAvidCert {
+            top_root: vote0.top_root,
+            pending_recipients: vote0.pending_recipients,
+        };
         let echoes_for_victim: Vec<VerifiedEcho> = receivers
             .iter()
             .map(|r| {
-                let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (builder, _) = r
-                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                    .process_avid_message(messages.message_for(r.id).unwrap())
                     .unwrap();
                 let echo = builder.create_echo(victim_id).unwrap();
                 receivers[victim_id as usize]
-                    .verify_avid_echo_message(echo, r.id, &cert0_top_root, &cert)
+                    .verify_avid_echo_message(echo, r.id, &avid_cert0)
                     .unwrap()
             })
             .collect();
@@ -1537,16 +1540,18 @@ mod tests {
             .map(|r| {
                 let vcm = r.verify_common_message(common.clone()).unwrap();
                 let (_, vote) = r
-                    .process_avid_message(messages.message_for(r.id).unwrap(), &vcm)
+                    .process_avid_message(messages.message_for(r.id).unwrap())
                     .unwrap();
-                let top_root = vote.top_root;
+                let avid_cert = UnsignedAvidCert {
+                    top_root: vote.top_root,
+                    pending_recipients: vote.pending_recipients,
+                };
                 let resp = r
                     .handle_avid_complaint(
                         &blame,
                         victim_id,
                         &vcm,
-                        &top_root,
-                        &cert,
+                        &avid_cert,
                         state.ciphertexts[r.id as usize].clone(),
                     )
                     .unwrap();
@@ -1676,7 +1681,7 @@ mod tests {
         ) -> FastCryptoResult<AvidMessageBuilder> {
             let f = self.params.f as usize;
             let n = self.nodes.total_weight() as usize;
-            self.create_avid_dispersals_with_mutation(state, cert, |shards_by_recipient| {
+            self.create_avid_messages_with_mutation(state, cert, |shards_by_recipient| {
                 // Flip a byte in the shards held by the last `f` dispersers for receiver 0's
                 // ciphertext.
                 if let Some(shards) = shards_by_recipient.get_mut(&0) {

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -27,7 +27,6 @@ use fastcrypto::error::FastCryptoError::{
 use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::{GroupElement, MultiScalarMul, Scalar};
 use fastcrypto::hash::{Blake2b256, HashFunction};
-use fastcrypto::merkle;
 use fastcrypto::traits::AllowedRng;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -120,17 +119,19 @@ pub struct AvidMessage<C: Certificate<Payload = AvssVote>> {
     pub avss_cert: C,
 }
 
-/// An endorsement of the dealer's pessimistic dispersal.
+/// An endorsement of the dealer's pessimistic dispersal: the AVID-layer [avid::Vote]
+/// (`top_root` + `pending_recipients`) bundled with the `common_message_hash` of the AVSS
+/// instance it ratifies.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AvidVote {
-    pub top_root: merkle::Node,
-    pub pending_recipients: BTreeSet<PartyId>,
+    pub vote: avid::Vote,
     pub common_message_hash: Digest,
 }
 
-/// The result of [Receiver::decode_ciphertext] so either a successfully reconstructed ciphertext
-/// whose AVID dispersal is consistent, or a [AvidComplaint] when the collected shards either fail
-/// to RS-decode or decode to a ciphertext whose re-encoding disagrees with the ciphertext hashes.
+/// The result of [Receiver::decode_ciphertext]: either a successfully reconstructed ciphertext
+/// whose AVID dispersal is consistent, or an [AvidComplaint] when the collected shards either
+/// fail to RS-decode or decode to a ciphertext whose re-encoding disagrees with the ciphertext
+/// hashes.
 #[allow(clippy::large_enum_variant)]
 pub enum DecodeOutcome {
     Decoded(Ciphertext),
@@ -394,17 +395,17 @@ impl Dealer {
 
     /// 3. RS-encode and commit the pending recipients' ciphertexts via AVID, returning an
     ///    [AvidMessageBuilder] that can create per-receiver [AvidMessage]s on demand via
-    ///    [AvidMessageBuilder::message_for]. The pending recipients are derived as the complement
-    ///    of `cert.voters`.
+    ///    [AvidMessageBuilder::message_for]. The pending recipients are derived as the relative
+    ///    complement of `avss_cert.signers()` within the node set.
     ///
-    ///    All receivers that sends an [AvssVote] after the optimistic phase (even the ones who are
-    ///    late and are not in the [AvssCert]) should get an [AvidMessage].
+    ///    All receivers that sent an [AvssVote] in the optimistic phase — including late voters
+    ///    not in `avss_cert` — should get an [AvidMessage] from the dealer.
     ///
-    ///    When at least W-f votes counted by weight are returned from the receivers, the dealer can
-    ///    form and publish a certificate over the [AvssVote]s.
+    ///    Once `≥ W − f` weight of [AvidVote]s has been collected, the dealer can form and
+    ///    publish a certificate over those votes on the TOB.
     ///
-    ///    This phase is only needed if any receiver failed to confirm in the optimistic phase. If
-    ///    every receiver confirmed, the pessimistic phase can be skipped entirely.
+    ///    This phase is only needed if any receiver failed to confirm in the optimistic phase.
+    ///    If every receiver confirmed, the pessimistic phase can be skipped entirely.
     pub fn create_avid_messages<C: Certificate<Payload = AvssVote>>(
         &self,
         state: &DealerState,
@@ -490,10 +491,11 @@ impl Receiver {
     ///     * an [AvssVote] to be returned to the dealer,
     ///     * a [VerifiedAvssCommonMessage] to be retained for the rest of the session.
     ///
-    ///    On any failure the receiver silently ignores the message and falls through to the pessimistic phase.
+    ///    On any failure the receiver silently ignores the message and falls through to the
+    ///    pessimistic phase.
     ///
-    ///    A voter should also retain its own ciphertext (`message.ciphertext`) so it can
-    ///    answer complaints later via [Self::handle_avss_complaint] / [Self::handle_avid_complaint].
+    ///    A voter should also retain its own ciphertext (`message.ciphertext`) so it can answer
+    ///    complaints later via [Self::handle_avss_complaint] / [Self::handle_avid_complaint].
     pub fn process_avss_message(
         &self,
         message: &AvssMessage,
@@ -526,6 +528,10 @@ impl Receiver {
 
     /// 4. Verify a pessimistic-phase [AvidMessage] and emit an [EchoBuilder] which can build
     ///    [Echo]es on demand. Returns also an [AvidVote] to be signed and returned to the dealer.
+    ///
+    ///    Receivers who did not receive their shares through an [AvssMessage] should wait for a
+    ///    published [Certificate] over [AvidVote]s that confirms they are a pending recipient and
+    ///    then get [Echo]es from the signers and verify them with [Self::verify_avid_echo_message].
     pub fn process_avid_message<C: Certificate<Payload = AvssVote>>(
         &self,
         message: AvidMessage<C>,
@@ -550,8 +556,7 @@ impl Receiver {
         }
         let (builder, vote) = self.avid.process_dispersal(self.id, dispersal)?;
         let avid_vote = AvidVote {
-            top_root: vote.top_root,
-            pending_recipients: vote.pending_recipients,
+            vote,
             common_message_hash: avss_cert.payload().common_message_hash,
         };
         Ok((builder, avid_vote))
@@ -560,44 +565,40 @@ impl Receiver {
     /// Verify an [Echo] addressed to this receiver. Returns a [VerifiedEcho] suitable for
     /// [Self::decode_ciphertext].
     ///
-    /// Precondition: `self.id` is one of `cert.pending_recipients`. Echoes are only meaningful
-    /// for pending recipients, so voters calling this for themselves get [InvalidInput].
+    /// Precondition: `self.id` is one of `avid_cert.payload().vote.pending_recipients`. Echoes
+    /// are only meaningful for pending recipients, so voters calling this for themselves get
+    /// [InvalidInput].
     pub fn verify_avid_echo_message<C: Certificate<Payload = AvidVote>>(
         &self,
         echo: Echo,
         sender: PartyId,
         avid_cert: &VerifiedCertificate<C>,
     ) -> FastCryptoResult<VerifiedEcho> {
-        let vote = avid_cert.payload();
-        let receiver_idx = vote
-            .pending_recipients
-            .iter()
-            .position(|&id| id == self.id)
-            .ok_or(InvalidInput)?;
         self.avid
-            .verify_echo(echo, sender, &vote.top_root, receiver_idx)
+            .verify_echo(echo, sender, &avid_cert.payload().vote, self.id)
     }
 
-    /// 5. Reconstruct this receiver's ciphertext from `W − 2f` weight of [VerifiedEcho]s — the
-    ///    AVID decode minimum. Callers should invoke this as soon as `W − 2f` weight has
-    ///    accumulated and drop later-arriving echoes (extra shards don't change the outcome).
-    ///    Returns [DecodeOutcome::Decoded] when the dispersal is consistent and the reconstructed
-    ///    ciphertext matches [VerifiedAvssCommonMessage], or [DecodeOutcome::InvalidDispersal] (an
-    ///    [AvidComplaint]) otherwise.
+    /// 5. Reconstruct this receiver's ciphertext from at least `W − 2f` weight of
+    ///    [VerifiedEcho]s. Returns [DecodeOutcome::Decoded] if the dispersal is consistent and
+    ///    the reconstructed ciphertext matches [VerifiedAvssCommonMessage], or
+    ///    [DecodeOutcome::InvalidDispersal] (an [AvidComplaint]) otherwise.
     ///
-    ///    The [AvidComplaint] is a dispersal-layer fault. Hold it until the matching `common_message_hash` is
-    ///    certified on the TOB, or discard it if a different one wins.
+    ///    The caller should get an [AvssCommonMessage] from one of the signers of the cert and
+    ///    verify it before calling this method.
     ///
-    ///    A pending recipient should retain its decoded ciphertext for the session to answer complaints.
+    ///    An [AvidComplaint] is a dispersal-layer fault. Hold it until the matching cert on
+    ///    [AvidVote]s is certified on the TOB, or discard it if a different one wins.
+    ///
+    ///    The caller should retain its decoded ciphertext for the session to answer complaints.
     pub fn decode_ciphertext<C: Certificate<Payload = AvidVote>>(
         &self,
         echoes: &[VerifiedEcho],
         verified_common: &VerifiedAvssCommonMessage,
-        cert: &VerifiedCertificate<C>,
+        avid_cert: &VerifiedCertificate<C>,
     ) -> FastCryptoResult<DecodeOutcome> {
-        if cert.payload().common_message_hash != verified_common.0.hash() {
+        if avid_cert.payload().common_message_hash != verified_common.0.hash() {
             warn!("batch_avss decode_ciphertext: AvidCert binds a different common message");
-            return Err(InvalidProof);
+            return Err(InvalidMessage);
         }
         let expected_hash = verified_common
             .0
@@ -621,7 +622,9 @@ impl Receiver {
     }
 
     /// 6. Decrypt and verify the receiver's own shares from a successfully decoded ciphertext.
-    ///    Rejects with [InvalidMessage] if the ciphertext doesn't match the hash pinned in [VerifiedAvssCommonMessage].
+    ///    Rejects with [InvalidMessage] if the ciphertext doesn't match the hash pinned in
+    ///    [VerifiedAvssCommonMessage] or if `avid_cert` is for a different [AvssCommonMessage].
+    ///
     ///    Otherwise, yields [DecryptionOutcome::Valid] when shares verify, or
     ///    [DecryptionOutcome::Invalid] (an [AvssComplaint]) when they don't.
     ///
@@ -632,11 +635,11 @@ impl Receiver {
         &self,
         ciphertext: &Ciphertext,
         verified_common: &VerifiedAvssCommonMessage,
-        cert: &VerifiedCertificate<C>,
+        avid_cert: &VerifiedCertificate<C>,
     ) -> FastCryptoResult<DecryptionOutcome> {
-        if cert.payload().common_message_hash != verified_common.0.hash() {
+        if avid_cert.payload().common_message_hash != verified_common.0.hash() {
             warn!("batch_avss decrypt_and_verify: AvidCert binds a different common message");
-            return Err(InvalidProof);
+            return Err(InvalidMessage);
         }
         self.check_ciphertext_hash(ciphertext, verified_common)?;
         match self.decrypt_and_verify_shares(ciphertext, verified_common) {
@@ -660,8 +663,9 @@ impl Receiver {
         }
     }
 
-    /// Reject a ciphertext whose hash doesn't match the one pinned for this receiver in [VerifiedAvssCommonMessage]. This
-    /// stops a dealer from dispersing a different ciphertext via AVID.
+    /// Reject a ciphertext whose hash doesn't match the one pinned for this receiver in
+    /// [VerifiedAvssCommonMessage]. This stops a dealer from dispersing a different ciphertext
+    /// via AVID.
     fn check_ciphertext_hash(
         &self,
         ciphertext: &Ciphertext,
@@ -719,10 +723,7 @@ impl Receiver {
         })
     }
 
-    /// 7a. Validate a [AvssComplaint] and respond with this party's own shares so the accuser
-    ///     can recover. Accepts iff the ciphertext is bound to the dealer's broadcast [VerifiedAvssCommonMessage]
-    ///     (via `common_message.ciphertext_hashes[accuser_id]`) and the recovery package decrypts it to invalid
-    ///     shares.
+    /// 7a. Validate a [AvssComplaint] and respond with this party's own shares.
     pub fn handle_avss_complaint(
         &self,
         reveal: &AvssComplaint,
@@ -765,7 +766,7 @@ impl Receiver {
         Ok(self.build_complaint_response(&verified_common.0, own_ciphertext))
     }
 
-    /// 7b. Validate a [AvidComplaint] and respond with this party's shares.
+    /// 7b. Validate a [AvidComplaint] and respond with this party's own shares.
     pub fn handle_avid_complaint<C: Certificate<Payload = AvidVote>>(
         &self,
         blame: &AvidComplaint,
@@ -780,7 +781,7 @@ impl Receiver {
             .get(accuser_id as usize)
             .ok_or(InvalidProof)?;
 
-        let vote = avid_cert.payload();
+        let vote = &avid_cert.payload().vote;
         if !self.avid.complaint_is_valid(
             blame,
             accuser_id,
@@ -859,9 +860,9 @@ impl Receiver {
         })
     }
 
-    /// 8. Recover the accuser's own shares from a quorum (>= t) of [VerifiedComplaintResponse]s.
-    ///    Responses must already be validated via [Self::verify_complaint_response]. Fails if
-    ///    the responses contribute `< t` weight, or the interpolated shares fail final verification.
+    /// 8. Recover the accuser's own shares from a quorum (`≥ t`) of [VerifiedComplaintResponse]s.
+    ///    Responses must already be validated via [Self::verify_complaint_response]. Fails if the
+    ///    responses contribute `< t` weight, or the interpolated shares fail final verification.
     pub fn recover(
         &self,
         verified_common: &VerifiedAvssCommonMessage,
@@ -1187,7 +1188,6 @@ mod tests {
     use crate::threshold_schnorr::{avid, batch_avss_avid as batch_avss, Certificate, EG};
     use crate::types::ShareIndex;
     use fastcrypto::error::FastCryptoResult;
-    use fastcrypto::merkle;
     use fastcrypto::traits::AllowedRng;
     use itertools::Itertools;
     use serde::{Deserialize, Serialize};
@@ -1323,12 +1323,12 @@ mod tests {
         // pending recipients still need to decode and verify their shares before relying on
         // them, but the AvidVote attests to the dispersal layer (Merkle root), not the
         // decryption, so it's safe to publish immediately.
-        let mut top_roots: Vec<merkle::Node> = Vec::with_capacity(receivers.len());
+        let mut avid_votes: Vec<AvidVote> = Vec::with_capacity(receivers.len());
         let mut verified_commons = Vec::with_capacity(receivers.len());
         let mut echo_sets = Vec::with_capacity(receivers.len());
         for r in &receivers {
             let vcm = r.verify_common_message(state.common.clone()).unwrap();
-            let (builder, vote) = r
+            let (builder, avid_vote) = r
                 .process_avid_message(messages.message_for(r.id).unwrap())
                 .unwrap();
             let echoes: BTreeMap<PartyId, avid::Echo> = builder
@@ -1336,7 +1336,7 @@ mod tests {
                 .iter()
                 .map(|&rcpt| (rcpt, builder.create_echo(rcpt).unwrap()))
                 .collect();
-            top_roots.push(vote.top_root);
+            avid_votes.push(avid_vote);
             verified_commons.push(vcm);
             echo_sets.push(echoes);
         }
@@ -1356,11 +1356,7 @@ mod tests {
             let r = &receivers[i as usize];
             let avid_cert = AvidCert {
                 signers: receivers.iter().map(|r| r.id).collect(),
-                vote: AvidVote {
-                    top_root: top_roots[i as usize].clone(),
-                    pending_recipients: pending.clone(),
-                    common_message_hash: state.common.hash(),
-                },
+                vote: avid_votes[i as usize].clone(),
             }
             .into_verified()
             .unwrap();

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -34,9 +34,11 @@ use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;
 use crate::threshold_schnorr::Extensions::{Challenge, Encryption, Recovery};
 use fastcrypto::encoding::{Encoding, Hex};
+use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups;
 use fastcrypto::groups::ristretto255::RistrettoPoint;
 use fastcrypto::groups::GroupElement;
+use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
 
 mod avid;
@@ -76,6 +78,40 @@ enum Extensions {
     Recovery(PartyId),
     Encryption,
     Challenge,
+}
+
+/// This represents a certificate over a payload that a subset of the parties have signed.
+/// Here, the implementation is abstract, and it is up to the caller to implement the actual
+/// verification functionality.
+pub trait Certificate {
+    type Payload;
+
+    fn signers(&self) -> &BTreeSet<PartyId>;
+
+    fn payload(&self) -> &Self::Payload;
+
+    fn verify(&self) -> FastCryptoResult<()>;
+
+    #[allow(clippy::wrong_self_convention)]
+    fn into_verified(&self) -> FastCryptoResult<VerifiedCertificate<Self>>
+    where
+        Self: Clone,
+    {
+        self.verify().map(|_| VerifiedCertificate(self.clone()))
+    }
+}
+
+/// A [Certificate] that has already been verified.
+pub struct VerifiedCertificate<C>(C);
+
+impl<C: Certificate> VerifiedCertificate<C> {
+    pub fn certificate(&self) -> &C {
+        &self.0
+    }
+
+    pub fn payload(&self) -> &C::Payload {
+        self.0.payload()
+    }
 }
 
 impl Display for Extensions {

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -287,7 +287,7 @@ mod tests {
             let (_, opt_messages) = dealer.create_avss_messages(&mut rng).unwrap();
             for r in &receivers {
                 let (output, _confirm, _verified_common) =
-                    r.process_avss_message(&opt_messages[&r.id]).unwrap();
+                    r.process_avss_message(&opt_messages[&r.id], None).unwrap();
                 presigning_outputs.get_mut(&r.id).unwrap().push(output);
             }
         }


### PR DESCRIPTION
Bundle the AVID dispersal and the `UnsignedAvssCert` into a single `AvidMessage` so the receiver can enter the pessimistic phase without an out-of-band cert distribution channel — the dealer broadcasts both together.