### PR TITLE
Clean up ristretto255, bulletproofs and pedersen modules

### DIFF
--- a/fastcrypto/src/bulletproofs.rs
+++ b/fastcrypto/src/bulletproofs.rs
@@ -10,13 +10,12 @@
 //! # use fastcrypto::groups::ristretto255::RistrettoScalar;
 //! # use fastcrypto::groups::Scalar;
 //! use fastcrypto::pedersen::{Blinding, PedersenCommitment};
-//! let value = 300;
-//! let range = Bits16;
 //! let mut rng = rand::thread_rng();
-//! let blinding = Blinding::rand(&mut rng);
+//! let value = 300;
+//! let (commitment, blinding) = PedersenCommitment::commit_u64(value, &mut rng);
+//! let range = Bits16;
 //! let proof =
 //!    RangeProof::prove(value, &blinding, &range, b"dst", &mut rng).unwrap();
-//! let commitment = PedersenCommitment::new(&RistrettoScalar::from(value), &blinding);
 //! assert!(proof.verify(&commitment, &range, b"dst", &mut rng).is_ok());
 //! ```
 
@@ -25,6 +24,7 @@ use crate::error::FastCryptoResult;
 use crate::pedersen::{Blinding, PedersenCommitment, GENERATORS};
 use crate::traits::AllowedRng;
 use bulletproofs::{BulletproofGens, RangeProof as ExternalRangeProof};
+use itertools::Itertools;
 use merlin::Transcript;
 
 /// Bulletproof Range Proofs
@@ -110,17 +110,12 @@ impl RangeProof {
         }
 
         let bits = range.upper_bound_in_bits() as usize;
-        let bp_gens = BulletproofGens::new(bits, values.len());
-        let mut prover_transcript = Transcript::new(&[]);
-        prover_transcript.append_message(b"DST", dst);
-
-        // TODO: Can we avoid calculating the Pedersen commitments here?
         ExternalRangeProof::prove_multiple_with_rng(
-            &bp_gens,
+            &BulletproofGens::new(bits, values.len()),
             &GENERATORS,
-            &mut prover_transcript,
+            &mut transcript(dst),
             values,
-            &blindings.iter().map(|b| b.0 .0).collect::<Vec<_>>(),
+            &blindings.iter().map(Blinding::to_dalek).collect_vec(),
             bits,
             rng,
         )
@@ -137,19 +132,15 @@ impl RangeProof {
         rng: &mut impl AllowedRng,
     ) -> FastCryptoResult<()> {
         let bits = range.upper_bound_in_bits() as usize;
-        let bp_gens = BulletproofGens::new(bits, commitments.len());
-        let mut verifier_transcript = Transcript::new(&[]);
-        verifier_transcript.append_message(b"DST", dst);
-
         self.0
             .verify_multiple_with_rng(
-                &bp_gens,
+                &BulletproofGens::new(bits, commitments.len()),
                 &GENERATORS,
-                &mut verifier_transcript,
+                &mut transcript(dst),
                 &commitments
                     .iter()
-                    .map(|c| c.0 .0.compress())
-                    .collect::<Vec<_>>(),
+                    .map(PedersenCommitment::to_dalek)
+                    .collect_vec(),
                 bits,
                 rng,
             )
@@ -170,6 +161,13 @@ impl RangeProof {
     }
 }
 
+/// Create a transcript bound to the given domain separation tag.
+fn transcript(dst: &[u8]) -> Transcript {
+    let mut transcript = Transcript::new(&[]);
+    transcript.append_message(b"DST", dst);
+    transcript
+}
+
 #[test]
 fn test_is_in_range() {
     assert!(Range::Bits8.is_in_range(0));
@@ -186,28 +184,29 @@ fn test_is_in_range() {
 }
 
 #[test]
-fn test_range_proof_valid() {
-    use crate::groups::ristretto255::RistrettoScalar;
-
-    let range = Range::Bits32;
+fn test_range_proof() {
+    let range = Range::Bits16;
     let mut rng = rand::thread_rng();
-    let blinding = Blinding::rand(&mut rng);
+    let value = 1234u64;
+    let (commitment, blinding) = PedersenCommitment::commit_u64(value, &mut rng);
 
-    let value = 1u64;
     let proof = RangeProof::prove(value, &blinding, &range, b"test", &mut rng).unwrap();
-    let commitment = PedersenCommitment::new(&RistrettoScalar::from(value), &blinding);
+    assert!(RangeProof::prove(value, &blinding, &Range::Bits8, b"test", &mut rng).is_err());
+
     assert!(proof.verify(&commitment, &range, b"test", &mut rng).is_ok());
+    assert!(proof
+        .verify(&commitment, &range, b"other", &mut rng)
+        .is_err());
 }
 
 #[test]
 fn test_batch_range_proof_valid() {
-    use crate::groups::ristretto255::RistrettoScalar;
     let range = Range::Bits32;
     let mut rng = rand::thread_rng();
     let values = (1u64..=8).collect::<Vec<_>>();
     let (commitments, blindings) = values
         .iter()
-        .map(|&v| PedersenCommitment::commit(&RistrettoScalar::from(v), &mut rng))
+        .map(|&v| PedersenCommitment::commit_u64(v, &mut rng))
         .unzip::<_, _, Vec<_>, Vec<_>>();
     let proof =
         RangeProof::prove_batch(&values, &blindings, &range, b"test_dst", &mut rng).unwrap();
@@ -218,14 +217,12 @@ fn test_batch_range_proof_valid() {
 
 #[test]
 fn test_to_from_bytes() {
-    use crate::groups::ristretto255::RistrettoScalar;
-
     let range = Range::Bits32;
     let mut rng = rand::thread_rng();
     let values = (1u64..=8).collect::<Vec<_>>();
     let (commitments, blindings) = values
         .iter()
-        .map(|&v| PedersenCommitment::commit(&RistrettoScalar::from(v), &mut rng))
+        .map(|&v| PedersenCommitment::commit_u64(v, &mut rng))
         .unzip::<_, _, Vec<_>, Vec<_>>();
     let proof = RangeProof::prove_batch(&values, &blindings, &range, b"test", &mut rng).unwrap();
     let proof_bytes = proof.to_bytes();

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -220,9 +220,9 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
         bytes: &[u8; RISTRETTO_SCALAR_BYTE_LENGTH],
     ) -> Result<Self, FastCryptoError> {
         ExternalScalar::from_canonical_bytes(*bytes)
+            .map(RistrettoScalar)
             .into_option()
             .ok_or(InvalidInput)
-            .map(RistrettoScalar)
     }
 
     fn to_byte_array(&self) -> [u8; RISTRETTO_SCALAR_BYTE_LENGTH] {

--- a/fastcrypto/src/groups/ristretto255.rs
+++ b/fastcrypto/src/groups/ristretto255.rs
@@ -21,12 +21,12 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::RistrettoPoint as ExternalPoint;
 use curve25519_dalek::scalar::Scalar as ExternalScalar;
 use curve25519_dalek::traits::{Identity, VartimeMultiscalarMul};
-use derive_more::{Add, Div, Neg, Sub};
+use derive_more::{Add, From, Mul, Neg, Sub};
 use elliptic_curve::group::GroupEncoding;
 use elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, Expander};
-use elliptic_curve::Field;
+use elliptic_curve::{Field, Group};
 use fastcrypto_derive::GroupOpsExtend;
-use std::ops::{Add, Div, Mul};
+use std::ops::{Div, Mul};
 use zeroize::Zeroize;
 
 pub const RISTRETTO_POINT_BYTE_LENGTH: usize = 32;
@@ -68,7 +68,7 @@ impl RistrettoPoint {
 
 impl Doubling for RistrettoPoint {
     fn double(self) -> Self {
-        Self(self.0.add(self.0))
+        Self(self.0.double())
     }
 }
 
@@ -90,8 +90,7 @@ impl Div<RistrettoScalar> for RistrettoPoint {
     type Output = Result<Self, FastCryptoError>;
 
     fn div(self, rhs: RistrettoScalar) -> Self::Output {
-        let inv = rhs.inverse()?;
-        Ok(self * inv)
+        rhs.inverse().map(|inv| self * inv)
     }
 }
 
@@ -107,7 +106,7 @@ impl GroupElement for RistrettoPoint {
     type ScalarType = RistrettoScalar;
 
     fn zero() -> RistrettoPoint {
-        RistrettoPoint(ExternalPoint::identity())
+        RistrettoPoint(<curve25519_dalek::RistrettoPoint as Identity>::identity())
     }
 
     fn generator() -> Self {
@@ -124,7 +123,10 @@ impl HashToGroupElement for RistrettoPoint {
 
 impl ToFromByteArray<RISTRETTO_POINT_BYTE_LENGTH> for RistrettoPoint {
     fn from_byte_array(bytes: &[u8; RISTRETTO_POINT_BYTE_LENGTH]) -> FastCryptoResult<Self> {
-        Option::from(ExternalPoint::from_bytes(bytes).map(RistrettoPoint)).ok_or(InvalidInput)
+        ExternalPoint::from_bytes(bytes)
+            .map(RistrettoPoint)
+            .into_option()
+            .ok_or(InvalidInput)
     }
 
     fn to_byte_array(&self) -> [u8; RISTRETTO_POINT_BYTE_LENGTH] {
@@ -138,7 +140,9 @@ impl FromTrustedByteArray<RISTRETTO_POINT_BYTE_LENGTH> for RistrettoPoint {
     ) -> FastCryptoResult<Self> {
         // Note that the external crate does not distinguish between from_bytes and from_bytes_unchecked:
         // https://github.com/dalek-cryptography/curve25519-dalek/blob/11f5375375d3d52c153049f18bd8b1b7669c2565/curve25519-dalek/src/ristretto.rs#L1221-L1224
-        Option::from(ExternalPoint::from_bytes_unchecked(bytes).map(RistrettoPoint))
+        ExternalPoint::from_bytes_unchecked(bytes)
+            .map(RistrettoPoint)
+            .into_option()
             .ok_or(InvalidInput)
     }
 }
@@ -146,7 +150,9 @@ impl FromTrustedByteArray<RISTRETTO_POINT_BYTE_LENGTH> for RistrettoPoint {
 serialize_deserialize_with_to_from_byte_array!(RistrettoPoint);
 
 /// Represents a scalar.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Add, Sub, Neg, Div, GroupOpsExtend, Zeroize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, From, Add, Sub, Mul, Neg, GroupOpsExtend, Zeroize)]
+#[mul(forward)]
+#[from(forward)]
 pub struct RistrettoScalar(pub(crate) ExternalScalar);
 
 impl RistrettoScalar {
@@ -161,33 +167,12 @@ impl RistrettoScalar {
     }
 }
 
-impl From<u128> for RistrettoScalar {
-    fn from(value: u128) -> RistrettoScalar {
-        RistrettoScalar(ExternalScalar::from(value))
-    }
-}
-
-impl From<u64> for RistrettoScalar {
-    fn from(value: u64) -> RistrettoScalar {
-        RistrettoScalar(ExternalScalar::from(value))
-    }
-}
-
-impl Mul<RistrettoScalar> for RistrettoScalar {
-    type Output = RistrettoScalar;
-
-    fn mul(self, rhs: RistrettoScalar) -> RistrettoScalar {
-        RistrettoScalar(self.0 * rhs.0)
-    }
-}
-
 #[allow(clippy::suspicious_arithmetic_impl)]
 impl Div<RistrettoScalar> for RistrettoScalar {
     type Output = Result<RistrettoScalar, FastCryptoError>;
 
     fn div(self, rhs: RistrettoScalar) -> Result<RistrettoScalar, FastCryptoError> {
-        let inv = rhs.inverse()?;
-        Ok(self * inv)
+        rhs.inverse().map(|inv| self * inv)
     }
 }
 
@@ -234,9 +219,10 @@ impl ToFromByteArray<RISTRETTO_SCALAR_BYTE_LENGTH> for RistrettoScalar {
     fn from_byte_array(
         bytes: &[u8; RISTRETTO_SCALAR_BYTE_LENGTH],
     ) -> Result<Self, FastCryptoError> {
-        Ok(RistrettoScalar(
-            Option::from(ExternalScalar::from_canonical_bytes(*bytes)).ok_or(InvalidInput)?,
-        ))
+        ExternalScalar::from_canonical_bytes(*bytes)
+            .into_option()
+            .ok_or(InvalidInput)
+            .map(RistrettoScalar)
     }
 
     fn to_byte_array(&self) -> [u8; RISTRETTO_SCALAR_BYTE_LENGTH] {

--- a/fastcrypto/src/pedersen.rs
+++ b/fastcrypto/src/pedersen.rs
@@ -39,6 +39,10 @@ impl PedersenCommitment {
         )
     }
 
+    pub fn commit_u64(value: u64, rng: &mut impl AllowedRng) -> (Self, Blinding) {
+        Self::commit(&RistrettoScalar::from(value), rng)
+    }
+
     pub fn commit(value: &RistrettoScalar, rng: &mut impl AllowedRng) -> (Self, Blinding) {
         let blinding = Blinding::rand(rng);
         (Self::new(value, &blinding), blinding)
@@ -51,11 +55,21 @@ impl PedersenCommitment {
             Err(InvalidProof)
         }
     }
+
+    /// The compressed representation of this commitment as a [curve25519_dalek::ristretto::CompressedRistretto].
+    pub(crate) fn to_dalek(&self) -> curve25519_dalek::ristretto::CompressedRistretto {
+        self.0 .0.compress()
+    }
 }
 
 impl Blinding {
     pub fn rand(rng: &mut impl AllowedRng) -> Self {
         Self(RistrettoScalar::rand(rng))
+    }
+
+    /// The underlying scalar as a [curve25519_dalek::scalar::Scalar].
+    pub(crate) fn to_dalek(&self) -> curve25519_dalek::scalar::Scalar {
+        self.0 .0
     }
 }
 


### PR DESCRIPTION
Extract shared transcript setup in `bulletproofs.rs` and move the dalek-type interop conversions into `pedersen.rs` via `as_dalek` helpers, so all external-crate representation knowledge lives in one place.

Also simplifies some calls in the modules.