### PR TITLE
[tschnorr] fix doc typos and clarify parameter-validation scope

### DIFF
--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -696,9 +696,9 @@ mod tests {
         // Worst case for total weight <= 2500: the maximum number of nodes (Nodes::MAX_NODES = 1000,
         // which maximizes the per-recipient encryption overhead) summing to the maximum total weight
         // 2500, with t as large as the parameters allow (which maximizes the feldman commitment of t
-        // group elements). The security/liveness condition `t + 2f <= total_weight` (which the
-        // caller is expected to enforce; see `Parameters`) means that with `f = 1` the largest
-        // admissible `t` is `total_weight - 2`, which is what we pick here.
+        // group elements). We pick `t` as large as the security/liveness condition
+        // `t + 2f <= total_weight` allows (which the caller is expected to enforce, see
+        // `Parameters`).
         let num_nodes = 1000usize;
         let total_weight = 2500u16;
         let params = Parameters {

--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -696,9 +696,7 @@ mod tests {
         // Worst case for total weight <= 2500: the maximum number of nodes (Nodes::MAX_NODES = 1000,
         // which maximizes the per-recipient encryption overhead) summing to the maximum total weight
         // 2500, with t as large as the parameters allow (which maximizes the feldman commitment of t
-        // group elements). We pick `t` as large as the security/liveness condition
-        // `t + 2f <= total_weight` allows (which the caller is expected to enforce, see
-        // `Parameters`).
+        // group elements). We pick `t` as large as `t + 2f <= total_weight` allows.
         let num_nodes = 1000usize;
         let total_weight = 2500u16;
         let params = Parameters {

--- a/fastcrypto-tbls/src/threshold_schnorr/avss.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/avss.rs
@@ -696,8 +696,9 @@ mod tests {
         // Worst case for total weight <= 2500: the maximum number of nodes (Nodes::MAX_NODES = 1000,
         // which maximizes the per-recipient encryption overhead) summing to the maximum total weight
         // 2500, with t as large as the parameters allow (which maximizes the feldman commitment of t
-        // group elements). `Parameters::validate` requires `total_weight >= 2f + t`, so with `f = 1`
-        // the largest admissible `t` is `total_weight - 2`.
+        // group elements). The security/liveness condition `t + 2f <= total_weight` (which the
+        // caller is expected to enforce; see `Parameters`) means that with `f = 1` the largest
+        // admissible `t` is `total_weight - 2`, which is what we pick here.
         let num_nodes = 1000usize;
         let total_weight = 2500u16;
         let params = Parameters {

--- a/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/batch_avss_avid.rs
@@ -234,8 +234,7 @@ impl Dealer {
     /// * `dealer_id` is the id of this dealer as a node.
     /// * `params` carries the reconstruction thresholds.
     /// * `sid` is a session identifier that should be unique for each invocation of a dealer, but
-    ///   the same
-    ///   for all parties in the same session.
+    ///   the same for all parties in the same session.
     /// * `batch_size_per_weight` is the number of secrets a dealer should deal per weight it has.
     pub fn new(
         nodes: Nodes<EG>,
@@ -482,7 +481,7 @@ impl Receiver {
     ) -> FastCryptoResult<Self> {
         let _ = nodes.node_id_to_node(id)?;
 
-        // The dealer is expected to deal a number of nonces proportional to it's weight
+        // The dealer is expected to deal a number of nonces proportional to its weight
         let batch_size = nodes.weight_of(dealer_id)? as usize * batch_size_per_weight as usize;
 
         let total_weight = nodes.total_weight();

--- a/fastcrypto-tbls/src/threshold_schnorr/key_derivation.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/key_derivation.rs
@@ -22,7 +22,7 @@ pub(crate) fn compute_tweak(vk: &G, address: &Address) -> FastCryptoResult<S> {
 }
 
 /// Derive a new verifying key from an existing one and a Sui address.
-/// This is computed as vk + [compute_tweak](vk, index) * G.
+/// This is computed as vk + [compute_tweak](vk, address) * G.
 ///
 /// The derived key can have odd Y coordinate and hence not be a valid BIP-0340 Schnorr public key.
 /// However, the signing protocol ensures that the signature will be valid for the derived key
@@ -33,7 +33,7 @@ pub(crate) fn derive_verifying_key_internal(vk: &G, address: &Address) -> FastCr
     Ok(vk + G::generator() * compute_tweak(vk, address)?)
 }
 
-/// Derive a new verifying key from an existing one and a Sui addreess.
+/// Derive a new verifying key from an existing one and a Sui address.
 /// This will be a valid BIP-0340 Schnorr public key.
 ///
 /// Returns an error if `vk` is the identity point.

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -28,10 +28,8 @@
 //! * <i>f</i> = maximum Byzantine weight
 //! * <i>t</i> = threshold for signing
 //!
-//! For the original weights, the caller must ensure <i>t + 2f &leq; W</i> and <i>t > f</i>. These
-//! may be relaxed for a reduced weight set, so [Parameters::validate] only checks what is needed
-//! functionally here (`t < W` and `t &geq; f`), not the trust and liveness assumptions. See
-//! [Parameters] for details.
+//! For the weights used here, [Parameters::validate] checks what is needed functionally:
+//! `t < W` and `t &geq; f`.
 
 use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;
@@ -82,12 +80,8 @@ pub struct Parameters {
 }
 
 impl Parameters {
-    /// Validate `(t, f)` against the given total weight `W`, checking `0 < f`, `t < W` and
-    /// `t ≥ f`.
-    ///
-    /// This only checks what must hold for a (possibly reduced) weight set. The full
-    /// security/liveness conditions `t > f` and `t + 2f ≤ W` are required for the original weights
-    /// and are the caller's responsibility (see the module-level documentation).
+    /// Validate `(t, f)` against the given total weight `W`, checking what is needed functionally
+    /// for the weights used here: `0 < f`, `t < W` and `t ≥ f`.
     pub fn validate(&self, total_weight: u16) -> FastCryptoResult<()> {
         let Parameters { t, f } = *self;
         if f == 0 || t == 0 || t >= total_weight || t < f {

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -81,24 +81,12 @@ pub struct Parameters {
 }
 
 impl Parameters {
-    /// Validate `(t, f)` against the given total weight `W`:
-    /// * `0 < f, t < W`
-    /// * `t ≥ f`
+    /// Validate `(t, f)` against the given total weight `W`, checking `0 < f`, `t < W` and
+    /// `t ≥ f`.
     ///
-    /// Note that we allow `t = f` here since this may happen after weight reduction.
-    ///
-    /// This is intentionally weaker than the full security/liveness conditions `t > f` and
-    /// `t + 2f ≤ W` (see the module-level documentation). Those are **not** enforced here and
-    /// are the caller's responsibility to guarantee:
-    /// * `t > f` is required for privacy: with `t = f`, an adversary controlling `f` weight holds
-    ///   `t` shares and could reconstruct the secret. `t = f` is only safe as a post-weight-reduction
-    ///   artifact, where the actual adversarial weight is provably `< t`.
-    /// * `t + 2f ≤ W` is required for liveness of the pessimistic phase, which needs `t + f` weight
-    ///   of voters while only `W - f` weight is guaranteed honest.
-    ///
-    /// Violating either condition does not break the correctness of the honest-path computation
-    /// (nothing panics and outputs are correct), which is why they are left to the caller rather
-    /// than rejected here.
+    /// This only checks what must hold for a (possibly reduced) weight set. The full
+    /// security/liveness conditions `t > f` and `t + 2f ≤ W` are required for the original weights
+    /// and are the caller's responsibility (see the module-level documentation).
     pub fn validate(&self, total_weight: u16) -> FastCryptoResult<()> {
         let Parameters { t, f } = *self;
         if f == 0 || t == 0 || t >= total_weight || t < f {

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -28,8 +28,9 @@
 //! * <i>f</i> = maximum Byzantine weight
 //! * <i>t</i> = threshold for signing
 //!
-//! For the weights used here, [Parameters::validate] checks what is needed functionally:
-//! `t < W` and `t &geq; f`.
+//! For the weights used here, [Parameters::validate] checks the basic invariants `t < W` and
+//! `t &geq; f`. The AVID-based nonce protocol additionally requires `W > 2f` (enforced in
+//! `Avid::new`).
 
 use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;
@@ -80,8 +81,10 @@ pub struct Parameters {
 }
 
 impl Parameters {
-    /// Validate `(t, f)` against the given total weight `W`, checking what is needed functionally
-    /// for the weights used here: `0 < f`, `t < W` and `t ≥ f`.
+    /// Validate `(t, f)` against the given total weight `W`, checking the basic invariants needed
+    /// for the sharing here: `0 < f`, `t < W` and `t ≥ f`. Note the AVID-based nonce protocol has a
+    /// further requirement, `W > 2f`, which is enforced when its Reed-Solomon coder is built
+    /// (`Avid::new`), not here.
     pub fn validate(&self, total_weight: u16) -> FastCryptoResult<()> {
         let Parameters { t, f } = *self;
         if f == 0 || t == 0 || t >= total_weight || t < f {

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -29,8 +29,9 @@
 //! * <i>t</i> = threshold for signing
 //!
 //! For the original weights, the caller must ensure <i>t + 2f &leq; W</i> and <i>t > f</i>. These
-//! may be relaxed for a reduced weight set (e.g. <i>t = f</i>), so [Parameters::validate] only
-//! checks the weaker `t < W` and `t &geq; f`. See [Parameters] for details.
+//! may be relaxed for a reduced weight set, so [Parameters::validate] only checks what is needed
+//! functionally here (`t < W` and `t &geq; f`), not the trust and liveness assumptions. See
+//! [Parameters] for details.
 
 use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -28,10 +28,9 @@
 //! * <i>f</i> = maximum Byzantine weight
 //! * <i>t</i> = threshold for signing
 //!
-//! For the protocols to be secure and live, the following conditions must hold:
-//! <i>t + 2f &leq; W</i> and <i>t > f</i>. These are <b>not</b> fully enforced by
-//! [Parameters::validate] (which only checks the weaker `t < W` and `t &geq; f`); it is the
-//! caller's responsibility to ensure them. See [Parameters] for details.
+//! For the original weights, the caller must ensure <i>t + 2f &leq; W</i> and <i>t > f</i>. These
+//! may be relaxed for a reduced weight set (e.g. <i>t = f</i>), so [Parameters::validate] only
+//! checks the weaker `t < W` and `t &geq; f`. See [Parameters] for details.
 
 use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;

--- a/fastcrypto-tbls/src/threshold_schnorr/mod.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/mod.rs
@@ -24,11 +24,14 @@
 //! reused for all instances of the protocols.
 //!
 //! The thresholds are defined as follows:
-//! * <i>n</i> = total number of parties
-//! * <i>f</i> = maximum number of Byzantine parties
+//! * <i>W</i> = total weight of all parties
+//! * <i>f</i> = maximum Byzantine weight
 //! * <i>t</i> = threshold for signing
 //!
-//! The following conditions must hold: <i>t + 2f &leq; n</i> and <i>t > f</i>.
+//! For the protocols to be secure and live, the following conditions must hold:
+//! <i>t + 2f &leq; W</i> and <i>t > f</i>. These are <b>not</b> fully enforced by
+//! [Parameters::validate] (which only checks the weaker `t < W` and `t &geq; f`); it is the
+//! caller's responsibility to ensure them. See [Parameters] for details.
 
 use crate::nodes::PartyId;
 use crate::random_oracle::RandomOracle;
@@ -84,6 +87,19 @@ impl Parameters {
     /// * `t ≥ f`
     ///
     /// Note that we allow `t = f` here since this may happen after weight reduction.
+    ///
+    /// This is intentionally weaker than the full security/liveness conditions `t > f` and
+    /// `t + 2f ≤ W` (see the module-level documentation). Those are **not** enforced here and
+    /// are the caller's responsibility to guarantee:
+    /// * `t > f` is required for privacy: with `t = f`, an adversary controlling `f` weight holds
+    ///   `t` shares and could reconstruct the secret. `t = f` is only safe as a post-weight-reduction
+    ///   artifact, where the actual adversarial weight is provably `< t`.
+    /// * `t + 2f ≤ W` is required for liveness of the pessimistic phase, which needs `t + f` weight
+    ///   of voters while only `W - f` weight is guaranteed honest.
+    ///
+    /// Violating either condition does not break the correctness of the honest-path computation
+    /// (nothing panics and outputs are correct), which is why they are left to the caller rather
+    /// than rejected here.
     pub fn validate(&self, total_weight: u16) -> FastCryptoResult<()> {
         let Parameters { t, f } = *self;
         if f == 0 || t == 0 || t >= total_weight || t < f {
@@ -618,7 +634,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Mock DKG
-        // Here, we don't assume anything about the partity of the vk's Y coordinate since we can't do that in a real DKG.
+        // Here, we don't assume anything about the parity of the vk's Y coordinate since we can't do that in a real DKG.
         let sk_element = S::rand(&mut rng);
         let vk_element = G::generator() * sk_element;
 
@@ -755,7 +771,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Mock DKG
-        // Here, we don't assume anything about the partity of the vk's Y coordinate since we can't do that in a real DKG.
+        // Here, we don't assume anything about the parity of the vk's Y coordinate since we can't do that in a real DKG.
         let sk_element = S::rand(&mut rng);
         let vk_element = G::generator() * sk_element;
 

--- a/fastcrypto-tbls/src/threshold_schnorr/pascal_matrix.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/pascal_matrix.rs
@@ -6,7 +6,7 @@ use fastcrypto::groups::GroupElement;
 
 /// Lazy evaluation of Pascal matrix-vector multiplication, returning one element at a time.
 /// Computing the next element takes O(h) group additions, where h is the height of the input column.
-/// The construction is from https://eprint.iacr.org/2023/1175.pdf.
+/// The construction is from <https://eprint.iacr.org/2023/1175.pdf>.
 pub struct LazyPascalVectorMultiplier<C> {
     height: usize,
     buffer: Vec<C>,
@@ -56,7 +56,7 @@ impl<C: GroupElement> ExactSizeIterator for LazyPascalVectorMultiplier<C> {}
 
 /// Lazy evaluation of Pascal matrix multiplication, returning one element at a time.
 /// Computing the next element takes O(h) group additions, where h is the height of the given columns.
-/// The construction is from https://eprint.iacr.org/2023/1175.pdf.
+/// The construction is from <https://eprint.iacr.org/2023/1175.pdf>.
 pub struct LazyPascalMatrixMultiplier<C> {
     height: usize,
     buffers: Vec<Vec<C>>,

--- a/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/presigning.rs
@@ -94,7 +94,7 @@ impl Presignatures {
             total_weight_of_outputs - (params.t as usize - 1)
         };
 
-        // This party's weight, aka it's number of shares
+        // This party's weight, aka its number of shares
         let my_weight =
             get_uniform_value(outputs.iter().map(|o| o.my_shares.weight())).ok_or(InvalidInput)?;
 

--- a/fastcrypto-tbls/src/threshold_schnorr/reed_solomon.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/reed_solomon.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// The distance is given by `n - k + 1`, where `n` is the length of `a`.
 ///
 /// The implementation follows the Gao decoding algorithm
-/// (see https://www.math.clemson.edu/~sgao/papers/RS.pdf).
+/// (see <https://www.math.clemson.edu/~sgao/papers/RS.pdf>).
 pub struct RSDecoder {
     g0: Poly<S>,
     a: Vec<ShareIndex>,

--- a/fastcrypto-tbls/src/threshold_schnorr/signing.rs
+++ b/fastcrypto-tbls/src/threshold_schnorr/signing.rs
@@ -18,7 +18,7 @@ use tracing::warn;
 /// The presigning tuple must be taken from a [Presignatures] iterator, the other parties should use the same tuple and one tuple may only be used once.
 /// Returns also the public nonce R.
 ///
-/// The signatures produced follow the BIP-0340 standard (https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki).
+/// The signatures produced follow the BIP-0340 standard (<https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki>).
 ///
 /// If a derivation index is provided, a new verifying key is derived for this index (see
 /// [derive_verifying_key]), and the signature is adjusted accordingly.


### PR DESCRIPTION
Documentation-only cleanup of the `threshold_schnorr` module. Fixes typos and wraps bare URLs in doc comments. Also revises the threshold-condition docs so they describe what `Parameters::validate` actually checks for the weights used here (`t < W`, `t ≥ f`) and points to the AVID nonce protocol's further `W > 2f` requirement, which is enforced in `Avid::new`.