### PR TITLE
Derive serde for BP++ proofs instead of hand-written to/from bytes

### DIFF
--- a/fastcrypto/src/bulletproofspp/README.md
+++ b/fastcrypto/src/bulletproofspp/README.md
@@ -25,21 +25,21 @@ base to `pedersen::H` and the blinding base to `pedersen::G`, so existing
 ## Proof sizes
 
 Proofs are serialized with `bcs`: every group element and scalar in its canonical
-32-byte encoding, and one length prefix for each of the norm-linear proof's three
-vectors. That gives a size of `64*log2(nm) + 163` bytes, where `nm = max(M*b/4, 16)`
-rounded up to a power of two.
+32-byte encoding, and one length prefix for each of the norm-linear proof's two
+variable-length vectors (its final `l` is a single scalar). That gives a size of
+`64*log2(nm) + 162` bytes, where `nm = max(M*b/4, 16)` rounded up to a power of two.
 The table below compares BulletProofs (BP) and BulletProofs++ proof sizes for different (aggregate) range proof configurations.
 
 | Config | BP (bytes) | BP++ (bytes) | smaller |
 | --- | ---: | ---: | ---: |
-| 16-bit x1 | 544 | 419 | 23% |
-| 32-bit x1 | 608 | 419 | 31% |
-| 64-bit x1 | 672 | 419 | 38% |
-| 16-bit x4 | 672 | 419 | 38% |
-| 16-bit x8 | 736 | 483 | 34% |
-| 32-bit x8 | 800 | 547 | 32% |
-| 64-bit x16 | 928 | 675 | 27% |
-| 64-bit x32 | 992 | 739 | 26% |
+| 16-bit x1 | 544 | 418 | 23% |
+| 32-bit x1 | 608 | 418 | 31% |
+| 64-bit x1 | 672 | 418 | 38% |
+| 16-bit x4 | 672 | 418 | 38% |
+| 16-bit x8 | 736 | 482 | 34% |
+| 32-bit x8 | 800 | 546 | 32% |
+| 64-bit x16 | 928 | 674 | 27% |
+| 64-bit x32 | 992 | 738 | 26% |
 
 ## Benchmarks
 

--- a/fastcrypto/src/bulletproofspp/README.md
+++ b/fastcrypto/src/bulletproofspp/README.md
@@ -24,20 +24,22 @@ base to `pedersen::H` and the blinding base to `pedersen::G`, so existing
 
 ## Proof sizes
 
-Proofs have a size of `64*log2(nm) + 160` bytes, where `nm = max(M*b/4, 16)` rounded up
-to a power of two. 
+Proofs are serialized with `bcs`: every group element and scalar in its canonical
+32-byte encoding, and one length prefix for each of the norm-linear proof's three
+vectors. That gives a size of `64*log2(nm) + 163` bytes, where `nm = max(M*b/4, 16)`
+rounded up to a power of two.
 The table below compares BulletProofs (BP) and BulletProofs++ proof sizes for different (aggregate) range proof configurations.
 
 | Config | BP (bytes) | BP++ (bytes) | smaller |
 | --- | ---: | ---: | ---: |
-| 16-bit x1 | 544 | 416 | 24% |
-| 32-bit x1 | 608 | 416 | 32% |
-| 64-bit x1 | 672 | 416 | 38% |
-| 16-bit x4 | 672 | 416 | 38% |
-| 16-bit x8 | 736 | 480 | 35% |
-| 32-bit x8 | 800 | 544 | 32% |
-| 64-bit x16 | 928 | 672 | 28% |
-| 64-bit x32 | 992 | 736 | 26% |
+| 16-bit x1 | 544 | 419 | 23% |
+| 32-bit x1 | 608 | 419 | 31% |
+| 64-bit x1 | 672 | 419 | 38% |
+| 16-bit x4 | 672 | 419 | 38% |
+| 16-bit x8 | 736 | 483 | 34% |
+| 32-bit x8 | 800 | 547 | 32% |
+| 64-bit x16 | 928 | 675 | 27% |
+| 64-bit x32 | 992 | 739 | 26% |
 
 ## Benchmarks
 

--- a/fastcrypto/src/bulletproofspp/README.md
+++ b/fastcrypto/src/bulletproofspp/README.md
@@ -24,22 +24,23 @@ base to `pedersen::H` and the blinding base to `pedersen::G`, so existing
 
 ## Proof sizes
 
-Proofs are serialized with `bcs`: every group element and scalar in its canonical
-32-byte encoding, and one length prefix for each of the norm-linear proof's two
-variable-length vectors (its final `l` is a single scalar). That gives a size of
-`64*log2(nm) + 162` bytes, where `nm = max(M*b/4, 16)` rounded up to a power of two.
+Proofs are serialized with `bcs` as a flat sequence of canonical 32-byte group
+elements and scalars, with no length prefixes: the shape is not on the wire, so
+`RangeProof::from_bytes` takes the range and batch size it will be verified
+against. That gives a size of `64*log2(nm) + 160` bytes, where
+`nm = max(M*b/4, 16)` rounded up to a power of two.
 The table below compares BulletProofs (BP) and BulletProofs++ proof sizes for different (aggregate) range proof configurations.
 
 | Config | BP (bytes) | BP++ (bytes) | smaller |
 | --- | ---: | ---: | ---: |
-| 16-bit x1 | 544 | 418 | 23% |
-| 32-bit x1 | 608 | 418 | 31% |
-| 64-bit x1 | 672 | 418 | 38% |
-| 16-bit x4 | 672 | 418 | 38% |
-| 16-bit x8 | 736 | 482 | 34% |
-| 32-bit x8 | 800 | 546 | 32% |
-| 64-bit x16 | 928 | 674 | 27% |
-| 64-bit x32 | 992 | 738 | 26% |
+| 16-bit x1 | 544 | 416 | 24% |
+| 32-bit x1 | 608 | 416 | 32% |
+| 64-bit x1 | 672 | 416 | 38% |
+| 16-bit x4 | 672 | 416 | 38% |
+| 16-bit x8 | 736 | 480 | 35% |
+| 32-bit x8 | 800 | 544 | 32% |
+| 64-bit x16 | 928 | 672 | 28% |
+| 64-bit x32 | 992 | 736 | 26% |
 
 ## Benchmarks
 

--- a/fastcrypto/src/bulletproofspp/circuit.rs
+++ b/fastcrypto/src/bulletproofspp/circuit.rs
@@ -29,7 +29,7 @@ type S = RistrettoScalar;
 const CR_POWERS: [i32; H_LEN - 1] = [-1, 1, 2, 3, 5, 6, 7];
 
 /// Circuit proof: the four commitments plus the norm-linear proof.
-/// For 1x64: 4 + 6 group elements + 3 scalars + 3 bcs length prefixes = 419
+/// For 1x64: 4 + 6 group elements + 3 scalars + 2 bcs length prefixes = 418
 /// bytes. The vector lengths in `nl_proof` are declared on the wire; the
 /// verifier rejects any shape other than the one the statement implies.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -649,16 +649,16 @@ mod tests {
     }
 
     /// The spec's batched configurations, with their expected norm-linear
-    /// proof shapes (rounds, final l, final n), plus the widths not
-    /// instantiated there (8-bit, 64-bit x M).
+    /// proof shapes (rounds, final n), plus the widths not instantiated
+    /// there (8-bit, 64-bit x M).
     #[test]
     fn test_roundtrip_batched_configs() {
         let mut rng = rand::thread_rng();
         let configs: [(Range, usize, usize, usize); 8] = [
-            (Range::Bits16, 2, 3, 2), // 416 bytes
-            (Range::Bits16, 4, 3, 2), // 416 bytes
-            (Range::Bits16, 8, 3, 4), // 480 bytes
-            (Range::Bits32, 8, 4, 4), // 544 bytes
+            (Range::Bits16, 2, 3, 2), // 418 bytes
+            (Range::Bits16, 4, 3, 2), // 418 bytes
+            (Range::Bits16, 8, 3, 4), // 482 bytes
+            (Range::Bits32, 8, 4, 4), // 546 bytes
             (Range::Bits8, 1, 3, 2),
             (Range::Bits8, 4, 3, 2),
             (Range::Bits16, 5, 3, 4), // non-power-of-two digit count
@@ -676,12 +676,8 @@ mod tests {
                 .collect();
             let (gens, params, proof, v_commitments) = prove_batch(range, &values);
             assert_eq!(
-                (
-                    proof.nl_proof.rounds.len(),
-                    proof.nl_proof.l_final.len(),
-                    proof.nl_proof.n_final.len()
-                ),
-                (rounds, 1, n_final),
+                (proof.nl_proof.rounds.len(), proof.nl_proof.n_final.len()),
+                (rounds, n_final),
                 "unexpected shape for {n_bits}x{m}"
             );
             assert!(

--- a/fastcrypto/src/bulletproofspp/circuit.rs
+++ b/fastcrypto/src/bulletproofspp/circuit.rs
@@ -14,7 +14,7 @@ use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::groups::{GroupElement, MultiScalarMul, Scalar};
 use crate::pedersen::Range;
 use crate::traits::AllowedRng;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::array::from_fn;
 
 use crate::bulletproofspp::crs::{dims, Generators, BASE, H_LEN};
@@ -28,6 +28,24 @@ type S = RistrettoScalar;
 /// slots 1..7. The gap at 4 keeps `C_S` out of the value row.
 const CR_POWERS: [i32; H_LEN - 1] = [-1, 1, 2, 3, 5, 6, 7];
 
+/// Largest `log2(nm)` a decoded proof may claim; bounds the shape check in
+/// [deserialize_nl_proof] far above any practical statement (2^32 norm slots
+/// is 2^28 values of 64 bits).
+const MAX_LOG_NM: u32 = 32;
+
+/// Deserialize a norm-linear proof, rejecting shapes no norm length gives.
+fn deserialize_nl_proof<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<NormLinearProof, D::Error> {
+    let proof = NormLinearProof::deserialize(deserializer)?;
+    let shape = (proof.rounds.len(), proof.n_final.len());
+    (BASE.ilog2()..=MAX_LOG_NM)
+        .map(|k| norm_linear::proof_shape(H_LEN, 1usize << k))
+        .any(|valid| valid == shape)
+        .then_some(proof)
+        .ok_or_else(|| de::Error::custom("no norm length gives this proof shape"))
+}
+
 /// Circuit proof: the four commitments plus the norm-linear proof.
 /// For 1x64: 4 + 6 group elements + 3 scalars + 2 bcs length prefixes = 418
 /// bytes. The vector lengths in `nl_proof` are declared on the wire; the
@@ -38,6 +56,7 @@ pub(crate) struct CircuitProof {
     pub(crate) c_o: RistrettoPoint,
     pub(crate) c_r: RistrettoPoint,
     pub(crate) c_s: RistrettoPoint,
+    #[serde(deserialize_with = "deserialize_nl_proof")]
     pub(crate) nl_proof: NormLinearProof,
 }
 
@@ -646,6 +665,38 @@ mod tests {
                 "roundtrip failed for {value}"
             );
         }
+    }
+
+    /// A decoded proof must carry a shape that some norm length produces.
+    /// Whether it is *this* statement's shape stays verification's job.
+    #[test]
+    fn test_impossible_shape_rejected_at_decoding() {
+        let (gens, params, proof, v_commitments) = prove_batch(Range::Bits16, &[7, 9]);
+        assert!(verify_batch(&gens, &params, &proof, &v_commitments).is_ok());
+        let shape = |p: &CircuitProof| (p.nl_proof.rounds.len(), p.nl_proof.n_final.len());
+        assert_eq!(shape(&proof), (3, 2));
+
+        // Shapes no norm length gives are rejected at decoding.
+        let mut short_round = proof.clone();
+        short_round.nl_proof.rounds.pop();
+        let mut odd_finals = proof.clone();
+        odd_finals.nl_proof.n_final.push(S::zero());
+        for bad in [short_round, odd_finals] {
+            let bytes = bcs::to_bytes(&bad).unwrap();
+            assert!(
+                bcs::from_bytes::<CircuitProof>(&bytes).is_err(),
+                "shape {:?} accepted",
+                shape(&bad)
+            );
+        }
+
+        // A shape another norm length does produce decodes, and fails at
+        // verification against this statement instead.
+        let mut other_nm = proof.clone();
+        other_nm.nl_proof.n_final.extend([S::zero(), S::zero()]);
+        assert_eq!(shape(&other_nm), (3, 4)); // the nm = 32 shape
+        let decoded: CircuitProof = bcs::from_bytes(&bcs::to_bytes(&other_nm).unwrap()).unwrap();
+        assert!(verify_batch(&gens, &params, &decoded, &v_commitments).is_err());
     }
 
     /// The spec's batched configurations, with their expected norm-linear

--- a/fastcrypto/src/bulletproofspp/circuit.rs
+++ b/fastcrypto/src/bulletproofspp/circuit.rs
@@ -13,8 +13,8 @@ use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::groups::{GroupElement, MultiScalarMul, Scalar};
 use crate::pedersen::Range;
-use crate::serde_helpers::ToFromByteArray;
 use crate::traits::AllowedRng;
+use serde::{Deserialize, Serialize};
 use std::array::from_fn;
 
 use crate::bulletproofspp::crs::{dims, Generators, BASE, H_LEN};
@@ -28,55 +28,17 @@ type S = RistrettoScalar;
 /// slots 1..7. The gap at 4 keeps `C_S` out of the value row.
 const CR_POWERS: [i32; H_LEN - 1] = [-1, 1, 2, 3, 5, 6, 7];
 
-/// Largest `log2(nm)` a decoded proof may claim; bounds the shape search in
-/// [CircuitProof::from_bytes] far above any practical statement (2^32 norm
-/// slots is 2^28 values of 64 bits).
-const MAX_LOG_NM: u32 = 32;
-
 /// Circuit proof: the four commitments plus the norm-linear proof.
-/// For 1x64: 4 + 6 group elements + 3 scalars = 416 bytes.
-#[derive(Clone, Debug)]
+/// For 1x64: 4 + 6 group elements + 3 scalars + 3 bcs length prefixes = 419
+/// bytes. The vector lengths in `nl_proof` are declared on the wire; the
+/// verifier rejects any shape other than the one the statement implies.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct CircuitProof {
     pub(crate) c_l: RistrettoPoint,
     pub(crate) c_o: RistrettoPoint,
     pub(crate) c_r: RistrettoPoint,
     pub(crate) c_s: RistrettoPoint,
     pub(crate) nl_proof: NormLinearProof,
-}
-
-impl CircuitProof {
-    /// Serialize: `C_L, C_O, C_R, C_S`, then the norm-linear proof.
-    pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(4 * 32 + self.nl_proof.serialized_len());
-        for point in [&self.c_l, &self.c_o, &self.c_r, &self.c_s] {
-            bytes.extend(point.to_byte_array());
-        }
-        bytes.extend(self.nl_proof.to_bytes());
-        bytes
-    }
-
-    /// Deserialize. The length of the norm-linear part selects the norm
-    /// length `nm` (a power of two from `BASE` to `2^MAX_LOG_NM`), which
-    /// fixes the proof shape; consistency with the statement is checked at
-    /// verification.
-    pub(crate) fn from_bytes(bytes: &[u8]) -> FastCryptoResult<Self> {
-        if bytes.len() < 4 * 32 {
-            return Err(FastCryptoError::InvalidInput);
-        }
-        let (head, tail) = bytes.split_at(4 * 32);
-        let nm = (BASE.ilog2()..=MAX_LOG_NM)
-            .map(|k| 1usize << k)
-            .find(|&nm| NormLinearProof::serialized_len_for(H_LEN, nm) == tail.len())
-            .ok_or(FastCryptoError::InvalidInput)?;
-        let mut chunks = head.chunks_exact(32);
-        Ok(CircuitProof {
-            c_l: decode_next(&mut chunks)?,
-            c_o: decode_next(&mut chunks)?,
-            c_r: decode_next(&mut chunks)?,
-            c_s: decode_next(&mut chunks)?,
-            nl_proof: NormLinearProof::from_bytes(tail, H_LEN, nm)?,
-        })
-    }
 }
 
 /// Dimensions of a batched instance: `m` values in `range`, `d = bits/4`

--- a/fastcrypto/src/bulletproofspp/circuit.rs
+++ b/fastcrypto/src/bulletproofspp/circuit.rs
@@ -14,11 +14,11 @@ use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::groups::{GroupElement, MultiScalarMul, Scalar};
 use crate::pedersen::Range;
 use crate::traits::AllowedRng;
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::Serialize;
 use std::array::from_fn;
 
 use crate::bulletproofspp::crs::{dims, Generators, BASE, H_LEN};
-use crate::bulletproofspp::norm_linear::{self, NormLinearProof};
+use crate::bulletproofspp::norm_linear::{self, NormLinearProof, NormLinearProofSeed};
 use crate::bulletproofspp::transcript::BpppTranscript;
 use crate::bulletproofspp::util::*;
 
@@ -28,36 +28,41 @@ type S = RistrettoScalar;
 /// slots 1..7. The gap at 4 keeps `C_S` out of the value row.
 const CR_POWERS: [i32; H_LEN - 1] = [-1, 1, 2, 3, 5, 6, 7];
 
-/// Largest `log2(nm)` a decoded proof may claim; bounds the shape check in
-/// [deserialize_nl_proof] far above any practical statement (2^32 norm slots
-/// is 2^28 values of 64 bits).
-const MAX_LOG_NM: u32 = 32;
-
-/// Deserialize a norm-linear proof, rejecting shapes no norm length gives.
-fn deserialize_nl_proof<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<NormLinearProof, D::Error> {
-    let proof = NormLinearProof::deserialize(deserializer)?;
-    let shape = (proof.rounds.len(), proof.n_final.len());
-    (BASE.ilog2()..=MAX_LOG_NM)
-        .map(|k| norm_linear::proof_shape(H_LEN, 1usize << k))
-        .any(|valid| valid == shape)
-        .then_some(proof)
-        .ok_or_else(|| de::Error::custom("no norm length gives this proof shape"))
-}
-
 /// Circuit proof: the four commitments plus the norm-linear proof.
-/// For 1x64: 4 + 6 group elements + 3 scalars + 2 bcs length prefixes = 418
-/// bytes. The vector lengths in `nl_proof` are declared on the wire; the
-/// verifier rejects any shape other than the one the statement implies.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// For 1x64: 4 + 6 group elements + 3 scalars = 416 bytes, with no length
+/// prefixes: the shape is not on the wire, so decoding takes it from the
+/// statement instead.
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct CircuitProof {
     pub(crate) c_l: RistrettoPoint,
     pub(crate) c_o: RistrettoPoint,
     pub(crate) c_r: RistrettoPoint,
     pub(crate) c_s: RistrettoPoint,
-    #[serde(deserialize_with = "deserialize_nl_proof")]
     pub(crate) nl_proof: NormLinearProof,
+}
+
+impl CircuitProof {
+    /// Deserialize a proof of the shape norm length `nm` implies. The four
+    /// commitments are a fixed-size head, so only the norm-linear tail needs
+    /// the shape; a length that is not exactly right for `nm` is rejected.
+    pub(crate) fn from_bytes(bytes: &[u8], nm: usize) -> FastCryptoResult<Self> {
+        let head_len = 4 * 32;
+        if bytes.len() != head_len + norm_linear::serialized_len(H_LEN, nm) {
+            return Err(FastCryptoError::InvalidInput);
+        }
+        let (head, tail) = bytes.split_at(head_len);
+        let invalid = |_| FastCryptoError::InvalidInput;
+        let [c_l, c_o, c_r, c_s] = bcs::from_bytes::<[RistrettoPoint; 4]>(head).map_err(invalid)?;
+        let nl_proof =
+            bcs::from_bytes_seed(NormLinearProofSeed::new(H_LEN, nm), tail).map_err(invalid)?;
+        Ok(CircuitProof {
+            c_l,
+            c_o,
+            c_r,
+            c_s,
+            nl_proof,
+        })
+    }
 }
 
 /// Dimensions of a batched instance: `m` values in `range`, `d = bits/4`
@@ -667,38 +672,6 @@ mod tests {
         }
     }
 
-    /// A decoded proof must carry a shape that some norm length produces.
-    /// Whether it is *this* statement's shape stays verification's job.
-    #[test]
-    fn test_impossible_shape_rejected_at_decoding() {
-        let (gens, params, proof, v_commitments) = prove_batch(Range::Bits16, &[7, 9]);
-        assert!(verify_batch(&gens, &params, &proof, &v_commitments).is_ok());
-        let shape = |p: &CircuitProof| (p.nl_proof.rounds.len(), p.nl_proof.n_final.len());
-        assert_eq!(shape(&proof), (3, 2));
-
-        // Shapes no norm length gives are rejected at decoding.
-        let mut short_round = proof.clone();
-        short_round.nl_proof.rounds.pop();
-        let mut odd_finals = proof.clone();
-        odd_finals.nl_proof.n_final.push(S::zero());
-        for bad in [short_round, odd_finals] {
-            let bytes = bcs::to_bytes(&bad).unwrap();
-            assert!(
-                bcs::from_bytes::<CircuitProof>(&bytes).is_err(),
-                "shape {:?} accepted",
-                shape(&bad)
-            );
-        }
-
-        // A shape another norm length does produce decodes, and fails at
-        // verification against this statement instead.
-        let mut other_nm = proof.clone();
-        other_nm.nl_proof.n_final.extend([S::zero(), S::zero()]);
-        assert_eq!(shape(&other_nm), (3, 4)); // the nm = 32 shape
-        let decoded: CircuitProof = bcs::from_bytes(&bcs::to_bytes(&other_nm).unwrap()).unwrap();
-        assert!(verify_batch(&gens, &params, &decoded, &v_commitments).is_err());
-    }
-
     /// The spec's batched configurations, with their expected norm-linear
     /// proof shapes (rounds, final n), plus the widths not instantiated
     /// there (8-bit, 64-bit x M).
@@ -706,10 +679,10 @@ mod tests {
     fn test_roundtrip_batched_configs() {
         let mut rng = rand::thread_rng();
         let configs: [(Range, usize, usize, usize); 8] = [
-            (Range::Bits16, 2, 3, 2), // 418 bytes
-            (Range::Bits16, 4, 3, 2), // 418 bytes
-            (Range::Bits16, 8, 3, 4), // 482 bytes
-            (Range::Bits32, 8, 4, 4), // 546 bytes
+            (Range::Bits16, 2, 3, 2), // 416 bytes
+            (Range::Bits16, 4, 3, 2), // 416 bytes
+            (Range::Bits16, 8, 3, 4), // 480 bytes
+            (Range::Bits32, 8, 4, 4), // 544 bytes
             (Range::Bits8, 1, 3, 2),
             (Range::Bits8, 4, 3, 2),
             (Range::Bits16, 5, 3, 4), // non-power-of-two digit count

--- a/fastcrypto/src/bulletproofspp/norm_linear.rs
+++ b/fastcrypto/src/bulletproofspp/norm_linear.rs
@@ -12,11 +12,11 @@
 use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::groups::{GroupElement, MultiScalarMul, Scalar};
-use crate::serde_helpers::ToFromByteArray;
 
 use crate::bulletproofspp::crs::Generators;
 use crate::bulletproofspp::transcript::BpppTranscript;
 use crate::bulletproofspp::util::*;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 /// Fold until fewer than this many scalars remain; the remaining opening is
@@ -25,61 +25,13 @@ const FOLD_THRESHOLD: usize = 6;
 
 /// Norm-linear proof: one `(X, R)` pair per fold round, then the final
 /// opening `(l, n)` in the clear (`sigma` is implied by the relation).
-#[derive(Clone, Debug)]
+/// The three vector lengths are a function of the base lengths via
+/// [proof_shape]; [verify] rejects any other shape.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct NormLinearProof {
     pub(crate) rounds: Vec<(RistrettoPoint, RistrettoPoint)>,
     pub(crate) l_final: Vec<RistrettoScalar>,
     pub(crate) n_final: Vec<RistrettoScalar>,
-}
-
-impl NormLinearProof {
-    /// Serialized size of a proof for initial vector lengths `(l_len, n_len)`.
-    pub(crate) fn serialized_len_for(l_len: usize, n_len: usize) -> usize {
-        let (rounds, l_len, n_len) = proof_shape(l_len, n_len);
-        32 * (2 * rounds + l_len + n_len)
-    }
-
-    pub(crate) fn serialized_len(&self) -> usize {
-        32 * (2 * self.rounds.len() + self.l_final.len() + self.n_final.len())
-    }
-
-    /// Serialize: the per-round `(X, R)` pairs, then `l_final`, then
-    /// `n_final`, 32 bytes each.
-    pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(self.serialized_len());
-        for (x, r) in &self.rounds {
-            bytes.extend(x.to_byte_array());
-            bytes.extend(r.to_byte_array());
-        }
-        for scalar in self.l_final.iter().chain(&self.n_final) {
-            bytes.extend(scalar.to_byte_array());
-        }
-        bytes
-    }
-
-    /// Deserialize a proof for initial vector lengths `(l_len, n_len)`. The
-    /// byte length must match the implied shape exactly.
-    pub(crate) fn from_bytes(bytes: &[u8], l_len: usize, n_len: usize) -> FastCryptoResult<Self> {
-        if bytes.len() != Self::serialized_len_for(l_len, n_len) {
-            return Err(FastCryptoError::InvalidInput);
-        }
-        let (rounds, l_len, n_len) = proof_shape(l_len, n_len);
-        let mut chunks = bytes.chunks_exact(32);
-        let rounds = (0..rounds)
-            .map(|_| Ok((decode_next(&mut chunks)?, decode_next(&mut chunks)?)))
-            .collect::<FastCryptoResult<Vec<_>>>()?;
-        let l_final = (0..l_len)
-            .map(|_| decode_next(&mut chunks))
-            .collect::<FastCryptoResult<Vec<_>>>()?;
-        let n_final = (0..n_len)
-            .map(|_| decode_next(&mut chunks))
-            .collect::<FastCryptoResult<Vec<_>>>()?;
-        Ok(NormLinearProof {
-            rounds,
-            l_final,
-            n_final,
-        })
-    }
 }
 
 /// The vector lengths of a proof for initial sizes `(l_len, n_len)`:
@@ -659,20 +611,24 @@ mod tests {
     }
 
     #[test]
-    fn test_to_from_bytes() {
+    fn test_serde_roundtrip() {
         for (l_len, n_len) in [(8, 16), (8, 15), (8, 64), (3, 5), (4, 1)] {
             let inst = random_instance(l_len, n_len);
             let proof = prove_instance(&inst);
-            let bytes = proof.to_bytes();
-            assert_eq!(
-                bytes.len(),
-                NormLinearProof::serialized_len_for(l_len, n_len)
-            );
-            let recovered = NormLinearProof::from_bytes(&bytes, l_len, n_len).unwrap();
+            let bytes = bcs::to_bytes(&proof).unwrap();
+            // 32 bytes per group element and scalar, plus one length prefix
+            // per vector.
+            let (rounds, l, n) = proof_shape(l_len, n_len);
+            assert_eq!(bytes.len(), 32 * (2 * rounds + l + n) + 3);
+
+            let recovered: NormLinearProof = bcs::from_bytes(&bytes).unwrap();
             assert!(verify_instance(&inst, &recovered).is_ok());
-            assert!(NormLinearProof::from_bytes(&bytes[..bytes.len() - 32], l_len, n_len).is_err());
-            // The shape is fixed by the declared lengths, not by the bytes.
-            assert!(NormLinearProof::from_bytes(&bytes, l_len, 2 * n_len).is_err());
+
+            // Truncated and trailing-byte encodings are rejected.
+            assert!(bcs::from_bytes::<NormLinearProof>(&bytes[..bytes.len() - 32]).is_err());
+            let mut extended = bytes.clone();
+            extended.push(0);
+            assert!(bcs::from_bytes::<NormLinearProof>(&extended).is_err());
         }
     }
 

--- a/fastcrypto/src/bulletproofspp/norm_linear.rs
+++ b/fastcrypto/src/bulletproofspp/norm_linear.rs
@@ -35,11 +35,8 @@ pub(crate) struct NormLinearProof {
     pub(crate) n_final: Vec<RistrettoScalar>,
 }
 
-/// The shape of a proof for initial sizes `(l_len, n_len)`: the number of
-/// rounds and the final `n` length. Each round pads to even length and
-/// halves, and folding continues until `l` is a single scalar, so the final
-/// `l` length is always 1 and is not reported.
-fn proof_shape(mut l_len: usize, mut n_len: usize) -> (usize, usize) {
+/// Rounds and final `n` length for `(l_len, n_len)`; final `l` is always 1.
+pub(crate) fn proof_shape(mut l_len: usize, mut n_len: usize) -> (usize, usize) {
     let mut rounds = 0;
     while l_len > 1 || l_len + n_len >= FOLD_THRESHOLD {
         l_len = l_len.div_ceil(2);

--- a/fastcrypto/src/bulletproofspp/norm_linear.rs
+++ b/fastcrypto/src/bulletproofspp/norm_linear.rs
@@ -25,26 +25,28 @@ const FOLD_THRESHOLD: usize = 6;
 
 /// Norm-linear proof: one `(X, R)` pair per fold round, then the final
 /// opening `(l, n)` in the clear (`sigma` is implied by the relation).
-/// The three vector lengths are a function of the base lengths via
-/// [proof_shape]; [verify] rejects any other shape.
+/// Folding runs until `l` is a single scalar, so only `rounds` and
+/// `n_final` are variable-length; both are a function of the base lengths
+/// via [proof_shape], and [verify] rejects any other shape.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct NormLinearProof {
     pub(crate) rounds: Vec<(RistrettoPoint, RistrettoPoint)>,
-    pub(crate) l_final: Vec<RistrettoScalar>,
+    pub(crate) l_final: RistrettoScalar,
     pub(crate) n_final: Vec<RistrettoScalar>,
 }
 
-/// The vector lengths of a proof for initial sizes `(l_len, n_len)`:
-/// number of rounds and final `l`/`n` lengths. Each round pads to even
-/// length and halves.
-fn proof_shape(mut l_len: usize, mut n_len: usize) -> (usize, usize, usize) {
+/// The shape of a proof for initial sizes `(l_len, n_len)`: the number of
+/// rounds and the final `n` length. Each round pads to even length and
+/// halves, and folding continues until `l` is a single scalar, so the final
+/// `l` length is always 1 and is not reported.
+fn proof_shape(mut l_len: usize, mut n_len: usize) -> (usize, usize) {
     let mut rounds = 0;
-    while l_len + n_len >= FOLD_THRESHOLD {
+    while l_len > 1 || l_len + n_len >= FOLD_THRESHOLD {
         l_len = l_len.div_ceil(2);
         n_len = n_len.div_ceil(2);
         rounds += 1;
     }
-    (rounds, l_len, n_len)
+    (rounds, n_len)
 }
 
 /// Grow a fold tensor by one level, the new round in the top bit:
@@ -143,7 +145,7 @@ pub(crate) fn prove(
 
     transcript.domain_sep(b"norm_linear");
 
-    while l.len() + n.len() >= FOLD_THRESHOLD {
+    while l.len() > 1 || l.len() + n.len() >= FOLD_THRESHOLD {
         if levels == FOLD_BATCH_ROUNDS {
             base_h = Cow::Owned(batch_fold(&base_h, &w_h)?);
             base_g = Cow::Owned(batch_fold(&base_g, &w_g)?);
@@ -259,9 +261,10 @@ pub(crate) fn prove(
     transcript.append_scalars(b"l_final", &l);
     transcript.append_scalars(b"n_final", &n);
 
+    debug_assert_eq!(l.len(), 1);
     Ok(NormLinearProof {
         rounds,
-        l_final: l,
+        l_final: l[0],
         n_final: n,
     })
 }
@@ -302,9 +305,8 @@ pub(crate) fn verify(
     }
     // The prover's fold count and final lengths are determined by the base
     // lengths; reject any other shape.
-    let (rounds, l_len, n_len) = proof_shape(gens.h_vec.len(), gens.g_vec.len());
-    if proof.rounds.len() != rounds || proof.l_final.len() != l_len || proof.n_final.len() != n_len
-    {
+    let (rounds, n_len) = proof_shape(gens.h_vec.len(), gens.g_vec.len());
+    if proof.rounds.len() != rounds || proof.n_final.len() != n_len {
         return Err(FastCryptoError::InvalidProof);
     }
 
@@ -341,14 +343,18 @@ pub(crate) fn verify(
         mu = mu * mu;
     }
 
-    transcript.append_scalars(b"l_final", &proof.l_final);
+    transcript.append_scalars(b"l_final", std::slice::from_ref(&proof.l_final));
     transcript.append_scalars(b"n_final", &proof.n_final);
 
-    let sigma = inner_product(&c, &proof.l_final) + weighted_norm(&proof.n_final, mu);
+    // `c` folds exactly as `l` did, so it is a single scalar here too.
+    debug_assert_eq!(c.len(), 1);
+    let sigma = c[0] * proof.l_final + weighted_norm(&proof.n_final, mu);
 
     let mask = (1usize << k) - 1;
 
-    let l = (0..gens.h_vec.len()).map(|i| w_h[i & mask] * proof.l_final[i >> k]);
+    // `l_len <= 2^k` since folding ran until a single scalar remained, so
+    // every coordinate reads that one scalar.
+    let l = (0..gens.h_vec.len()).map(|i| w_h[i & mask] * proof.l_final);
     let n = pn
         .iter()
         .enumerate()
@@ -453,16 +459,16 @@ mod tests {
 
     #[test]
     fn test_roundtrip_sizes() {
-        // (8, 16) is the 64-bit range-proof shape: 3 rounds + 1 + 2 scalars.
-        // (8, 15) is the 16/32-bit shape, (8, 64) the aggregated 32-bit x 8
-        // shape (4 rounds, finals (1, 4)). Small and odd sizes exercise
-        // padding and the no-round base case.
+        // (8, 16) is the 64-bit range-proof shape: 3 rounds, l plus 2
+        // scalars. (8, 15) is the 16/32-bit shape, (8, 64) the aggregated
+        // 32-bit x 8 shape (4 rounds, 4 final n). Small and odd sizes
+        // exercise padding and the shortest fold.
         for (l_len, n_len) in [(8, 16), (8, 15), (8, 64), (1, 2), (2, 4), (3, 5), (4, 1)] {
             let inst = random_instance(l_len, n_len);
             let proof = prove_instance(&inst);
-            let (rounds, fl, fn_) = proof_shape(l_len, n_len);
+            let (rounds, fn_) = proof_shape(l_len, n_len);
             assert_eq!(proof.rounds.len(), rounds);
-            assert_eq!((proof.l_final.len(), proof.n_final.len()), (fl, fn_));
+            assert_eq!(proof.n_final.len(), fn_);
             assert!(
                 verify_instance(&inst, &proof).is_ok(),
                 "roundtrip failed for ({l_len}, {n_len})"
@@ -482,7 +488,7 @@ mod tests {
         assert!(verify_instance(&inst, &bad).is_err());
 
         let mut bad = proof.clone();
-        bad.l_final[0] += RistrettoScalar::generator();
+        bad.l_final += RistrettoScalar::generator();
         assert!(verify_instance(&inst, &bad).is_err());
 
         let mut bad = proof.clone();
@@ -539,14 +545,12 @@ mod tests {
             let proof = prove_instance(&inst);
             assert!(verify_instance(&inst, &proof).is_ok());
 
-            for i in 0..proof.l_final.len() {
-                let mut bad = proof.clone();
-                bad.l_final[i] += RistrettoScalar::generator();
-                assert!(
-                    verify_instance(&inst, &bad).is_err(),
-                    "l_final[{i}] unbound for ({l_len}, {n_len})"
-                );
-            }
+            let mut bad = proof.clone();
+            bad.l_final += RistrettoScalar::generator();
+            assert!(
+                verify_instance(&inst, &bad).is_err(),
+                "l_final unbound for ({l_len}, {n_len})"
+            );
             for i in 0..proof.n_final.len() {
                 let mut bad = proof.clone();
                 bad.n_final[i] += RistrettoScalar::generator();
@@ -617,9 +621,9 @@ mod tests {
             let proof = prove_instance(&inst);
             let bytes = bcs::to_bytes(&proof).unwrap();
             // 32 bytes per group element and scalar, plus one length prefix
-            // per vector.
-            let (rounds, l, n) = proof_shape(l_len, n_len);
-            assert_eq!(bytes.len(), 32 * (2 * rounds + l + n) + 3);
+            // for each of the two variable-length vectors.
+            let (rounds, n) = proof_shape(l_len, n_len);
+            assert_eq!(bytes.len(), 32 * (2 * rounds + 1 + n) + 2);
 
             let recovered: NormLinearProof = bcs::from_bytes(&bytes).unwrap();
             assert!(verify_instance(&inst, &recovered).is_ok());

--- a/fastcrypto/src/bulletproofspp/norm_linear.rs
+++ b/fastcrypto/src/bulletproofspp/norm_linear.rs
@@ -16,8 +16,11 @@ use crate::groups::{GroupElement, MultiScalarMul, Scalar};
 use crate::bulletproofspp::crs::Generators;
 use crate::bulletproofspp::transcript::BpppTranscript;
 use crate::bulletproofspp::util::*;
-use serde::{Deserialize, Serialize};
+use serde::de::{self, DeserializeSeed, SeqAccess, Visitor};
+use serde::ser::SerializeTuple;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
+use std::fmt;
 
 /// Fold until fewer than this many scalars remain; the remaining opening is
 /// sent in the clear. 6 balances rounds (2 points each) against final scalars.
@@ -28,11 +31,104 @@ const FOLD_THRESHOLD: usize = 6;
 /// Folding runs until `l` is a single scalar, so only `rounds` and
 /// `n_final` are variable-length; both are a function of the base lengths
 /// via [proof_shape], and [verify] rejects any other shape.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+///
+/// Serialized as a flat tuple of 32-byte elements with no length prefixes,
+/// so decoding needs the shape from [NormLinearProofSeed].
+#[derive(Clone, Debug)]
 pub(crate) struct NormLinearProof {
     pub(crate) rounds: Vec<(RistrettoPoint, RistrettoPoint)>,
     pub(crate) l_final: RistrettoScalar,
     pub(crate) n_final: Vec<RistrettoScalar>,
+}
+
+/// Serialized size of a proof for initial vector lengths `(l_len, n_len)`.
+pub(crate) fn serialized_len(l_len: usize, n_len: usize) -> usize {
+    let (rounds, n_len) = proof_shape(l_len, n_len);
+    32 * (2 * rounds + 1 + n_len)
+}
+
+impl Serialize for NormLinearProof {
+    /// The per-round `(X, R)` pairs, then `l_final`, then `n_final`. A tuple
+    /// rather than a sequence, so no length is written.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let len = 2 * self.rounds.len() + 1 + self.n_final.len();
+        let mut tuple = serializer.serialize_tuple(len)?;
+        for (x, r) in &self.rounds {
+            tuple.serialize_element(x)?;
+            tuple.serialize_element(r)?;
+        }
+        tuple.serialize_element(&self.l_final)?;
+        for scalar in &self.n_final {
+            tuple.serialize_element(scalar)?;
+        }
+        tuple.end()
+    }
+}
+
+/// The next element of a prefix-free sequence, reported as a length error
+/// when the input ends early.
+pub(crate) fn next_element<'de, A: SeqAccess<'de>, T: Deserialize<'de>>(
+    seq: &mut A,
+    index: usize,
+    expected: &dyn de::Expected,
+) -> Result<T, A::Error> {
+    seq.next_element()?
+        .ok_or_else(|| de::Error::invalid_length(index, expected))
+}
+
+/// The shape a [NormLinearProof] is decoded at, from [proof_shape] for the
+/// statement's base lengths. Nothing on the wire can change it.
+pub(crate) struct NormLinearProofSeed {
+    rounds: usize,
+    n_len: usize,
+}
+
+impl NormLinearProofSeed {
+    /// The shape implied by the statement's base lengths.
+    pub(crate) fn new(l_len: usize, n_len: usize) -> Self {
+        let (rounds, n_len) = proof_shape(l_len, n_len);
+        NormLinearProofSeed { rounds, n_len }
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for NormLinearProofSeed {
+    type Value = NormLinearProof;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        let len = 2 * self.rounds + 1 + self.n_len;
+        deserializer.deserialize_tuple(len, self)
+    }
+}
+
+impl<'de> Visitor<'de> for NormLinearProofSeed {
+    type Value = NormLinearProof;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "a norm-linear proof of {} rounds with {} final n scalars",
+            self.rounds, self.n_len
+        )
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<NormLinearProof, A::Error> {
+        let mut rounds = Vec::with_capacity(self.rounds);
+        for i in 0..self.rounds {
+            let x = next_element(&mut seq, 2 * i, &self)?;
+            let r = next_element(&mut seq, 2 * i + 1, &self)?;
+            rounds.push((x, r));
+        }
+        let l_final = next_element(&mut seq, 2 * self.rounds, &self)?;
+        let mut n_final = Vec::with_capacity(self.n_len);
+        for i in 0..self.n_len {
+            n_final.push(next_element(&mut seq, 2 * self.rounds + 1 + i, &self)?);
+        }
+        Ok(NormLinearProof {
+            rounds,
+            l_final,
+            n_final,
+        })
+    }
 }
 
 /// Rounds and final `n` length for `(l_len, n_len)`; final `l` is always 1.
@@ -617,19 +713,25 @@ mod tests {
             let inst = random_instance(l_len, n_len);
             let proof = prove_instance(&inst);
             let bytes = bcs::to_bytes(&proof).unwrap();
-            // 32 bytes per group element and scalar, plus one length prefix
-            // for each of the two variable-length vectors.
-            let (rounds, n) = proof_shape(l_len, n_len);
-            assert_eq!(bytes.len(), 32 * (2 * rounds + 1 + n) + 2);
+            // 32 bytes per group element and scalar, and nothing else.
+            assert_eq!(bytes.len(), serialized_len(l_len, n_len));
 
-            let recovered: NormLinearProof = bcs::from_bytes(&bytes).unwrap();
+            let seed = || NormLinearProofSeed::new(l_len, n_len);
+            let recovered = bcs::from_bytes_seed(seed(), &bytes).unwrap();
             assert!(verify_instance(&inst, &recovered).is_ok());
 
             // Truncated and trailing-byte encodings are rejected.
-            assert!(bcs::from_bytes::<NormLinearProof>(&bytes[..bytes.len() - 32]).is_err());
+            assert!(bcs::from_bytes_seed(seed(), &bytes[..bytes.len() - 32]).is_err());
             let mut extended = bytes.clone();
             extended.push(0);
-            assert!(bcs::from_bytes::<NormLinearProof>(&extended).is_err());
+            assert!(bcs::from_bytes_seed(seed(), &extended).is_err());
+
+            // The shape is fixed by the seed, not by the bytes. (Doubling
+            // n_len alone can land on the same shape, so pick a base length
+            // whose encoded size really differs.)
+            let other = 4 * n_len + 8;
+            assert_ne!(serialized_len(l_len, other), serialized_len(l_len, n_len));
+            assert!(bcs::from_bytes_seed(NormLinearProofSeed::new(l_len, other), &bytes).is_err());
         }
     }
 

--- a/fastcrypto/src/bulletproofspp/range_proof.rs
+++ b/fastcrypto/src/bulletproofspp/range_proof.rs
@@ -7,7 +7,7 @@ use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::pedersen::{Blinding, PedersenCommitment};
 use crate::traits::AllowedRng;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::bulletproofspp::circuit::{self, CircuitParams, CircuitProof};
 use crate::bulletproofspp::crs::Generators;
@@ -21,7 +21,7 @@ pub use crate::pedersen::Range;
 /// Unlike `fastcrypto::bulletproofs`, batches of any size `>= 1` are
 /// supported; amortization per value is best when the total digit count
 /// `m * bits/4` fills a power of two.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct RangeProof {
     proof: CircuitProof,
 }
@@ -127,19 +127,19 @@ impl RangeProof {
 
     /// Serialize with [bcs]: the four circuit commitments, then the
     /// norm-linear proof's per-round `(X, R)` pairs and final scalars, each
-    /// group element and scalar in its canonical 32-byte encoding, with a
-    /// length prefix on each of the two variable-length vectors.
+    /// group element and scalar in its canonical 32-byte encoding, with no
+    /// length prefixes.
     pub fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self.proof).expect("serializing a proof cannot fail")
     }
 
-    /// Deserialize. Points and scalars are checked for canonical encoding,
-    /// and trailing bytes are rejected; consistency of the proof shape with
-    /// the statement is checked at verification.
-    pub fn from_bytes(bytes: &[u8]) -> FastCryptoResult<Self> {
-        bcs::from_bytes(bytes)
-            .map(|proof| RangeProof { proof })
-            .map_err(|_| FastCryptoError::InvalidInput)
+    /// Deserialize a proof of `m` commitments in `range`, the statement it
+    /// will be verified against. The shape is not on the wire, so it comes
+    /// from `(range, m)`: any input whose length is not exactly right for
+    /// them is rejected, as is a non-canonical point or scalar encoding.
+    pub fn from_bytes(bytes: &[u8], range: &Range, m: usize) -> FastCryptoResult<Self> {
+        let params = CircuitParams::new(*range, m)?;
+        CircuitProof::from_bytes(bytes, params.nm).map(|proof| RangeProof { proof })
     }
 }
 
@@ -150,13 +150,14 @@ mod tests {
     use crate::serde_helpers::ToFromByteArray;
 
     /// Frozen proof for values [0, u32::MAX, 12345, 1 << 31] in Bits32 with
-    /// dst "test", 482 bytes (15 group elements and scalars plus the two
-    /// bcs length prefixes). Breaks if the transcript layout, challenge
-    /// derivation, generator derivation, or serialization change.
+    /// dst "test", 480 bytes (15 group elements and scalars, no framing).
+    /// Breaks if the transcript layout, challenge derivation, generator
+    /// derivation, or serialization change.
     // TODO: regenerate when the DST strings and transcript labels are frozen.
     #[test]
     fn regression_test() {
-        let proof = RangeProof::from_bytes(&hex::decode("00d5d5d1529f01cf6420ec103dace15476ca510f5b92ae6762bc25f4bd1249021219fad1752e829b54c9726bdb9253128ba6e82ca16fd8ea2595e26a536b4406621a5bbe5a65f5d917da8906719361ad8dcb5c9618861e1ccaee288bd7db8d5e9e5b0e4cb21110d789b367d90e778ec30faeda08c405e7b40a64c9f55e35510503dad137e8eb12facf2017dd0887338d6d1416718a9ab599e36a5fc26844b2ce5f44c9c0a0e79d43c07257498c7d755a0fb1e36d620fb312db78f230c11795af452ec6fd20bdddcd078dd121fd667b1226e14f79027b1502b770e804c776ce2e617c2e34ae010e418b31f72222ae7e76d5107747b507355aaa17b89d113ff8ee16963d2647afb472778c27d1983e8e0741be8e3252ce46faa2973ce1f6e352f670484baa1173bae5e99c5f3f0ff65ee368d191f8519986017a8faf1e08d6310d0f0bdf52df2d0b75fdbbdd56eacce0a932270b24b242ec9efb49a062b1d8dd4a000432d10c7962108d26a9239e1103806279e12396a064585f6b878050a84bbe41058a3416edfe76b21e7ec4945454970e53fe7cfb47d49e87373ae22f5ae499b50238eb4f534c997a1e88772fdc181885e7089147978798c99c43867803f5d554015048dbb1bbaa9976da6a08d9457c049a4521e733a28994bb3060f17119940509").unwrap()).unwrap();
+        let proof = RangeProof::from_bytes(&hex::decode("00d5d5d1529f01cf6420ec103dace15476ca510f5b92ae6762bc25f4bd1249021219fad1752e829b54c9726bdb9253128ba6e82ca16fd8ea2595e26a536b4406621a5bbe5a65f5d917da8906719361ad8dcb5c9618861e1ccaee288bd7db8d5e9e5b0e4cb21110d789b367d90e778ec30faeda08c405e7b40a64c9f55e355105dad137e8eb12facf2017dd0887338d6d1416718a9ab599e36a5fc26844b2ce5f44c9c0a0e79d43c07257498c7d755a0fb1e36d620fb312db78f230c11795af452ec6fd20bdddcd078dd121fd667b1226e14f79027b1502b770e804c776ce2e617c2e34ae010e418b31f72222ae7e76d5107747b507355aaa17b89d113ff8ee16963d2647afb472778c27d1983e8e0741be8e3252ce46faa2973ce1f6e352f670484baa1173bae5e99c5f3f0ff65ee368d191f8519986017a8faf1e08d6310d0f0bdf52df2d0b75fdbbdd56eacce0a932270b24b242ec9efb49a062b1d8dd4a0032d10c7962108d26a9239e1103806279e12396a064585f6b878050a84bbe41058a3416edfe76b21e7ec4945454970e53fe7cfb47d49e87373ae22f5ae499b50238eb4f534c997a1e88772fdc181885e7089147978798c99c43867803f5d554015048dbb1bbaa9976da6a08d9457c049a4521e733a28994bb3060f17119940509").unwrap(), &Range::Bits32, 4)
+        .unwrap();
         let commitments: Vec<PedersenCommitment> = [
             "442e20bdd70d96394130625763bb90729481036a4c0643972d0febc382919279",
             "464bbfe7ad1f58a942a57736d2627fe6d514609f0caeeb855eb6cacfe665c773",
@@ -209,7 +210,7 @@ mod tests {
                     range.bits()
                 );
                 // Serialization round-trips at every shape.
-                assert!(RangeProof::from_bytes(&proof.to_bytes())
+                assert!(RangeProof::from_bytes(&proof.to_bytes(), &range, m)
                     .unwrap()
                     .verify_batch(&commitments, &range, b"test")
                     .is_ok());
@@ -312,24 +313,27 @@ mod tests {
         let proof = RangeProof::prove(9, &blinding, &Range::Bits16, b"test", &mut rng).unwrap();
         let bytes = proof.to_bytes();
 
-        // Lengths that cannot be a valid encoding: too short for the four
-        // commitments and three length prefixes, or with bytes left over.
-        assert!(RangeProof::from_bytes(&[]).is_err());
-        for len in [1usize, 31, 32, 33, 128, 129, 415, 417, 419, 480] {
+        // Bits16 x1 has the 416-byte shape; every other length is rejected,
+        // including the lengths that are valid for some other statement.
+        assert_eq!(bytes.len(), 416);
+        assert!(RangeProof::from_bytes(&[], &Range::Bits16, 1).is_err());
+        for len in [1usize, 31, 32, 33, 128, 415, 417, 480, 544] {
             assert!(
-                RangeProof::from_bytes(&vec![0u8; len]).is_err(),
+                RangeProof::from_bytes(&vec![0u8; len], &Range::Bits16, 1).is_err(),
                 "length {len} accepted"
             );
         }
+        // A batch size the bytes are not the right length for.
+        assert!(RangeProof::from_bytes(&bytes, &Range::Bits16, 8).is_err());
+        // An empty batch has no shape at all.
+        assert!(RangeProof::from_bytes(&bytes, &Range::Bits16, 0).is_err());
 
-        // Random bytes at plausible lengths: never panic, never verify.
-        for len in [418usize, 482, 546, 610] {
-            for _ in 0..32 {
-                let mut buf = vec![0u8; len];
-                rand::RngCore::fill_bytes(&mut rng, &mut buf);
-                if let Ok(p) = RangeProof::from_bytes(&buf) {
-                    assert!(p.verify(&commitment, &Range::Bits16, b"test").is_err());
-                }
+        // Random bytes at the right length: never panic, never verify.
+        for _ in 0..128 {
+            let mut buf = vec![0u8; 416];
+            rand::RngCore::fill_bytes(&mut rng, &mut buf);
+            if let Ok(p) = RangeProof::from_bytes(&buf, &Range::Bits16, 1) {
+                assert!(p.verify(&commitment, &Range::Bits16, b"test").is_err());
             }
         }
 
@@ -337,7 +341,7 @@ mod tests {
         for i in (0..bytes.len()).step_by(7) {
             let mut corrupted = bytes.clone();
             corrupted[i] ^= 0x80;
-            let accepted = RangeProof::from_bytes(&corrupted)
+            let accepted = RangeProof::from_bytes(&corrupted, &Range::Bits16, 1)
                 .and_then(|p| p.verify(&commitment, &Range::Bits16, b"test"))
                 .is_ok();
             assert!(!accepted, "corruption at byte {i} accepted");
@@ -482,24 +486,27 @@ mod tests {
             RangeProof::prove_batch(&values, &blindings, &range, b"test", &mut rng).unwrap();
 
         let bytes = proof.to_bytes();
-        // 16x2 has the 64-bit shape: 10 group elements + 3 scalars, plus one
-        // length prefix for each of `rounds` and `n_final`.
-        assert_eq!(bytes.len(), 13 * 32 + 2);
-        let recovered = RangeProof::from_bytes(&bytes).unwrap();
+        // 16x2 has the 64-bit shape: 10 group elements + 3 scalars.
+        assert_eq!(bytes.len(), 13 * 32);
+        let recovered = RangeProof::from_bytes(&bytes, &range, values.len()).unwrap();
         assert!(recovered
             .verify_batch(&commitments, &range, b"test")
             .is_ok());
 
         // Length and encoding validation: truncation, and trailing bytes.
-        assert!(RangeProof::from_bytes(&bytes[..bytes.len() - 1]).is_err());
-        assert!(RangeProof::from_bytes(&bytes[..bytes.len() - 32]).is_err());
+        assert!(RangeProof::from_bytes(&bytes[..bytes.len() - 1], &range, 2).is_err());
+        assert!(RangeProof::from_bytes(&bytes[..bytes.len() - 32], &range, 2).is_err());
         let mut extended = bytes.clone();
         extended.push(0);
-        assert!(RangeProof::from_bytes(&extended).is_err());
+        assert!(RangeProof::from_bytes(&extended, &range, 2).is_err());
+
+        // The shape comes from the statement: a proof of this length is not
+        // accepted for a batch whose shape differs.
+        assert!(RangeProof::from_bytes(&bytes, &range, 8).is_err());
         let mut corrupted = bytes.clone();
         corrupted[0] ^= 1;
         // Either an invalid point encoding or a proof that fails to verify.
-        assert!(RangeProof::from_bytes(&corrupted)
+        assert!(RangeProof::from_bytes(&corrupted, &range, 2)
             .map(|p| p.verify_batch(&commitments, &range, b"test"))
             .and_then(|r| r)
             .is_err());
@@ -508,7 +515,7 @@ mod tests {
         // verification (shape gate).
         let (c64, b64) = PedersenCommitment::commit_u64(5, &mut rng);
         let proof64 = RangeProof::prove(5, &b64, &Range::Bits64, b"test", &mut rng).unwrap();
-        let recovered64 = RangeProof::from_bytes(&proof64.to_bytes()).unwrap();
+        let recovered64 = RangeProof::from_bytes(&proof64.to_bytes(), &Range::Bits64, 1).unwrap();
         assert!(recovered64.verify(&c64, &Range::Bits64, b"test").is_ok());
         assert!(recovered64
             .verify_batch(&[c64.clone(), c64], &Range::Bits64, b"test")

--- a/fastcrypto/src/bulletproofspp/range_proof.rs
+++ b/fastcrypto/src/bulletproofspp/range_proof.rs
@@ -127,8 +127,8 @@ impl RangeProof {
 
     /// Serialize with [bcs]: the four circuit commitments, then the
     /// norm-linear proof's per-round `(X, R)` pairs and final scalars, each
-    /// group element and scalar in its canonical 32-byte encoding, each
-    /// vector behind a length prefix.
+    /// group element and scalar in its canonical 32-byte encoding, with a
+    /// length prefix on each of the two variable-length vectors.
     pub fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self.proof).expect("serializing a proof cannot fail")
     }
@@ -150,13 +150,13 @@ mod tests {
     use crate::serde_helpers::ToFromByteArray;
 
     /// Frozen proof for values [0, u32::MAX, 12345, 1 << 31] in Bits32 with
-    /// dst "test", 483 bytes (15 group elements and scalars plus three bcs
-    /// length prefixes). Breaks if the transcript layout, challenge
+    /// dst "test", 482 bytes (15 group elements and scalars plus the two
+    /// bcs length prefixes). Breaks if the transcript layout, challenge
     /// derivation, generator derivation, or serialization change.
     // TODO: regenerate when the DST strings and transcript labels are frozen.
     #[test]
     fn regression_test() {
-        let proof = RangeProof::from_bytes(&hex::decode("00d5d5d1529f01cf6420ec103dace15476ca510f5b92ae6762bc25f4bd1249021219fad1752e829b54c9726bdb9253128ba6e82ca16fd8ea2595e26a536b4406621a5bbe5a65f5d917da8906719361ad8dcb5c9618861e1ccaee288bd7db8d5e9e5b0e4cb21110d789b367d90e778ec30faeda08c405e7b40a64c9f55e35510503dad137e8eb12facf2017dd0887338d6d1416718a9ab599e36a5fc26844b2ce5f44c9c0a0e79d43c07257498c7d755a0fb1e36d620fb312db78f230c11795af452ec6fd20bdddcd078dd121fd667b1226e14f79027b1502b770e804c776ce2e617c2e34ae010e418b31f72222ae7e76d5107747b507355aaa17b89d113ff8ee16963d2647afb472778c27d1983e8e0741be8e3252ce46faa2973ce1f6e352f670484baa1173bae5e99c5f3f0ff65ee368d191f8519986017a8faf1e08d6310d0f010bdf52df2d0b75fdbbdd56eacce0a932270b24b242ec9efb49a062b1d8dd4a000432d10c7962108d26a9239e1103806279e12396a064585f6b878050a84bbe41058a3416edfe76b21e7ec4945454970e53fe7cfb47d49e87373ae22f5ae499b50238eb4f534c997a1e88772fdc181885e7089147978798c99c43867803f5d554015048dbb1bbaa9976da6a08d9457c049a4521e733a28994bb3060f17119940509").unwrap()).unwrap();
+        let proof = RangeProof::from_bytes(&hex::decode("00d5d5d1529f01cf6420ec103dace15476ca510f5b92ae6762bc25f4bd1249021219fad1752e829b54c9726bdb9253128ba6e82ca16fd8ea2595e26a536b4406621a5bbe5a65f5d917da8906719361ad8dcb5c9618861e1ccaee288bd7db8d5e9e5b0e4cb21110d789b367d90e778ec30faeda08c405e7b40a64c9f55e35510503dad137e8eb12facf2017dd0887338d6d1416718a9ab599e36a5fc26844b2ce5f44c9c0a0e79d43c07257498c7d755a0fb1e36d620fb312db78f230c11795af452ec6fd20bdddcd078dd121fd667b1226e14f79027b1502b770e804c776ce2e617c2e34ae010e418b31f72222ae7e76d5107747b507355aaa17b89d113ff8ee16963d2647afb472778c27d1983e8e0741be8e3252ce46faa2973ce1f6e352f670484baa1173bae5e99c5f3f0ff65ee368d191f8519986017a8faf1e08d6310d0f0bdf52df2d0b75fdbbdd56eacce0a932270b24b242ec9efb49a062b1d8dd4a000432d10c7962108d26a9239e1103806279e12396a064585f6b878050a84bbe41058a3416edfe76b21e7ec4945454970e53fe7cfb47d49e87373ae22f5ae499b50238eb4f534c997a1e88772fdc181885e7089147978798c99c43867803f5d554015048dbb1bbaa9976da6a08d9457c049a4521e733a28994bb3060f17119940509").unwrap()).unwrap();
         let commitments: Vec<PedersenCommitment> = [
             "442e20bdd70d96394130625763bb90729481036a4c0643972d0febc382919279",
             "464bbfe7ad1f58a942a57736d2627fe6d514609f0caeeb855eb6cacfe665c773",
@@ -315,7 +315,7 @@ mod tests {
         // Lengths that cannot be a valid encoding: too short for the four
         // commitments and three length prefixes, or with bytes left over.
         assert!(RangeProof::from_bytes(&[]).is_err());
-        for len in [1usize, 31, 32, 33, 128, 130, 415, 418, 420, 480] {
+        for len in [1usize, 31, 32, 33, 128, 129, 415, 417, 419, 480] {
             assert!(
                 RangeProof::from_bytes(&vec![0u8; len]).is_err(),
                 "length {len} accepted"
@@ -323,7 +323,7 @@ mod tests {
         }
 
         // Random bytes at plausible lengths: never panic, never verify.
-        for len in [419usize, 483, 547, 611] {
+        for len in [418usize, 482, 546, 610] {
             for _ in 0..32 {
                 let mut buf = vec![0u8; len];
                 rand::RngCore::fill_bytes(&mut rng, &mut buf);
@@ -483,8 +483,8 @@ mod tests {
 
         let bytes = proof.to_bytes();
         // 16x2 has the 64-bit shape: 10 group elements + 3 scalars, plus one
-        // length prefix for each of the three vectors.
-        assert_eq!(bytes.len(), 13 * 32 + 3);
+        // length prefix for each of `rounds` and `n_final`.
+        assert_eq!(bytes.len(), 13 * 32 + 2);
         let recovered = RangeProof::from_bytes(&bytes).unwrap();
         assert!(recovered
             .verify_batch(&commitments, &range, b"test")

--- a/fastcrypto/src/bulletproofspp/range_proof.rs
+++ b/fastcrypto/src/bulletproofspp/range_proof.rs
@@ -7,6 +7,7 @@ use crate::error::{FastCryptoError, FastCryptoResult};
 use crate::groups::ristretto255::{RistrettoPoint, RistrettoScalar};
 use crate::pedersen::{Blinding, PedersenCommitment};
 use crate::traits::AllowedRng;
+use serde::{Deserialize, Serialize};
 
 use crate::bulletproofspp::circuit::{self, CircuitParams, CircuitProof};
 use crate::bulletproofspp::crs::Generators;
@@ -20,7 +21,7 @@ pub use crate::pedersen::Range;
 /// Unlike `fastcrypto::bulletproofs`, batches of any size `>= 1` are
 /// supported; amortization per value is best when the total digit count
 /// `m * bits/4` fills a power of two.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RangeProof {
     proof: CircuitProof,
 }
@@ -124,17 +125,21 @@ impl RangeProof {
         .map_err(|_| FastCryptoError::InvalidProof)
     }
 
-    /// Serialize: the four circuit commitments, the per-round `(X, R)`
-    /// pairs, and the final scalars, 32 bytes each.
+    /// Serialize with [bcs]: the four circuit commitments, then the
+    /// norm-linear proof's per-round `(X, R)` pairs and final scalars, each
+    /// group element and scalar in its canonical 32-byte encoding, each
+    /// vector behind a length prefix.
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.proof.to_bytes()
+        bcs::to_bytes(&self.proof).expect("serializing a proof cannot fail")
     }
 
-    /// Deserialize. The byte length determines the proof shape (13 elements
-    /// for norm length 16, 2*rounds + 9 otherwise). Points and scalars are
-    /// validated; consistency with the statement is checked at verification.
+    /// Deserialize. Points and scalars are checked for canonical encoding,
+    /// and trailing bytes are rejected; consistency of the proof shape with
+    /// the statement is checked at verification.
     pub fn from_bytes(bytes: &[u8]) -> FastCryptoResult<Self> {
-        CircuitProof::from_bytes(bytes).map(|proof| RangeProof { proof })
+        bcs::from_bytes(bytes)
+            .map(|proof| RangeProof { proof })
+            .map_err(|_| FastCryptoError::InvalidInput)
     }
 }
 
@@ -145,12 +150,13 @@ mod tests {
     use crate::serde_helpers::ToFromByteArray;
 
     /// Frozen proof for values [0, u32::MAX, 12345, 1 << 31] in Bits32 with
-    /// dst "test". Breaks if the transcript layout, challenge derivation,
-    /// generator derivation, or serialization change.
+    /// dst "test", 483 bytes (15 group elements and scalars plus three bcs
+    /// length prefixes). Breaks if the transcript layout, challenge
+    /// derivation, generator derivation, or serialization change.
     // TODO: regenerate when the DST strings and transcript labels are frozen.
     #[test]
     fn regression_test() {
-        let proof = RangeProof::from_bytes(&hex::decode("00d5d5d1529f01cf6420ec103dace15476ca510f5b92ae6762bc25f4bd1249021219fad1752e829b54c9726bdb9253128ba6e82ca16fd8ea2595e26a536b4406621a5bbe5a65f5d917da8906719361ad8dcb5c9618861e1ccaee288bd7db8d5e9e5b0e4cb21110d789b367d90e778ec30faeda08c405e7b40a64c9f55e355105dad137e8eb12facf2017dd0887338d6d1416718a9ab599e36a5fc26844b2ce5f44c9c0a0e79d43c07257498c7d755a0fb1e36d620fb312db78f230c11795af452ec6fd20bdddcd078dd121fd667b1226e14f79027b1502b770e804c776ce2e617c2e34ae010e418b31f72222ae7e76d5107747b507355aaa17b89d113ff8ee16963d2647afb472778c27d1983e8e0741be8e3252ce46faa2973ce1f6e352f670484baa1173bae5e99c5f3f0ff65ee368d191f8519986017a8faf1e08d6310d0f0bdf52df2d0b75fdbbdd56eacce0a932270b24b242ec9efb49a062b1d8dd4a0032d10c7962108d26a9239e1103806279e12396a064585f6b878050a84bbe41058a3416edfe76b21e7ec4945454970e53fe7cfb47d49e87373ae22f5ae499b50238eb4f534c997a1e88772fdc181885e7089147978798c99c43867803f5d554015048dbb1bbaa9976da6a08d9457c049a4521e733a28994bb3060f17119940509").unwrap()).unwrap();
+        let proof = RangeProof::from_bytes(&hex::decode("00d5d5d1529f01cf6420ec103dace15476ca510f5b92ae6762bc25f4bd1249021219fad1752e829b54c9726bdb9253128ba6e82ca16fd8ea2595e26a536b4406621a5bbe5a65f5d917da8906719361ad8dcb5c9618861e1ccaee288bd7db8d5e9e5b0e4cb21110d789b367d90e778ec30faeda08c405e7b40a64c9f55e35510503dad137e8eb12facf2017dd0887338d6d1416718a9ab599e36a5fc26844b2ce5f44c9c0a0e79d43c07257498c7d755a0fb1e36d620fb312db78f230c11795af452ec6fd20bdddcd078dd121fd667b1226e14f79027b1502b770e804c776ce2e617c2e34ae010e418b31f72222ae7e76d5107747b507355aaa17b89d113ff8ee16963d2647afb472778c27d1983e8e0741be8e3252ce46faa2973ce1f6e352f670484baa1173bae5e99c5f3f0ff65ee368d191f8519986017a8faf1e08d6310d0f010bdf52df2d0b75fdbbdd56eacce0a932270b24b242ec9efb49a062b1d8dd4a000432d10c7962108d26a9239e1103806279e12396a064585f6b878050a84bbe41058a3416edfe76b21e7ec4945454970e53fe7cfb47d49e87373ae22f5ae499b50238eb4f534c997a1e88772fdc181885e7089147978798c99c43867803f5d554015048dbb1bbaa9976da6a08d9457c049a4521e733a28994bb3060f17119940509").unwrap()).unwrap();
         let commitments: Vec<PedersenCommitment> = [
             "442e20bdd70d96394130625763bb90729481036a4c0643972d0febc382919279",
             "464bbfe7ad1f58a942a57736d2627fe6d514609f0caeeb855eb6cacfe665c773",
@@ -306,23 +312,20 @@ mod tests {
         let proof = RangeProof::prove(9, &blinding, &Range::Bits16, b"test", &mut rng).unwrap();
         let bytes = proof.to_bytes();
 
-        // Lengths that are not a valid element count.
+        // Lengths that cannot be a valid encoding: too short for the four
+        // commitments and three length prefixes, or with bytes left over.
         assert!(RangeProof::from_bytes(&[]).is_err());
-        for elems in [1usize, 2, 4, 12, 14, 16, 74, 100] {
+        for len in [1usize, 31, 32, 33, 128, 130, 415, 418, 420, 480] {
             assert!(
-                RangeProof::from_bytes(&vec![0u8; 32 * elems]).is_err(),
-                "{elems} elements accepted"
+                RangeProof::from_bytes(&vec![0u8; len]).is_err(),
+                "length {len} accepted"
             );
         }
-        // Non-multiples of 32.
-        for len in [1usize, 31, 33, 415] {
-            assert!(RangeProof::from_bytes(&vec![0u8; len]).is_err());
-        }
 
-        // Random bytes at valid lengths: never panic, never verify.
-        for elems in [13usize, 15, 17, 19] {
+        // Random bytes at plausible lengths: never panic, never verify.
+        for len in [419usize, 483, 547, 611] {
             for _ in 0..32 {
-                let mut buf = vec![0u8; 32 * elems];
+                let mut buf = vec![0u8; len];
                 rand::RngCore::fill_bytes(&mut rng, &mut buf);
                 if let Ok(p) = RangeProof::from_bytes(&buf) {
                     assert!(p.verify(&commitment, &Range::Bits16, b"test").is_err());
@@ -479,16 +482,20 @@ mod tests {
             RangeProof::prove_batch(&values, &blindings, &range, b"test", &mut rng).unwrap();
 
         let bytes = proof.to_bytes();
-        // 16x2 has the 64-bit shape: 10 group elements + 3 scalars.
-        assert_eq!(bytes.len(), 416);
+        // 16x2 has the 64-bit shape: 10 group elements + 3 scalars, plus one
+        // length prefix for each of the three vectors.
+        assert_eq!(bytes.len(), 13 * 32 + 3);
         let recovered = RangeProof::from_bytes(&bytes).unwrap();
         assert!(recovered
             .verify_batch(&commitments, &range, b"test")
             .is_ok());
 
-        // Length and encoding validation.
-        assert!(RangeProof::from_bytes(&bytes[..415]).is_err());
-        assert!(RangeProof::from_bytes(&bytes[..384]).is_err()); // 12 elements
+        // Length and encoding validation: truncation, and trailing bytes.
+        assert!(RangeProof::from_bytes(&bytes[..bytes.len() - 1]).is_err());
+        assert!(RangeProof::from_bytes(&bytes[..bytes.len() - 32]).is_err());
+        let mut extended = bytes.clone();
+        extended.push(0);
+        assert!(RangeProof::from_bytes(&extended).is_err());
         let mut corrupted = bytes.clone();
         corrupted[0] ^= 1;
         // Either an invalid point encoding or a proof that fails to verify.

--- a/fastcrypto/src/bulletproofspp/util.rs
+++ b/fastcrypto/src/bulletproofspp/util.rs
@@ -3,28 +3,14 @@
 
 //! Scalar-vector helpers shared by the BP++ modules.
 
-use crate::error::{FastCryptoError, FastCryptoResult};
+use crate::error::FastCryptoResult;
 use crate::groups::ristretto255::RistrettoScalar;
 use crate::groups::{GroupElement, Scalar};
-use crate::serde_helpers::ToFromByteArray;
-use std::slice::ChunksExact;
 
 /// The scalar 1. `GroupElement::generator` is the multiplicative identity
 /// for fastcrypto's scalar types; this name says what it means here.
 pub(crate) fn one() -> RistrettoScalar {
     RistrettoScalar::generator()
-}
-
-/// The next 32-byte chunk of `chunks` decoded as `T`; `InvalidInput` if the
-/// chunk is missing or not a valid encoding.
-pub(crate) fn decode_next<T: ToFromByteArray<32>>(
-    chunks: &mut ChunksExact<'_, u8>,
-) -> FastCryptoResult<T> {
-    let chunk: &[u8; 32] = chunks
-        .next()
-        .and_then(|c| c.try_into().ok())
-        .ok_or(FastCryptoError::InvalidInput)?;
-    T::from_byte_array(chunk).map_err(|_| FastCryptoError::InvalidInput)
 }
 
 /// Inner product `<a, b> = sum_i a_i * b_i`.


### PR DESCRIPTION
## What

`CircuitProof` and `NormLinearProof` now derive `Serialize`/`Deserialize`, and `RangeProof::{to_bytes, from_bytes}` go through `bcs`. `RistrettoPoint` and `RistrettoScalar` already have canonical 32-byte serde impls (via `serialize_deserialize_with_to_from_byte_array`), so the derived encoding is byte-identical to the hand-written one apart from one length prefix per vector in the norm-linear proof.

**Cost: 3 bytes per proof.** Every configuration grows by exactly 3 (419 instead of 416 for the 1x64 shape); the README table and the size formula (`64*log2(nm) + 163`) are updated and were checked against measured sizes.

**Saving: ~100 lines of hand-written codec.**

- `CircuitProof::to_bytes`/`from_bytes`, including the shape search over powers of two and the `MAX_LOG_NM` bound it needed
- `NormLinearProof::to_bytes`/`from_bytes`/`serialized_len`/`serialized_len_for`
- `decode_next` in `util.rs`

## Trade-off

The proof shape used to be *derived* from the total byte length, so anything that parsed had self-consistent vector lengths. Now the lengths are declared on the wire and a decoded proof may carry any of them. This was already checked where it matters:

- `norm_linear::verify` rejects any shape other than the one `proof_shape` gives for the statement's base lengths — covered by `test_wrong_shape_fails`, and by the cross-configuration tests in `range_proof.rs`
- element encodings are still validated at parse time: the serde impls call `from_byte_array`, exactly as `decode_next` did
- `bcs::from_bytes` rejects trailing bytes, so there is still exactly one valid encoding per proof

`RangeProof` also implements `Serialize`/`Deserialize` now, so it can be nested in other serde types without going through bytes.

## Regression vector

The frozen vector in `regression_test` is the same proof re-encoded (the old bytes with the three length prefixes spliced in), not a fresh proof, so it still pins the transcript layout, challenge derivation and generator derivation. It verifies against the unchanged committed commitments.

## Testing

`cargo test -p fastcrypto --lib --features experimental` — 409 passed. Clippy clean.