### PR TITLE
Update READMEs to match the current workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Build status](https://github.com/MystenLabs/fastcrypto/actions/workflows/rust.yml/badge.svg)](https://github.com/MystenLabs/fastcrypto/actions)
-[![Update the fastcrypto pointer Sui](https://github.com/MystenLabs/sui/actions/workflows/fastcrypto_pull.yml/badge.svg)](https://github.com/MystenLabs/sui/actions/workflows/fastcrypto_pull.yml)
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![codecov](https://codecov.io/gh/MystenLabs/fastcrypto/branch/main/graph/badge.svg?token=zlB0v8k4O5)](https://codecov.io/gh/MystenLabs/fastcrypto)
@@ -12,7 +11,7 @@
  <img width="300" src="images/fastcrypto_logo_800.png">
 </p>
 
-`fastcrypto` is a common cryptography library used in software at Mysten Labs. It contains three individual crates: `fastcrypto`, `fastcrypto-zkp` and `fastcrypto-cli`. They are published as independent crates to encourage reusability across different applications and domains.
+`fastcrypto` is a common cryptography library used in software at Mysten Labs. It is a Cargo workspace containing the crates `fastcrypto`, `fastcrypto-derive`, `fastcrypto-tbls`, `fastcrypto-zkp`, `fastcrypto-vdf`, `fastcrypto-pq` and `fastcrypto-cli`. Most of them are published as independent crates to encourage reusability across different applications and domains; `fastcrypto-pq` is not yet published.
 
 `fastcrypto` is a wrapper library around several carefully selected crates with the following considerations:
 
@@ -28,6 +27,10 @@ Furthermore, we extend the selected libraries with additional features:
 
 This library will be continuously updated with more schemes and faster implementations based on benchmarking results, RFC updates, new research and auditor inputs.
 
+Some modules are gated behind the `experimental` feature flag. These have not been audited and should not be relied on in production.
+
+## `fastcrypto`
+
 The `fastcrypto` crate contains:
 
 - Traits that should be implemented by concrete types representing digital cryptographic materials.
@@ -41,26 +44,55 @@ The `fastcrypto` crate contains:
 
 - Concrete signature schemes of type that implement the recommended traits required for cryptographic agility.
     - Ed25519: Backed by [`ed25519-consensus`](https://github.com/penumbra-zone/ed25519-consensus) crate. Compliant to [ZIP-215](https://zips.z.cash/zip-0215) that defines the signature validity that is lacking from RFC8032 but critical for consensus algorithms. [`ed25519-dalek`](https://github.com/dalek-cryptography/ed25519-dalek) is fully deprecated due to the recently discovered [Chalkias double pub-key api vulnerability](https://github.com/MystenLabs/ed25519-unsafe-libs).
-    - Secp256k1: ECDSA signatures over the secp256k1 curve. Backed by [Secp256k1 FFI](https://crates.io/crates/secp256k1/0.23.1) wrapper that binds to C library and provides performance faster than the native Rust implementation [k256](https://crates.io/crates/k256) library by ~30% on verification. Produces either a standard ECDSA signature or a 65-byte recoverable signature of shape [r, s, v] where v can be 0 or 1 representing the recovery Id. Produces deterministic signatures using the pseudo-random deterministic nonce generation according to [RFC6979](https://www.rfc-editor.org/rfc/rfc6979), without the strong requirement to generate randomness for nonce protection. Uses sha256 as the default hash function for sign and verify. An interface for `verify_hashed` is provided to accept a pre-hashed message and its signature for verification. Supports public key recovery by providing the Secp256k1 recoverable signature with the corresponding pre-hashed message. An accepted signature must have its `s` in the lower half of the curve order. If s is too high, normalize `s` to `order - s` where curve order is `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`. See more at [BIP-0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures).
+    - Secp256k1: ECDSA signatures over the secp256k1 curve. Backed by [Secp256k1 FFI](https://crates.io/crates/secp256k1) wrapper that binds to C library and provides performance faster than the native Rust implementation [k256](https://crates.io/crates/k256) library by ~30% on verification. Produces either a standard ECDSA signature or a 65-byte recoverable signature of shape [r, s, v] where v can be 0 or 1 representing the recovery Id. Produces deterministic signatures using the pseudo-random deterministic nonce generation according to [RFC6979](https://www.rfc-editor.org/rfc/rfc6979), without the strong requirement to generate randomness for nonce protection. Uses sha256 as the default hash function for sign and verify. An interface for `verify_hashed` is provided to accept a pre-hashed message and its signature for verification. Supports public key recovery by providing the Secp256k1 recoverable signature with the corresponding pre-hashed message. An accepted signature must have its `s` in the lower half of the curve order. If s is too high, normalize `s` to `order - s` where curve order is `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`. See more at [BIP-0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures).
     - Secp256r1: ECDSA signatures over the secp256r1 curve backed by the [`p256`](https://crates.io/crates/p256) crate which is a pure rust implementation of the Secp256r1 (aka [NIST P-256](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) and prime256v1) curve. The functionality from `p256` is extended such that, besides standard ECDSA signatures, our implementation can also produce and verify 65 byte recoverable signatures of the form [r, s, v] where v is the recoveryID. Signatures are produced deterministically using the pseudo-random deterministic nonce generation according to [RFC6979](https://www.rfc-editor.org/rfc/rfc6979), without the strong requirement to generate randomness for nonce protection. Uses sha256 as the default hash function for sign and verify. Supports public key recovery by providing the Secp256r1 ECDSA recoverable signature with the corresponding pre-hashed message. An accepted signature must have its `s` in the lower half of the curve order. If s is too high, normalize `s` to `order - s` where curve order is `0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551` defined [here](https://secg.org/SEC2-Ver-1.0.pdf).
     - BLS12-381: Backed by [`blst`](https://github.com/supranational/blst) crate written in Assembly and C that optimizes for performance and security. G1 and G2 points are serialized following [ZCash specification](https://github.com/supranational/blst#serialization-format) in compressed format. Provides functions for verifying signatures in the G1 group against public keys in the G2 group (min-sig) or vice versa (min-pk). Provides functions for aggregating signatures and fast verifying aggregated signatures, where public keys are assumed to be verified for proof of possession.
-   - RSA: Backed by crate [rsa](https://crates.io/crates/rsa).  Provides functions to sign and verify RSA signature according to [RFC 8017](https://www.rfc-editor.org/rfc/rfc8017)
+    - RSA: Backed by crate [rsa](https://crates.io/crates/rsa). Provides verification of RSASSA-PKCS1-v1_5 signatures using SHA-256 according to [RFC 8017](https://www.rfc-editor.org/rfc/rfc8017), from either a DER encoded public key or raw modulus and exponent. Signing is not provided.
+
+- Group arithmetic over the elliptic curves used by the schemes above, exposed through the [`GroupElement`] and [`Scalar`] traits in the `groups` module. Implementations are available for BLS12-381 (G1, G2 and GT, including pairings), Ristretto255, secp256k1 and secp256r1. The `groups::multiplier` module provides windowed and BGMW scalar multiplication with precomputation, along with traits for multi-scalar multiplication.
 
 - Utility functions on cryptographic primitives. Some of them serve as the Rust implementation of the Move smart contract API in Sui.
     - HKDF: An HMAC-based key derivation function based on [RFC-5869](https://tools.ietf.org/html/rfc5869), to derive keypairs with a salt and an optional domain for the given keypair. This requires choosing an HMAC function that expands precisely to the byte length of a private key for the chosen KeyPair parameter.
     - Pedersen Commitment: Function to create a Pedersen commitment with a value and a blinding factor. Add or subtract Ristretto points that represent Pedersen commitments.
     - Bulletproofs Range Proof: Function to prove that a committed value is an unsigned integer that is within the range `[0, 2^bits)`. Function to verify that the commitment is a Pedersen commitment of some value with an unsigned bit length, a value is an integer within the range `[0, 2^bits)`.
+    - Bulletproofs++ Range Proof (`experimental`): A shorter range proof over Ristretto255 supporting batches of commitments and bit sizes 8, 16, 32 and 64. See the [module README](fastcrypto/src/bulletproofspp/README.md) for details.
     - Elliptic Curve VRF (ECVRF): A verifiable random function implementation using the Ristretto255 group. Function to create a proof based on a given input and verify a proof for a given output, based on specification in [draft-irtf-cfrg-vrf-15](https://datatracker.ietf.org/doc/draft-irtf-cfrg-vrf/).
+    - Twisted ElGamal: Encryption over Ristretto255 with sigma protocols proving that a ciphertext is well-formed, plus a verifiable key encapsulation that encrypts a private key to multiple recipients and proves consistency with the sender's public key.
+    - NIZK: A non-interactive zero-knowledge proof of knowledge for a DDH tuple `(G, H, xG, xH)`, made non-interactive with the Fiat-Shamir transform.
+    - Merkle tree: A simple binary Merkle tree with both inclusion and non-inclusion proofs.
+    - AWS Nitro attestation: Verification of AWS Nitro enclave attestation documents, covering COSE_Sign1 parsing, attestation document validation and certificate chain verification against the AWS Nitro root of trust. Enabled by default; the root certificate is bundled with the crate.
+    - JWT: Parsing and validation of the JWT claims used by zkLogin.
 
-- Encoding: Base64 and Hex are defined with an encoding trait with its customized serialization and validations, backed by [base64ct](https://crates.io/crates/base64ct) and [hex]((https://crates.io/crates/base64ct)). Notably, the base64ct crate has been chosen instead of the most popular base64 Rust crate, because (a) it is constant time and (b) mangled encodings are explicitly rejected to prevent malleability attacks when decoding, see [paper](https://dl.acm.org/doi/10.1145/3488932.3527284) on in-depth analysis.
+- Symmetric encryption (`aes` feature): AES in CTR, CBC (with PKCS7, ISO 10126 and ANSI X9.23 padding), GCM and GCM-SIV modes, for 128, 192 and 256 bit keys where applicable.
+
+- Encoding: Base64, Hex, Base58 and Bech32 are defined with an encoding trait with its customized serialization and validations, backed by [base64ct](https://crates.io/crates/base64ct), [hex](https://crates.io/crates/hex), [bs58](https://crates.io/crates/bs58) and [bech32](https://crates.io/crates/bech32). Notably, the base64ct crate has been chosen instead of the most popular base64 Rust crate, because (a) it is constant time and (b) mangled encodings are explicitly rejected to prevent malleability attacks when decoding, see [paper](https://dl.acm.org/doi/10.1145/3488932.3527284) on in-depth analysis.
 
 - Hash functions wrappers: [SHA2_256](https://en.wikipedia.org/wiki/SHA-2) with 256 bit digests, [SHA3_256](https://en.wikipedia.org/wiki/SHA-3) with 256 bit digests, [SHA2_512](https://en.wikipedia.org/wiki/SHA-2) with 512 bit digests, [SHA3_512](https://en.wikipedia.org/wiki/SHA-3) with 512 bit digests, [KECCAK](https://keccak.team/files/Keccak-reference-3.0.pdf) with 256 bit digests, [BLAKE2-256](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2) with 256 bit digests.
 
 - Multiset Hash: A hash function where the output of the hash function is a point on the elliptic curve. It also allows for efficient computation for the hash of the union of two multiset. 
 
-- A asynchronous signature service is provided for testing and benchmarking.
+- An asynchronous signature service is provided for testing and benchmarking.
 
-The `fastcryto-zkp` crate contains APIs to verify a Groth16 proof along with its prepared verifying key and public inputs. BN254 and BLS12381 curves are supported. The verifier is backed [Arkworks](https://github.com/arkworks-rs/) and [`blst`](https://github.com/supranational/blst) libraries.
+### Feature flags
+
+| Flag | Effect |
+| --- | --- |
+| `aes` | Include AES and its modes. |
+| `copy_key` | Allow private keys to be copied. |
+| `experimental` | Include modules that have not been audited. |
+| `wasm` | Required when targeting `wasm32`. |
+
+## Other crates
+
+The `fastcrypto-zkp` crate contains APIs to verify a Groth16 proof along with its prepared verifying key and public inputs. BN254 and BLS12381 curves are supported. The verifier is backed by [Arkworks](https://github.com/arkworks-rs/) and [`blst`](https://github.com/supranational/blst) libraries. It also contains the zkLogin verifier used by Sui, including parsing and validation of zkLogin proofs and address derivation, and a Poseidon hash implementation over the BN254 scalar field.
+
+The `fastcrypto-tbls` crate implements threshold BLS signatures and distributed key generation. It contains Shamir secret sharing over polynomials, ECIES encryption, a weighted node set with knapsack-based weight reduction, a random oracle, the discrete-log NIZKs used by the protocols, and a threshold Schnorr protocol built on asynchronous verifiable secret sharing with presigning and signing.
+
+The `fastcrypto-vdf` crate implements verifiable delay functions. It contains the Wesolowski and Pietrzak VDF constructions, imaginary class groups and RSA groups as the underlying groups of unknown order, hash-to-group and discriminant generation, and the supporting number-theoretic routines. The entire crate is gated behind its own `experimental` feature flag and has not been audited.
+
+The `fastcrypto-pq` crate implements post-quantum signature schemes: ML-DSA-65 ([FIPS 204](https://csrc.nist.gov/pubs/fips/204/final)) behind fastcrypto's traits, backed by the formally verified `mldsa-native` C implementation, and SLH-DSA ([FIPS 205](https://csrc.nist.gov/pubs/fips/205/final)) building blocks in pure Rust. It is not published and has not been audited. See the [crate README](fastcrypto-pq/README.md).
+
+The `fastcrypto-derive` crate provides the `SilentDisplay` and `SilentDebug` derive macros, which keep private key material out of formatted output, and `GroupOpsExtend`, which expands a group element's `Add`, `Sub`, `Neg` and scalar `Mul` implementations to cover all borrowed and owned argument combinations plus the assigning variants.
 
 The `fastcrypto-cli` crate includes CLI tools available for debugging. See usages with `-h` flag.
 
@@ -71,15 +103,19 @@ $ cargo build --bin sigs-cli
 $ target/debug/sigs-cli -h
 $ cargo build --bin ecvrf-cli
 $ target/debug/ecvrf-cli -h
+$ cargo build --bin vdf-cli
+$ target/debug/vdf-cli -h
+$ cargo build --bin tlock-cli
+$ target/debug/tlock-cli -h
 ```
 
 ## WASM
 
-The `fastcrypto` crate can be used when building WASM modules. To do this, enable the `wasm` feature flag when including the `fastcrypto` crate in your `Cargo.toml` file and follow the instructions found in the [Rust and WASM book](https://rustwasm.github.io/docs/book/) to build the WASM module.
+The `fastcrypto` crate can be used when building WASM modules. To do this, enable the `wasm` feature flag when including the `fastcrypto` crate in your `Cargo.toml` file and follow the instructions found in the [Rust and WASM book](https://rustwasm.github.io/docs/book/) to build the WASM module. Note that `fastcrypto-pq` depends on a C toolchain and does not build for `wasm32`.
 
 ## Tests
 
-There exist unit tests for all primitives in all three crates, which can be run by: 
+There exist unit tests for all primitives in all crates, which can be run by: 
 ```
 $ cargo test
 ```
@@ -100,7 +136,7 @@ Below is another plot made using data from the benchmark report, showing benchma
 
 ![Batched signature verification with all signatures on same message.](https://github.com/MystenLabs/fastcrypto/blob/plots/batch-dd5adb.svg)
 
-In `fastcrypto-zkp`, benchmarks can be ran for Arkworks to `blst` representation of field elements, and verifying Groth16 in BN254 and BLS12381:
+The other crates carry their own benchmarks, which are run the same way from the crate directory. In `fastcrypto-zkp`, for example, benchmarks can be run for Arkworks to `blst` representation of field elements, and for verifying Groth16 in BN254 and BLS12381:
 
 ```
 $ cd fastcrypto-zkp/
@@ -115,9 +151,9 @@ All crates licensed under either of
 
 [//]: # (badges)
 
-[crate-image]: https://buildstats.info/crate/fastcrypto
+[crate-image]: https://img.shields.io/crates/v/fastcrypto.svg
 [crate-link]: https://crates.io/crates/fastcrypto
 [docs-image]: https://docs.rs/fastcrypto/badge.svg
 [docs-link]: https://docs.rs/fastcrypto/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.96+-blue.svg

--- a/fastcrypto-tbls/README.md
+++ b/fastcrypto-tbls/README.md
@@ -1,8 +1,33 @@
 # fastcrypto-tbls
 
-A crate that implements threshold BLS (tBLS) and distributed key generation (DKG) protocols.
+A crate that implements threshold BLS (tBLS) signatures, distributed key generation (DKG) and
+threshold Schnorr signatures.
 
-Currently, it only provides a fake object for creating the outputs of the DKG protocol.
+It contains:
+
+- **Threshold BLS** (`tbls`): partial signing and aggregation of BLS signatures over a shared key,
+  built on Shamir secret sharing over polynomials (`polynomial`).
+- **DKG** (`dkg_v1`): a distributed key generation protocol over a weighted set of nodes
+  (`nodes`), using ECIES encryption (`ecies_v1`) to deal shares and discrete-log NIZKs
+  (`nizk`, `dl_verification`) to prove the dealings correct. `mocked_dkg` provides deterministic
+  outputs for tests.
+- **Weight reduction** (`knapsack_weight_reduction`): reduces the total weight of a weighted node
+  set while preserving the threshold structure, which keeps protocol cost down for large
+  committees.
+- **Threshold Schnorr** (`threshold_schnorr`): asynchronous verifiable secret sharing, in plain
+  (`avss`), batched (`batch_avss`) and AVID-backed (`avid`, `batch_avss_avid`) variants, together
+  with presigning (`presigning`), signing (`signing`), key derivation (`key_derivation`),
+  complaints and recovery proofs.
+- **Random oracle** (`random_oracle`): domain-separated hashing shared by the protocols above.
+
+> [!WARNING]
+> The threshold Schnorr modules are still under development and have not been audited.
+
+## Benchmarks
+
+```
+$ cargo bench
+```
 
 ## License
 This software is licensed as [Apache 2.0](LICENSE). A copy of the license is available in the root

--- a/fastcrypto-vdf/README.md
+++ b/fastcrypto-vdf/README.md
@@ -2,7 +2,32 @@
 
 An experimental crate that implements verifiable delay functions (VDFs).
 
-Currently, it contains an implementation of the Wesolowski VDF based on imaginary class groups.
+Everything in this crate is gated behind the `experimental` feature flag. It has not been audited
+and should not be used in production.
+
+It contains:
+
+- **VDF constructions** (`vdf`): the Wesolowski (`wesolowski`) and Pietrzak (`pietrzak`) VDFs,
+  generic over the underlying group of unknown order.
+- **Imaginary class groups** (`class_group`): elements represented as binary quadratic forms, with
+  form reduction, discriminant generation and a hash-to-group construction whose output is uniform
+  over a large subset of the group.
+- **RSA groups** (`rsa_group`): an alternative group of unknown order, for comparison and testing.
+- **Supporting math** (`math`): extended GCD, the Chinese remainder theorem, Jacobi symbols,
+  modular square roots and hash-to-prime.
+
+A command line tool for generating and verifying proofs is available in `fastcrypto-cli`:
+
+```
+$ cargo build --bin vdf-cli
+$ target/debug/vdf-cli -h
+```
+
+## Benchmarks
+
+```
+$ cargo bench --features experimental
+```
 
 ## License
 This software is licensed as [Apache 2.0](LICENSE). A copy of the license is available in the root


### PR DESCRIPTION
Bring the top-level, tbls and vdf READMEs back in line with what the repo actually contains, and fix two badges that no longer render.