### PR TITLE
ci: run tests with nextest instead of cargo test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,13 +58,16 @@ jobs:
       # make sure benches don't bit-rot
       - name: build benches
         run: cargo build --benches --features experimental,copy_key,unsecure_schemes
-      - name: cargo test
-      # TODO: `cargo nextest run` doesn't work on windows, so we use `cargo test` instead
+      # nextest runs each test binary in parallel (cargo test runs them one after
+      # another), which is where most of this step's wall-clock time went.
       # Skip zklogin e2e tests (run separately in non-required workflow)
-        run: cargo test --all-features -- --skip zk_login_e2e
+      - name: cargo nextest
+        run: cargo nextest run --all-features -E 'not test(zk_login_e2e)'
+      # nextest does not run doctests, and the step above used to run them
+      # implicitly under --all-features, so run them here under the same features.
       - name: Doctests
         run: |
-          cargo test --doc --features experimental,copy_key,unsecure_schemes
+          cargo test --doc --all-features
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,8 +58,6 @@ jobs:
       # make sure benches don't bit-rot
       - name: build benches
         run: cargo build --benches --features experimental,copy_key,unsecure_schemes
-      # nextest runs each test binary in parallel (cargo test runs them one after
-      # another), which is where most of this step's wall-clock time went.
       # Skip zklogin e2e tests (run separately in non-required workflow)
       - name: cargo nextest
         run: cargo nextest run --all-features -E 'not test(zk_login_e2e)'


### PR DESCRIPTION
The `test` job already installs `cargo-nextest` but never used it since both os's ran `cargo test`, and the `TODO` claiming nextest doesn't work on Windows is stale. Switching to `cargo nextest run` parallelizes test binaries across the workspace's crates instead of running them one after another: locally the test step drops from 154s to 102s.

Since nextest doesn't run doctests and the old `cargo test --all-features` step was running them implicitly, the `Doctests` step moves to `--all-features` to preserve that coverage.

Note that this is not why Windows is much slower. Across the last 29 `rust.yml` runs, `windows-ghcloud` waited an average of 2673s (44 min) for a runner versus 14s on `ubuntu-ghcloud`, with a worst case of 2h46m — while the jobs themselves took 534s and 489s respectively, i.e. the Windows build is only ~9% slower and its `cargo test` step is actually marginally faster. Fixing that needs a bigger `windows-ghcloud` pool, or taking Windows off the per-PR critical path.