### PR TITLE
More small refactors across threshold_schnorr

### DIFF
--- a/fastcrypto-tbls/src/threshold_schnorr/complaint.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/complaint.rs
@@ -1,18 +1,19 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: This module is only used by the legacy `batch_avss` and can be removed once that is gone.
+
 use crate::ecies_v1;
 use crate::ecies_v1::RecoveryPackage;
 use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;
 use crate::threshold_schnorr::bcs::BCSSerialized;
+use crate::threshold_schnorr::recovery_proof::check_recovered_shares;
 use crate::threshold_schnorr::Extensions::{Encryption, Recovery};
 use crate::threshold_schnorr::EG;
-use fastcrypto::error::FastCryptoError::InvalidProof;
 use fastcrypto::error::FastCryptoResult;
 use fastcrypto::traits::AllowedRng;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 
 /// A complaint by an accuser that it could not decrypt or verify its shares.
 /// Given enough responses to the complaint, the accuser can recover its shares.
@@ -32,35 +33,15 @@ impl Complaint {
         verifier: impl Fn(&S) -> FastCryptoResult<()>,
     ) -> FastCryptoResult<()> {
         // Check that the recovery package is valid, and if not, return an error since the complaint is invalid.
-        let buffer = ciphertext.decrypt_with_recovery_package(
-            &self.proof,
-            &random_oracle.extend(&Recovery(self.accuser_id).to_string()),
-            &random_oracle.extend(&Encryption.to_string()),
-            enc_pk,
-            self.accuser_id as usize,
-        )?;
-
-        let Ok(shares) = S::from_bytes(&buffer) else {
-            debug!(
-                "Complaint by party {} is valid: Failed to deserialize shares",
-                self.accuser_id
-            );
-            return Ok(());
-        };
-
-        if verifier(&shares).is_ok() {
-            debug!(
-                "Complaint by party {} is invalid: Shares verify correctly",
-                self.accuser_id
-            );
-            Err(InvalidProof)
-        } else {
-            debug!(
-                "Complaint by party {} is valid: Shares do not verify correctly",
-                self.accuser_id
-            );
-            Ok(())
-        }
+        ciphertext
+            .decrypt_with_recovery_package(
+                &self.proof,
+                &random_oracle.extend(&Recovery(self.accuser_id).to_string()),
+                &random_oracle.extend(&Encryption.to_string()),
+                enc_pk,
+                self.accuser_id as usize,
+            )
+            .and_then(|buffer| check_recovered_shares(&buffer, verifier))
     }
 
     pub fn create(

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -141,12 +141,11 @@ impl<C: Certificate> VerifiedCertificate<C> {
 
 impl Display for Extensions {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let result = match self {
-            Recovery(accuser) => format!("recovery of {accuser}"),
-            Encryption => "encryption".to_string(),
-            Challenge => "challenge".to_string(),
-        };
-        write!(f, "{result}")
+        match self {
+            Recovery(accuser) => write!(f, "recovery of {accuser}"),
+            Encryption => write!(f, "encryption"),
+            Challenge => write!(f, "challenge"),
+        }
     }
 }
 

--- a/fastcrypto-tbls/src/threshold_schnorr/pascal_matrix.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/pascal_matrix.rs
@@ -47,7 +47,7 @@ impl<C: GroupElement> Iterator for LazyPascalVectorMultiplier<C> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.height - self.counter;
+        let remaining = self.remaining();
         (remaining, Some(remaining))
     }
 }

--- a/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
@@ -61,14 +61,15 @@ impl Presignatures {
         if batch_size_per_weight == 0 {
             return Err(InvalidInput);
         }
+        let batch_size_per_weight = batch_size_per_weight as usize;
 
         // Recover each dealer's weight from its public key count, which works even for a zero-weight party.
         let weights = outputs
             .iter()
             .map(|o| {
                 let batch_size = o.public_keys.len();
-                (batch_size % batch_size_per_weight as usize == 0)
-                    .then_some(batch_size / batch_size_per_weight as usize)
+                (batch_size % batch_size_per_weight == 0)
+                    .then_some(batch_size / batch_size_per_weight)
                     .ok_or(InvalidInput)
             })
             .collect::<FastCryptoResult<Vec<_>>>()?;
@@ -76,6 +77,9 @@ impl Presignatures {
         if total_weight_of_outputs < params.t as usize {
             return Err(InvalidInput);
         }
+
+        // The number of rows the Pascal multiplier folds the dealers' shares into.
+        let height = total_weight_of_outputs - params.f as usize;
 
         // This party's weight, aka it's number of shares
         let my_weight =
@@ -88,7 +92,7 @@ impl Presignatures {
                 && o.my_shares
                     .try_uniform_batch_size()
                     .ok()
-                    .is_none_or(|bs| bs != *w * batch_size_per_weight as usize)
+                    .is_none_or(|bs| bs != *w * batch_size_per_weight)
         }) {
             return Err(InvalidInput);
         }
@@ -97,8 +101,8 @@ impl Presignatures {
         let secret = (0..my_weight as usize)
             .map(|i| {
                 LazyPascalMatrixMultiplier::new(
-                    total_weight_of_outputs - params.f as usize,
-                    (0..batch_size_per_weight as usize)
+                    height,
+                    (0..batch_size_per_weight)
                         .map(|j| {
                             outputs
                                 .iter()
@@ -114,8 +118,8 @@ impl Presignatures {
             .collect_vec();
 
         let public = LazyPascalMatrixMultiplier::new(
-            total_weight_of_outputs - params.f as usize,
-            (0..batch_size_per_weight as usize)
+            height,
+            (0..batch_size_per_weight)
                 .map(|j| {
                     outputs
                         .iter()
@@ -127,8 +131,7 @@ impl Presignatures {
         );
 
         // Sanity check that the multiplier sizes match the expected nonce count.
-        let expected_len =
-            (total_weight_of_outputs - params.f as usize) * batch_size_per_weight as usize;
+        let expected_len = height * batch_size_per_weight;
         assert!(secret.iter().all(|s| s.len() == expected_len));
         assert_eq!(public.len(), expected_len);
 

--- a/fastcrypto-tbls/src/threshold_schnorr/recovery_proof.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/recovery_proof.rs
@@ -45,7 +45,7 @@ impl RecoveryProof {
                 enc_pk,
                 accuser_id as usize,
             )
-            .and_then(|buffer| check_recovered_shares(&buffer, verifier))
+            .and_then(|bytes| check_recovered_shares(&bytes, verifier))
     }
 
     pub fn create(

--- a/fastcrypto-tbls/src/threshold_schnorr/recovery_proof.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/recovery_proof.rs
@@ -12,7 +12,6 @@ use fastcrypto::error::FastCryptoError::InvalidProof;
 use fastcrypto::error::FastCryptoResult;
 use fastcrypto::traits::AllowedRng;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 
 /// Cryptographic proof attached to a complaint: an ECIES recovery package that opens the
 /// dealer's shared ciphertext with the accuser's private key and produces shares that fail a
@@ -37,36 +36,16 @@ impl RecoveryProof {
         verifier: impl Fn(&S) -> FastCryptoResult<()>,
     ) -> FastCryptoResult<()> {
         // Check that the recovery package is valid, and if not, return an error since the complaint is invalid.
-        let buffer = shared.decrypt_with_recovery_package(
-            ciphertext,
-            &self.0,
-            &random_oracle.extend(&Recovery(accuser_id).to_string()),
-            &random_oracle.extend(&Encryption.to_string()),
-            enc_pk,
-            accuser_id as usize,
-        )?;
-
-        let Ok(shares) = S::from_bytes(&buffer) else {
-            debug!(
-                "Complaint by party {} is valid: Failed to deserialize shares",
-                accuser_id
-            );
-            return Ok(());
-        };
-
-        if verifier(&shares).is_ok() {
-            debug!(
-                "Complaint by party {} is invalid: Shares verify correctly",
-                accuser_id
-            );
-            Err(InvalidProof)
-        } else {
-            debug!(
-                "Complaint by party {} is valid: Shares do not verify correctly",
-                accuser_id
-            );
-            Ok(())
-        }
+        shared
+            .decrypt_with_recovery_package(
+                ciphertext,
+                &self.0,
+                &random_oracle.extend(&Recovery(accuser_id).to_string()),
+                &random_oracle.extend(&Encryption.to_string()),
+                enc_pk,
+                accuser_id as usize,
+            )
+            .and_then(|buffer| check_recovered_shares(&buffer, verifier))
     }
 
     pub fn create(
@@ -81,5 +60,18 @@ impl RecoveryProof {
             &random_oracle.extend(&Recovery(accuser_id).to_string()),
             rng,
         ))
+    }
+}
+
+/// Given the `buffer` decrypted from an accuser's recovery package, decide whether their complaint
+/// holds: it is valid ([`Ok`]) when the bytes fail to deserialize or the recovered shares fail
+/// `verifier`, and invalid ([`InvalidProof`]) when the shares verify correctly.
+pub(crate) fn check_recovered_shares<S: BCSSerialized>(
+    bytes: &[u8],
+    verifier: impl Fn(&S) -> FastCryptoResult<()>,
+) -> FastCryptoResult<()> {
+    match S::from_bytes(bytes) {
+        Ok(shares) if verifier(&shares).is_ok() => Err(InvalidProof),
+        _ => Ok(()),
     }
 }

--- a/fastcrypto-tbls/src/threshold_schnorr/reed_solomon.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/reed_solomon.rs
@@ -136,6 +136,9 @@ type Element = [u8; ELEMENT_SIZE_IN_BYTES];
 /// Size in bytes of one `GF(2^16)` element.
 const ELEMENT_SIZE_IN_BYTES: usize = 2;
 
+/// Size in bytes of the `u32` length prefix framing an encoded payload.
+const LEN_PREFIX_SIZE: usize = std::mem::size_of::<u32>();
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Shard(pub(crate) Vec<u8>);
@@ -152,9 +155,7 @@ impl ErasureCoder {
     pub fn new(n: usize, k: usize) -> FastCryptoResult<Self> {
         // The code is defined over GF(2^16), which has 2^16 = 65536 elements; n cannot exceed
         // that or the evaluation points would collide.
-        if k == 0 || n <= k || n > 65536 {
-            return Err(InvalidInput);
-        }
+        Self::check_parameters(n, k)?;
         ReedSolomon::new(k, n - k)
             .map_err(|_| InvalidInput)
             .map(Self)
@@ -174,7 +175,7 @@ impl ErasureCoder {
             return Err(InvalidInput);
         }
         let len = u32::try_from(data.len()).map_err(|_| InvalidInput)?;
-        let framed_len = std::mem::size_of::<u32>() + data.len();
+        let framed_len = LEN_PREFIX_SIZE + data.len();
         let shard_size = framed_len.div_ceil(ELEMENT_SIZE_IN_BYTES * self.0.data_shard_count());
         let bytes_per_shard = ELEMENT_SIZE_IN_BYTES * shard_size;
         let mut framed = Vec::with_capacity(bytes_per_shard * self.0.total_shard_count());
@@ -221,18 +222,15 @@ impl ErasureCoder {
             .flatten()
             .flatten()
             .collect();
-        if framed.len() < std::mem::size_of::<u32>() {
+        if framed.len() < LEN_PREFIX_SIZE {
             return Err(InvalidInput);
         }
-        let len =
-            u32::from_le_bytes(framed[..std::mem::size_of::<u32>()].try_into().unwrap()) as usize;
-        let end = std::mem::size_of::<u32>()
-            .checked_add(len)
-            .ok_or(InvalidInput)?;
+        let len = u32::from_le_bytes(framed[..LEN_PREFIX_SIZE].try_into().unwrap()) as usize;
+        let end = LEN_PREFIX_SIZE.checked_add(len).ok_or(InvalidInput)?;
         if end > framed.len() {
             return Err(InvalidInput);
         }
-        Ok(framed[std::mem::size_of::<u32>()..end].to_vec())
+        Ok(framed[LEN_PREFIX_SIZE..end].to_vec())
     }
 }
 

--- a/fastcrypto-tbls/src/threshold_schnorr/signing.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/signing.rs
@@ -32,12 +32,7 @@ pub fn generate_partial_signatures(
     verifying_key: &G,
     derivation_address: Option<&Address>,
 ) -> FastCryptoResult<(G, Vec<Eval<S>>)> {
-    let r_g = public_presig + G::generator() * beacon_value;
-
-    // Since both the public_presig and the beacon_value are random, this should happen only with negligible probability.
-    if r_g == G::zero() {
-        return Err(FastCryptoError::GeneralOpaqueError);
-    }
+    let r_g = compute_nonce(&public_presig, beacon_value)?;
 
     // In BIP-340, the nonce R must have an even Y coordinate.
     // If it doesn't, we negate the secret nonce to get a new nonce R' = -R with an even Y.
@@ -152,10 +147,7 @@ pub fn finalize_schnorr_signature(
     derivation_address: Option<&Address>,
 ) -> FastCryptoResult<SchnorrSignature> {
     // Compute the nonce R for the signature.
-    let r_g = public_presig + G::generator() * beacon_value;
-    if r_g == G::zero() {
-        return Err(FastCryptoError::GeneralOpaqueError);
-    }
+    let r_g = compute_nonce(public_presig, beacon_value)?;
 
     // In acc. with BIP-0340, we need to ensure the nonce R has an even Y coordinate.
     // If it doesn't, we subtract the beacon value instead of adding it like it is done for the secret shares.
@@ -170,10 +162,11 @@ pub fn finalize_schnorr_signature(
     let verifying_key = if let Some(address) = derivation_address {
         let tweak = compute_tweak(verifying_key, address)?;
         let derived_vk = derive_verifying_key_internal(verifying_key, address)?;
+        let h = tweak * bip0340_hash(&r_g, &derived_vk, message)?;
         if derived_vk.has_even_y()? {
-            s += tweak * bip0340_hash(&r_g, &derived_vk, message)?;
+            s += h;
         } else {
-            s -= tweak * bip0340_hash(&r_g, &derived_vk, message)?;
+            s -= h;
         }
         derived_vk
     } else {
@@ -186,6 +179,17 @@ pub fn finalize_schnorr_signature(
     SchnorrPublicKey::try_from(&verifying_key)?.verify(message, &signature)?;
 
     Ok(signature)
+}
+
+/// Compute the signature nonce `R = public_presig + G * beacon_value`. Since both inputs are
+/// random, the identity element occurs only with negligible probability and is rejected with
+/// [`FastCryptoError::GeneralOpaqueError`].
+fn compute_nonce(public_presig: &G, beacon_value: &S) -> FastCryptoResult<G> {
+    let r_g = *public_presig + G::generator() * beacon_value;
+    if r_g == G::zero() {
+        return Err(FastCryptoError::GeneralOpaqueError);
+    }
+    Ok(r_g)
 }
 
 fn bip0340_hash(r_g: &G, vk: &G, message: &[u8]) -> FastCryptoResult<S> {


### PR DESCRIPTION
Some cleanups across the threshold_schnorr module. Left `batch_avss.rs` untouched since it's marked for removal.

No functional changes or changes to public facing APIs.